### PR TITLE
feat: GSD scaffold 개선 및 CRLF 근본 방지

### DIFF
--- a/.claude/hooks/scaffold-gsd.sh
+++ b/.claude/hooks/scaffold-gsd.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
 # scaffold-gsd.sh - Initialize GSD document structure in a project
+# 템플릿에서 working docs를 복사하여 초기화. 이미 존재하는 파일은 건너뜀.
 #
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 TARGET="$PROJECT_DIR/.gsd"
-TEMPLATES_SRC="$PROJECT_DIR/.gsd/templates"
+TEMPLATES_SRC="$TARGET/templates"
 
 echo "Scaffolding GSD documents..."
 echo "  Target: ${TARGET}"
@@ -15,8 +16,118 @@ echo ""
 # Create directories
 mkdir -p "$TARGET" "$TARGET/templates" "$TARGET/examples" "$TARGET/archive" "$TARGET/reports" "$TARGET/research"
 
+# ── 직접 복사 가능한 템플릿 → UPPERCASE working doc 매핑 ──
+# 템플릿 파일명(lowercase) → 대상 파일명(UPPERCASE)
+declare -A DIRECT_TEMPLATES=(
+    ["spec.md"]="SPEC.md"
+    ["decisions.md"]="DECISIONS.md"
+    ["journal.md"]="JOURNAL.md"
+    ["patterns.md"]="PATTERNS.md"
+    ["todo.md"]="TODO.md"
+    ["stack.md"]="STACK.md"
+    ["current.md"]="CURRENT.md"
+)
+
+CREATED=0
+SKIPPED=0
+
+for tmpl in "${!DIRECT_TEMPLATES[@]}"; do
+    dest="${DIRECT_TEMPLATES[$tmpl]}"
+    if [ ! -f "$TARGET/$dest" ]; then
+        if [ -f "$TEMPLATES_SRC/$tmpl" ]; then
+            cp "$TEMPLATES_SRC/$tmpl" "$TARGET/$dest"
+            echo "  [created] $dest (from templates/$tmpl)"
+            CREATED=$((CREATED + 1))
+        fi
+    else
+        echo "  [exists]  $dest"
+        SKIPPED=$((SKIPPED + 1))
+    fi
+done
+
+# ── Config 파일 (이름 그대로 복사) ──
+if [ ! -f "$TARGET/context-config.yaml" ]; then
+    if [ -f "$TEMPLATES_SRC/context-config.yaml" ]; then
+        cp "$TEMPLATES_SRC/context-config.yaml" "$TARGET/context-config.yaml"
+        echo "  [created] context-config.yaml"
+        CREATED=$((CREATED + 1))
+    fi
+else
+    echo "  [exists]  context-config.yaml"
+    SKIPPED=$((SKIPPED + 1))
+fi
+
+# ── 템플릿이 없는 파일: 최소 헤더로 생성 ──
+# STATE.md — state.md 템플릿은 메타(설명) 형식이므로 stub 생성
+if [ ! -f "$TARGET/STATE.md" ]; then
+    cat > "$TARGET/STATE.md" <<'STATEEOF'
+# Project State
+
+## Current Position
+**Status:** idle
+
+## Last Action
+None — freshly initialized.
+
+## Next Steps
+1. Define project spec in SPEC.md
+2. Create plan in PLAN.md
+
+## Blockers
+None
+
+---
+
+*Last updated: —*
+STATEEOF
+    echo "  [created] STATE.md (stub)"
+    CREATED=$((CREATED + 1))
+elif [ -f "$TARGET/STATE.md" ]; then
+    echo "  [exists]  STATE.md"
+    SKIPPED=$((SKIPPED + 1))
+fi
+
+# ROADMAP.md — roadmap.md 템플릿은 메타(설명) 형식이므로 stub 생성
+if [ ! -f "$TARGET/ROADMAP.md" ]; then
+    cat > "$TARGET/ROADMAP.md" <<'RMEOF'
+# Roadmap
+
+> **Current Phase:** —
+> **Status:** planning
+
+## Phases
+
+*Phases will be defined after SPEC.md is finalized.*
+
+---
+
+*Last updated: —*
+RMEOF
+    echo "  [created] ROADMAP.md (stub)"
+    CREATED=$((CREATED + 1))
+elif [ -f "$TARGET/ROADMAP.md" ]; then
+    echo "  [exists]  ROADMAP.md"
+    SKIPPED=$((SKIPPED + 1))
+fi
+
+# CHANGELOG.md — 훅이 자동 생성하지만, 빈 파일이 없으면 훅이 실패할 수 있음
+if [ ! -f "$TARGET/CHANGELOG.md" ]; then
+    cat > "$TARGET/CHANGELOG.md" <<'CLEOF'
+# Changelog
+
+> Auto-maintained by SessionEnd hook. `.gsd/` 내부 변경은 제외됨.
+
+---
+CLEOF
+    echo "  [created] CHANGELOG.md (stub)"
+    CREATED=$((CREATED + 1))
+elif [ -f "$TARGET/CHANGELOG.md" ]; then
+    echo "  [exists]  CHANGELOG.md"
+    SKIPPED=$((SKIPPED + 1))
+fi
+
 echo ""
