### PR TITLE
docs(build): 각 빌드 타겟 README 순수 bash 모드 반영

### DIFF
--- a/scripts/build-antigravity.sh
+++ b/scripts/build-antigravity.sh
@@ -584,6 +584,8 @@ cat > "$ANTIGRAVITY/README.md" << 'READMEEOF'
 
 AI agent development boilerplate for **Google Antigravity IDE**.
 
+**외부 종속성 없음** — 순수 bash 기반 메모리 시스템으로 바로 사용 가능합니다.
+
 ## Quick Start
 
 1. **Open in Antigravity**
@@ -592,25 +594,24 @@ AI agent development boilerplate for **Google Antigravity IDE**.
    antigravity .
    ```
 
-2. **Configure MCP Servers**
-   - Go to Agent panel "..." → MCP Servers → Manage MCP Servers → View raw config
-   - Copy contents from `mcp-settings.json` to your config
-   - Or copy to global config: `~/.gemini/antigravity/mcp-settings.json`
-
-3. **Initialize GSD Documents**
+2. **Initialize GSD Documents**
    ```bash
    zsh scripts/scaffold-gsd.sh
    ```
+
+3. **(선택) Configure MCP Servers**
+   - Go to Agent panel "..." → MCP Servers → Manage MCP Servers → View raw config
+   - Copy contents from `mcp-settings.json` to your config
 
 ## Directory Structure
 
 ```
 .agent/
-├── skills/          # 15 AI skills (SKILL.md format)
+├── skills/          # 16 AI skills (SKILL.md format)
 │   ├── planner/     # Planning skill
 │   ├── executor/    # Execution skill
 │   └── ...
-├── workflows/       # 30 workflow commands (// turbo supported)
+├── workflows/       # Workflow commands (// turbo supported)
 │   ├── plan.md      # /plan command
 │   ├── execute.md   # /execute command
 │   └── ...
@@ -620,23 +621,31 @@ AI agent development boilerplate for **Google Antigravity IDE**.
     └── gsd-workflow.md
 
 templates/gsd/       # GSD document templates
-scripts/             # Utility scripts
-mcp-settings.json    # MCP server configuration
+scripts/             # Utility scripts (메모리 포함)
+mcp-settings.json    # MCP server configuration (선택적)
 ```
 
-## Skills
+## Memory System (순수 Bash)
 
-Skills are specialized agent capabilities in `.agent/skills/[name]/SKILL.md`.
+외부 종속성 없는 파일 기반 메모리 시스템:
+
+```bash
+# 메모리 저장
+bash scripts/md-store-memory.sh "제목" "내용" "태그" "타입"
+
+# 메모리 검색
+bash scripts/md-recall-memory.sh "검색어" "." 5 compact
+```
+
+14개 메모리 타입: `architecture-decision`, `root-cause`, `session-summary` 등
+
+## Skills (16)
 
 | Skill | Description |
 |-------|-------------|
 | `planner` | Creates executable phase plans |
 | `executor` | Executes plans with atomic commits |
 | `verifier` | Verifies work with empirical evidence |
-| `commit` | Conventional emoji commits |
-| `create-pr` | Pull request creation |
-| `pr-review` | Multi-persona code review |
-| `clean` | Code quality tools (ruff, mypy) |
 | `debugger` | Systematic debugging |
 | `impact-analysis` | Change impact analysis |
 | `arch-review` | Architecture review |
@@ -645,6 +654,11 @@ Skills are specialized agent capabilities in `.agent/skills/[name]/SKILL.md`.
 | `context-health-monitor` | Context complexity monitoring |
 | `bootstrap` | Project initialization |
 | `empirical-validation` | Proof-based validation |
+| `memory-protocol` | Memory search/store protocol |
+| `commit` | Conventional emoji commits |
+| `create-pr` | Pull request creation |
+| `pr-review` | Multi-persona code review |
+| `clean` | Code quality tools (shellcheck) |
 
 ## Workflows
 
@@ -659,8 +673,6 @@ Add `// turbo` comment to auto-execute commands:
 2. `npm run test`
 ```
 
-Or `// turbo-all` at the top for all commands.
-
 ### Key Workflows
 
 | Command | Description |
@@ -670,7 +682,6 @@ Or `// turbo-all` at the top for all commands.
 | `/verify` | Verify completed work |
 | `/debug` | Systematic debugging |
 | `/map` | Map codebase structure |
