### PR TITLE
fix(paths): 메모리 스크립트 경로 정규화 (.claude/hooks/ → scripts/)

### DIFF
--- a/.claude/hooks/pre-compact-save.sh
+++ b/.claude/hooks/pre-compact-save.sh
@@ -42,7 +42,7 @@ main() {
     fi
 
     # compact-context.sh 실행 (자동 아카이빙)
-    COMPACT_SCRIPT="$PROJECT_DIR/.claude/hooks/compact-context.sh"
+    COMPACT_SCRIPT="$(cd "$(dirname "$0")" && pwd)/compact-context.sh"
     if [ -f "$COMPACT_SCRIPT" ]; then
         bash "$COMPACT_SCRIPT" 2>/dev/null || true
     fi

--- a/.claude/skills/arch-review/SKILL.md
+++ b/.claude/skills/arch-review/SKILL.md
@@ -31,7 +31,7 @@ trigger: "Before merging PRs or completing major features"
 아키텍처 리뷰 전 과거 결정 사항을 recall하여 일관성을 검증한다:
 
 ```bash
-bash .claude/hooks/md-recall-memory.sh "architecture" "." 5 compact
+bash scripts/md-recall-memory.sh "architecture" "." 5 compact
 ```
 
 또는 네이티브 도구:
@@ -77,7 +77,7 @@ Compile findings into a structured report.
 중요한 아키텍처 결정은 메모리에 저장:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Architecture Decision: {title}" \
   "{context and decision}" \
   "architecture,decision" \

--- a/.claude/skills/bootstrap/SKILL.md
+++ b/.claude/skills/bootstrap/SKILL.md
@@ -127,7 +127,7 @@ Delegate to the `codebase-mapper` skill to analyze the project:
 Store the bootstrap record:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Project Bootstrap" \
   "Bootstrap completed. System prerequisites verified. Memory initialized." \
   "bootstrap,init,setup" \

--- a/.claude/skills/context-health-monitor/SKILL.md
+++ b/.claude/skills/context-health-monitor/SKILL.md
@@ -100,7 +100,7 @@ Grep(pattern: "3-strike|{issue}", path: ".gsd/memories/health-event/", output_mo
 ```
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "3-Strike: {issue}" \
   "{approaches tried, errors seen, current hypothesis}" \
   "health,3-strike,{component}" \
@@ -118,7 +118,7 @@ Grep(pattern: "circular|{approach}", path: ".gsd/memories/health-event/", output
 ```
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Circular: {approach}" \
   "{what repeated, why it looped}" \
   "health,circular,{component}" \
@@ -130,7 +130,7 @@ bash .claude/hooks/md-store-memory.sh \
 Persist session context for the next session:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Handoff: {reason}" \
   "{current state, recommendations for next session}" \
   "health,handoff" \

--- a/.claude/skills/debugger/SKILL.md
+++ b/.claude/skills/debugger/SKILL.md
@@ -93,7 +93,7 @@ If matches found, review past root causes and eliminated hypotheses to avoid rep
 When a hypothesis is disproved, persist it to prevent future sessions from re-investigating:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Eliminated: {hypothesis}" \
   "{evidence that disproved this hypothesis}" \
   "debug,eliminated,{component}" \
@@ -105,7 +105,7 @@ bash .claude/hooks/md-store-memory.sh \
 When the root cause is identified, persist the full finding:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Root Cause: {cause}" \
   "{evidence, fix applied, verification result}" \
   "debug,root-cause,{component}" \
@@ -119,7 +119,7 @@ If related to a past bug, use tag encoding to link them (`related:{slug}`).
 When the 3-strike rule activates, persist the blocked state for the next session:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Blocked: {issue}" \
   "{approaches tried, errors seen, remaining hypotheses}" \
   "debug,blocked,3-strike" \

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -245,7 +245,7 @@ If results found, Read the matching files and review past deviations to anticipa
 After applying any deviation rule (Rules 1-4), persist it:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Rule {N} - {description}" \
   "{details of what was found, what was fixed, and why}" \
   "deviation,rule-{N},{phase-plan}" \
@@ -257,7 +257,7 @@ bash .claude/hooks/md-store-memory.sh \
 After writing SUMMARY.md, store an execution summary memory for cross-session learning:
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Plan {phase-plan} Summary" \
   "{tasks completed, deviations applied, verification results}" \
   "execution,{phase-plan}" \
@@ -459,7 +459,7 @@ PRD 파일은 직접 편집하거나 메모리 시스템을 통해 기록:
 
 ```bash
 # 실행 결과 메모리에 저장
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "Execution: Plan 1.2" \
   "Task 완료. Commit: abc1234" \
   "execution,summary,phase-1" \
@@ -479,7 +479,7 @@ git commit -m "feat(1-2): implement user authentication"
 COMMIT_HASH=$(git rev-parse --short HEAD)
 
 # 3. 메모리에 실행 결과 저장
-bash .claude/hooks/md-store-memory.sh "Plan 1.2 Complete" "Commit: $COMMIT_HASH" "execution" "execution-summary"
+bash scripts/md-store-memory.sh "Plan 1.2 Complete" "Commit: $COMMIT_HASH" "execution" "execution-summary"
 ```
 
 ### PRD File Structure
@@ -598,5 +598,5 @@ Grep(pattern: "<task id=", path: ".gsd/phases/", output_mode: "content")
 Grep(pattern: "status:.*done|status:.*completed", path: ".gsd/", output_mode: "files_with_matches")
 
 # 실행 결과 메모리 저장
-bash .claude/hooks/md-store-memory.sh "Execution: {plan}" "{summary}" "execution,summary" "execution-summary"
+bash scripts/md-store-memory.sh "Execution: {plan}" "{summary}" "execution,summary" "execution-summary"
 ```

--- a/.claude/skills/impact-analysis/SKILL.md
+++ b/.claude/skills/impact-analysis/SKILL.md
@@ -53,7 +53,7 @@ Grep(pattern: "utils|models", path: "tests/", output_mode: "files_with_matches")
 ### Step 3: Memory Recall (과거 변경 이력)
 
 ```bash
-bash .claude/hooks/md-recall-memory.sh "utils" "." 5 compact
+bash scripts/md-recall-memory.sh "utils" "." 5 compact
 ```
 
 과거 deviation이나 root-cause가 있으면 주의 필요.

--- a/.claude/skills/memory-protocol/SKILL.md
+++ b/.claude/skills/memory-protocol/SKILL.md
@@ -59,13 +59,13 @@ Grep(pattern: "tags:.*{tag}", path: ".gsd/memories/", output_mode: "files_with_m
 
 ```bash
 # 기본 검색 (compact 모드, 2-hop)
-bash .claude/hooks/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5
+bash scripts/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5
 
 # 상세 검색 (full 모드)
-bash .claude/hooks/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5 full
+bash scripts/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5 full
 
 # 1-hop만 (related 추적 안함)
-bash .claude/hooks/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5 compact 1
+bash scripts/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5 compact 1
 ```
 
 ### 4. 2-hop 이웃 검색 (A-Mem)
@@ -73,7 +73,7 @@ bash .claude/hooks/md-recall-memory.sh "{query}" "$PROJECT_DIR" 5 compact 1
 
 ```bash
 # hop=2 (기본값): related 필드의 메모리도 포함
-bash .claude/hooks/md-recall-memory.sh "auth" "." 5 compact 2
+bash scripts/md-recall-memory.sh "auth" "." 5 compact 2
 ```
 
 Output에서 `[→related]` 표시로 2-hop 결과 구분 가능.
@@ -111,10 +111,10 @@ Output에서 `[→related]` 표시로 2-hop 결과 구분 가능.
 **방법 1: 훅 사용 (권장, A-Mem 확장)**
 ```bash
 # 기본
-bash .claude/hooks/md-store-memory.sh "{title}" "{content}" "{tag1,tag2}" "{type}"
+bash scripts/md-store-memory.sh "{title}" "{content}" "{tag1,tag2}" "{type}"
 
 # A-Mem 확장 필드 포함
-bash .claude/hooks/md-store-memory.sh "{title}" "{content}" "{tags}" "{type}" "{keywords}" "{contextual_desc}" "{related}"
+bash scripts/md-store-memory.sh "{title}" "{content}" "{tags}" "{type}" "{keywords}" "{contextual_desc}" "{related}"
 ```
 
 **중복 방지 (Nemori Predict-Calibrate):**
@@ -188,7 +188,7 @@ related:
 `md-recall-memory.sh`가 자동으로 `related` 필드를 추적:
 ```bash
 # hop=2 (기본): 검색 결과 + related 메모리
-bash .claude/hooks/md-recall-memory.sh "auth" "." 5 compact 2
+bash scripts/md-recall-memory.sh "auth" "." 5 compact 2
 ```
 
 ### 태그 기반 연결 (레거시)

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -526,7 +526,7 @@ Grep(pattern: "auth|security|database|api", path: "src/", output_mode: "count")
 Glob(pattern: ".gsd/phases/*/*.md")
 
 # 과거 플랜 deviation 확인
-bash .claude/hooks/md-recall-memory.sh "deviation" "." 5 compact
+bash scripts/md-recall-memory.sh "deviation" "." 5 compact
 ```
 
 **Discovery Level 기준:**

--- a/.gsd/PATTERNS.md
+++ b/.gsd/PATTERNS.md
@@ -11,8 +11,8 @@
 - **외부 종속성 없음**: 순수 bash 스크립트 + 네이티브 Claude Code 도구만 사용
 
 ## Memory System
-- **저장**: `bash .claude/hooks/md-store-memory.sh <title> <content> [tags] [type] [keywords] [contextual_desc] [related]`
-- **검색**: `bash .claude/hooks/md-recall-memory.sh <query> [path] [limit] [mode] [hop]`
+- **저장**: `bash scripts/md-store-memory.sh <title> <content> [tags] [type] [keywords] [contextual_desc] [related]`
+- **검색**: `bash scripts/md-recall-memory.sh <query> [path] [limit] [mode] [hop]`
 - **A-Mem 필드**: `keywords`, `contextual_description`, `related` (2-hop 검색용)
 - **중복 방지**: 동일 title 저장 시 `[SKIP:DUPLICATE]` 반환 (Nemori Predict-Calibrate)
 - **스키마**: `.gsd/memories/_schema/`에 JSON Schema + type-relations.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ related: [related_file_slug]
 - Read `.gsd/SPEC.md` before implementation
 - Verify empirically — 명령 실행 결과로 증명
 - Atomic commits per task
+- **WebFetch는 순차적으로 실행할 것 (병렬 fetch 금지)** — 병렬 호출 시 "Sibling tool call errored" 발생
 
 ### Ask First
 - Adding external dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make patch-clean              # Patch workspace 삭제
 
 - **코드 분석**: 네이티브 Claude Code 도구(Grep, Glob, Read)
 - **에이전트 메모리**: `.gsd/memories/{type}/` 마크다운 파일 기반. 14개 타입 디렉토리 + `_schema/` 스키마 디렉토리
-- **메모리 도구**: `.claude/hooks/md-store-memory.sh` (저장, A-Mem 확장), `.claude/hooks/md-recall-memory.sh` (검색, 2-hop)
+- **메모리 도구**: `scripts/md-store-memory.sh` (저장, A-Mem 확장), `scripts/md-recall-memory.sh` (검색, 2-hop)
 - **GSD Workflow**: SPEC.md → PLAN.md → EXECUTE → VERIFY. Working docs in `.gsd/`
 
 ## Memory Protocol

--- a/scripts/_json_parse.sh
+++ b/scripts/_json_parse.sh
@@ -1,0 +1,1 @@
+../.claude/hooks/_json_parse.sh

--- a/scripts/md-recall-memory.sh
+++ b/scripts/md-recall-memory.sh
@@ -1,0 +1,1 @@
+../.claude/hooks/md-recall-memory.sh

--- a/scripts/md-store-memory.sh
+++ b/scripts/md-store-memory.sh
@@ -1,0 +1,1 @@
+../.claude/hooks/md-store-memory.sh


### PR DESCRIPTION
## Summary
- 플러그인 환경에서 `bash .claude/hooks/md-store-memory.sh` 실행 시 exit 127 발생하던 근본 원인 수정
- SKILL.md 내 하드코딩 경로를 중립 경로(`scripts/`)로 통일 (방안 C)
- 보일러플레이트 직접 사용 환경은 심볼릭 링크로 호환 유지

## Changes
- **8개 SKILL.md** (`arch-review`, `bootstrap`, `context-health-monitor`, `debugger`, `executor`, `impact-analysis`, `memory-protocol`, `planner`): `bash .claude/hooks/md-*.sh` → `bash scripts/md-*.sh` (33곳)
- **`scripts/` 심볼릭 링크 3개** 생성: `md-store-memory.sh`, `md-recall-memory.sh`, `_json_parse.sh` → `../.claude/hooks/`
- **`scripts/build-plugin.sh`** Phase 3: `scripts/md-*.sh` → `${CLAUDE_PLUGIN_ROOT}/scripts/md-*.sh` 치환 로직 + Phase 8 검증 추가
- **`.claude/hooks/pre-compact-save.sh`**: `COMPACT_SCRIPT` 경로를 `PROJECT_DIR` 절대경로 → `dirname "$0"` 기반 자기참조로 수정
- **`CLAUDE.md`**, **`.gsd/PATTERNS.md`**: 문서 경로 업데이트

## Test Plan
- [x] `grep -r ".claude/hooks/md-" .claude/skills/` → 0건
- [x] `ls -la scripts/md-store-memory.sh scripts/md-recall-memory.sh` → 심볼릭 링크 확인
- [x] `make build-plugin` → `BUILD SUCCESSFUL`
- [x] `grep -r ".claude/hooks/" gsd-plugin/skills/` → 0건
- [x] `grep -r "CLAUDE_PLUGIN_ROOT.*scripts/md-" gsd-plugin/skills/` → 치환 결과 확인

## GSD Context
- 근본 원인: 플러그인 환경(`.claude/plugins/gsd/scripts/`)과 SKILL.md 하드코딩 경로(`.claude/hooks/`)의 불일치
- 해결 방안: 방안 C (하드코딩 경로 정규화) — `scripts/` 중립 경로로 통일