-echo "GSD scaffolding complete!"
+echo "GSD scaffolding complete! (created: $CREATED, skipped: $SKIPPED)"
 echo "  Working docs: .gsd/{SPEC,DECISIONS,JOURNAL,ROADMAP,PATTERNS,STATE,TODO,STACK,CHANGELOG}.md"
 echo "  Config:       .gsd/context-config.yaml"
 echo "  Templates:    .gsd/templates/"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.{bat,cmd}]
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+# Use bash for all recipes
+SHELL := /opt/homebrew/bin/bash
+
 # Load .env if exists
 -include .env
 export
 
-.PHONY: status index setup install-deps \
+.PHONY: status index index-reset setup install-deps \
         install-memory init-env check-deps lint lint-fix fmt test typecheck \
         clean patch-prompt patch-restore patch-clean \
         build build-plugin build-antigravity build-opencode help generate-claude-md
@@ -59,10 +62,11 @@ status: ## Show tool status
 # code-graph-rag Indexing
 # ─────────────────────────────────────────────────────
 
-index: ## Index codebase with code-graph-rag
-	@command -v npx >/dev/null 2>&1 || { echo "ERROR: npx not found. Install Node.js: https://nodejs.org/"; exit 1; }
-	npx -y @er77/code-graph-rag-mcp index "$(CURDIR)"
-	@echo "Index complete."
+index: ## Index codebase with code-graph-rag (via MCP)
+	@bash scripts/index-codebase.sh "$(CURDIR)"
+
+index-reset: ## Re-index codebase from scratch (reset graph)
+	@bash scripts/index-codebase.sh "$(CURDIR)" true
 
 # ─────────────────────────────────────────────────────
 # Full Setup

--- a/scripts/index-codebase.sh
+++ b/scripts/index-codebase.sh
@@ -1,0 +1,28 @@
+#\!/usr/bin/env bash
+#
+# index-codebase.sh - code-graph-rag MCP indexing
+# claude -p를 통해 MCP 도구(mcp__graph-code__index)를 호출
+#
+set -euo pipefail
+
+PROJECT_DIR="${1:-$(pwd)}"
+RESET="${2:-false}"
+
+# claude CLI 필수
+command -v claude >/dev/null 2>&1 || {
+    echo "ERROR: claude CLI not found."
+    exit 1
+}
+
+echo "=== Code Graph Indexing ==="
+echo "  Directory: $PROJECT_DIR"
+echo "  Reset: $RESET"
+echo ""
+
+claude -p "Run the mcp__graph-code__index tool with directory=\\"$PROJECT_DIR\\" and reset=$RESET. Then run mcp__graph-code__get_graph_stats to show the result. Output only the stats summary." \
+    --model haiku \
+    --allowedTools "mcp__graph-code__index,mcp__graph-code__get_graph_stats" \
+    --output-format text 2>/dev/null
+
+echo ""
+echo "Index complete."


### PR DESCRIPTION
## Summary
- **scaffold-gsd.sh**: 템플릿에서 working docs 자동 복사 (멱등성 보장, 11개 문서)
- **make index**: 실패하던 npx CLI → `claude -p` MCP 도구 호출 방식으로 전환
- **CRLF 근본 방지**: `.editorconfig` 추가, `.gitattributes` LF 수정, working tree 전체 정규화 (CRLF 0개)

## Test plan
- [x] `scaffold-gsd.sh` 실행 → 9개 문서 생성 확인
- [x] `scaffold-gsd.sh` 재실행 → 기존 파일 덮어쓰기 없음 (멱등성)
- [x] `make index` → MCP 인덱싱 정상 완료
- [x] `make index-reset` → 그래프 리셋 후 재인덱싱 정상
- [x] `git ls-files | xargs file | grep CRLF` → 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)