-| `/new-project` | Initialize new project |
 | `/help` | List all commands |
 
 ## Rules
@@ -683,43 +694,14 @@ Rules in `.agent/rules/*.md` are always-on passive guidelines that govern agent 
 | `safety.md` | Dangerous action prevention |
 | `gsd-workflow.md` | GSD methodology rules |
 
-## MCP Servers
+## MCP Servers (선택적)
 
-Pre-configured in `mcp-settings.json`:
+MCP 서버는 **선택적**입니다. 기본 기능은 순수 bash로 동작합니다.
 
-| Server | Purpose |
-|--------|---------|
-| `graph-code` | AST-based code analysis (19 tools) |
-| `memory` | Persistent agent memory (8 tools) |
-| `context7` | Library documentation lookup |
-
-### Setup Options
-
-**Option 1: Project-level** (recommended)
-- Copy `mcp-settings.json` content via Agent panel → MCP Servers
-
-**Option 2: Global**
-```bash
-mkdir -p ~/.gemini/antigravity
-cp mcp-settings.json ~/.gemini/antigravity/
-```
-
-### Environment Variables
-
-```bash
-# Required for context7
-export CONTEXT7_API_KEY="your-api-key"
-```
-
-## Agent Settings
-
-Recommended Antigravity settings:
-
-| Setting | Value | Reason |
-|---------|-------|--------|
-| **Agent Mode** | Planning | Better for complex tasks |
-| **Artifact Review** | Request Review | Review plans before execution |
-| **Terminal Policy** | Always Proceed | With safety rules active |
+| Server | Purpose | Install |
+|--------|---------|---------|
+| `graph-code` | AST-based code analysis | `npm i -g @er77/code-graph-rag-mcp` |
+| `memory` | Semantic memory search | `pipx install mcp-memory-service` |
 
 ## GSD Methodology
 
@@ -737,7 +719,7 @@ Get Shit Done workflow:
 | `CLAUDE.md` | `.agent/rules/*.md` |
 | `.claude/skills/` | `.agent/skills/` |
 | Claude Hooks | `.agent/workflows/` (use `// turbo`) |
-| `.mcp.json` | `mcp-settings.json` |
+| `.mcp.json` | `mcp-settings.json` (선택적) |
 
 ## License
 
@@ -772,8 +754,8 @@ skill_count=$(ls -d "$ANTIGRAVITY/.agent/skills"/*/ 2>/dev/null | wc -l | tr -d 
 workflow_count=$(ls "$ANTIGRAVITY/.agent/workflows/"*.md 2>/dev/null | wc -l | tr -d ' ')
 rules_count=$(ls "$ANTIGRAVITY/.agent/rules/"*.md 2>/dev/null | wc -l | tr -d ' ')
 
-echo "  Skills:    ${skill_count} (expected: 15)"
-[ "$skill_count" -ge 14 ] || echo "    [WARN] Low skill count"
+echo "  Skills:    ${skill_count} (expected: 16)"
+[ "$skill_count" -ge 16 ] || echo "    [WARN] Low skill count"
 
 echo "  Workflows: ${workflow_count}"
 [ "$workflow_count" -ge 1 ] || echo "    [WARN] No workflows found"

--- a/scripts/build-opencode.sh
+++ b/scripts/build-opencode.sh
@@ -486,12 +486,15 @@ cat > "$OPENCODE/README.md" << 'READMEEOF'
 
 AI agent development boilerplate for **OpenCode**.
 
+**외부 종속성 없음** — 순수 bash 기반 메모리 시스템으로 바로 사용 가능합니다.
+
 ## Features
 
 - ✅ **Model per Agent**: Each agent has its own model configuration
 - ✅ **Token Optimization**: Haiku for planning, Sonnet/Opus for implementation
 - ✅ **Compaction**: Auto context compaction with pruning
 - ✅ **Multi-provider**: Anthropic, OpenAI, Google, and more
+- ✅ **Pure Bash Memory**: 외부 종속성 없는 파일 기반 메모리 시스템
 
 ## Quick Start
 
@@ -500,7 +503,6 @@ AI agent development boilerplate for **OpenCode**.
    cp -r opencode-boilerplate/.opencode /path/to/project/
    cp opencode-boilerplate/opencode.json /path/to/project/
    cp opencode-boilerplate/AGENTS.md /path/to/project/
-   cp opencode-boilerplate/.mcp.json /path/to/project/
    ```
 
 2. **Initialize GSD Documents**
@@ -517,18 +519,33 @@ AI agent development boilerplate for **OpenCode**.
 
 ```
 .opencode/
-├── agents/          # Agent definitions with model config
+├── agents/          # 14 agents with model config
 │   ├── planner.md   # model: anthropic/claude-opus-4-20250514
 │   ├── executor.md  # model: anthropic/claude-sonnet-4-20250514
 │   └── ...
 ├── commands/        # Workflow commands (/plan, /execute, etc.)
 ├── plugins/         # TypeScript plugins
-└── skill/           # Skills (SKILL.md format)
+└── skill/           # 16 skills (SKILL.md format)
 
+scripts/             # Utility scripts (메모리 포함)
 opencode.json        # Main config with agent model mapping
 AGENTS.md            # Project rules (equivalent to CLAUDE.md)
-.mcp.json            # MCP server configuration
+.mcp.json            # MCP server configuration (선택적)
 ```
+
+## Memory System (순수 Bash)
+
+외부 종속성 없는 파일 기반 메모리 시스템:
+
+```bash
+# 메모리 저장
+bash scripts/md-store-memory.sh "제목" "내용" "태그" "타입"
+
+# 메모리 검색
+bash scripts/md-recall-memory.sh "검색어" "." 5 compact
+```
+
+14개 메모리 타입: `architecture-decision`, `root-cause`, `session-summary` 등
 
 ## Agent Model Configuration
 
@@ -570,10 +587,6 @@ The `opencode.json` includes token-saving features:
 }
 ```
 
-- `auto`: Automatically compact when context is full
-- `prune`: Remove old tool outputs
-- `small_model`: Use Haiku for title generation, etc.
-
 ## Commands
 
 | Command | Description |
@@ -584,15 +597,14 @@ The `opencode.json` includes token-saving features:
 | `/debug` | Systematic debugging |
 | `/help` | List all commands |
 
-## MCP Servers
+## MCP Servers (선택적)
 
-Pre-configured in `.mcp.json`:
+MCP 서버는 **선택적**입니다. 기본 기능은 순수 bash로 동작합니다.
 
-| Server | Purpose |
-|--------|---------|
-| `graph-code` | AST-based code analysis |
-| `memory` | Persistent agent memory (8 tools) |
-| `context7` | Library documentation |
+| Server | Purpose | Install |
+|--------|---------|---------|
+| `graph-code` | AST-based code analysis | `npm i -g @er77/code-graph-rag-mcp` |
+| `memory` | Semantic memory search | `pipx install mcp-memory-service` |
 
 ## Migration from Claude Code
 
@@ -642,14 +654,14 @@ agent_count=$(ls "$OPENCODE/.opencode/agents/"*.md 2>/dev/null | wc -l | tr -d '
 command_count=$(ls "$OPENCODE/.opencode/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
 skill_count=$(ls -d "$OPENCODE/.opencode/skill"/*/ 2>/dev/null | wc -l | tr -d ' ')
 
-echo "  Agents:   ${agent_count} (expected: 13)"
-[ "$agent_count" -ge 12 ] || echo "    [WARN] Low agent count"
+echo "  Agents:   ${agent_count} (expected: 14)"
+[ "$agent_count" -ge 14 ] || echo "    [WARN] Low agent count"
 
 echo "  Commands: ${command_count}"
 [ "$command_count" -ge 1 ] || echo "    [WARN] No commands found"
 
-echo "  Skills:   ${skill_count} (expected: 15)"
-[ "$skill_count" -ge 14 ] || echo "    [WARN] Low skill count"
+echo "  Skills:   ${skill_count} (expected: 16)"
+[ "$skill_count" -ge 16 ] || echo "    [WARN] Low skill count"
 
 # Model field check
 echo ""

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -595,7 +595,9 @@ if os.path.isdir(agent_dir):
 # Build README
 readme = f"""# GSD Plugin for Claude Code
 
-**Get Shit Done** v{version} — AI agent development methodology with code-graph-rag and memory-graph integration.
+**Get Shit Done** v{version} — AI agent development methodology with pure bash-based memory system.
+
+**외부 종속성 없음** — Node.js, Python 환경, MCP 서버 설치 없이 바로 사용 가능합니다.
 
 ## Installation
 
@@ -607,30 +609,42 @@ claude --plugin-dir /path/to/gsd-plugin
 alias claude='claude --plugin-dir /path/to/gsd-plugin'
 ```
 
-### Per-Project Memory Isolation
+### GitHub Release에서 설치
 
-The plugin uses `${{CLAUDE_PROJECT_DIR}}` for all paths, so each project gets its own:
-- Memory DB: `.agent/data/memory-service/memories.db`
-- Code index: per-project AST graph
-
-Create the memory directory in your project:
 ```bash
-mkdir -p .agent/data/memory-service
+# 최신 버전
+VERSION=$(gh release view --json tagName -q .tagName | sed 's/gsd-plugin-v//')
+curl -L "https://github.com/SukbeomH/LLM_Bolierplate_Pack/releases/latest/download/gsd-plugin-${{VERSION}}.zip" -o gsd-plugin.zip
+unzip gsd-plugin.zip -d ~/.claude/plugins/gsd
 ```
 
 ## Prerequisites
 
 - **Claude Code** CLI
-- **Node.js** 18+ (code-graph-rag MCP server)
-- **Python** 3.11+ (hook scripts)
 
-### MCP Servers
+### Optional: MCP Servers
+
+MCP 서버는 **선택적**입니다. 기본 메모리 기능은 순수 bash 스크립트로 제공됩니다.
 
 | Server | Install | Role |
 |--------|---------|------|
-| code-graph-rag | `npm i -g @er77/code-graph-rag-mcp` | AST-based code analysis (19 tools) |
-| mcp-memory-service | `pipx install mcp-memory-service` | Agent memory persistence |
+| code-graph-rag *(optional)* | `npm i -g @er77/code-graph-rag-mcp` | AST-based code analysis |
+| mcp-memory-service *(optional)* | `pipx install mcp-memory-service` | Semantic memory search |
 | context7 *(optional)* | Project `.mcp.json`에 직접 추가 | Library documentation lookup |
+
+## Memory System
+
+순수 bash 기반 메모리 시스템 (외부 종속성 없음):
+
+```bash
+# 메모리 저장
+bash scripts/md-store-memory.sh "제목" "내용" "태그1,태그2" "타입"
+
+# 메모리 검색
+bash scripts/md-recall-memory.sh "검색어" "." 5 compact
+```
+
+14개 메모리 타입: `architecture-decision`, `root-cause`, `debug-eliminated`, `session-summary` 등
 
 ## Quick Start
 
@@ -763,11 +777,11 @@ template_count=$(ls "$PLUGIN/templates/gsd/templates/"*.md 2>/dev/null | wc -l |
 echo "  Commands:  ${cmd_count}"
 [ "$cmd_count" -ge 1 ] || { echo "    [WARN] No commands found"; }
 
-echo "  Skills:    ${skill_count} (expected: 15)"
-[ "$skill_count" -ge 15 ] || { echo "    [WARN] Expected 15 skills"; }
+echo "  Skills:    ${skill_count} (expected: 16)"
+[ "$skill_count" -ge 16 ] || { echo "    [WARN] Expected 16 skills"; }
 
-echo "  Agents:    ${agent_count} (expected: 13)"
-[ "$agent_count" -ge 13 ] || { echo "    [WARN] Expected 13 agents"; }
+echo "  Agents:    ${agent_count} (expected: 14)"
+[ "$agent_count" -ge 14 ] || { echo "    [WARN] Expected 14 agents"; }
 
 echo "  Scripts:   ${script_count} (expected: 9)"
 [ "$script_count" -ge 9 ] || { echo "    [WARN] Expected 9 scripts"; }


### PR DESCRIPTION
## Summary
- build-plugin.sh: 외부 종속성 없음 강조, MCP 선택적
- build-antigravity.sh: 16 skills, 순수 bash 메모리 시스템 안내
- build-opencode.sh: 14 agents, 순수 bash 메모리 시스템 안내
- 검증 카운트 업데이트 (16 skills, 14 agents)

## Test plan
- [x] `make build-plugin` 실행 확인
- [x] `make build-antigravity` 실행 확인
- [x] `make build-opencode` 실행 확인
- [x] 생성된 README.md 내용 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)