### PR TITLE
docs(memory): PR #26 변경사항 문서화 — scripts/ 중립 경로 반영

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -20,7 +20,7 @@
 ### 사용법
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "<title>" \
   "<content>" \
   "[tags]" \
@@ -63,7 +63,7 @@ bash .claude/hooks/md-store-memory.sh \
 ### 사용법
 
 ```bash
-bash .claude/hooks/md-recall-memory.sh \
+bash scripts/md-recall-memory.sh \
   "<query>" \
   "[project_path]" \
   "[limit]" \
@@ -178,10 +178,10 @@ related:
 
 ```bash
 # hop=2 (기본값): related 필드 추적
-bash .claude/hooks/md-recall-memory.sh "인증" "." 5 compact 2
+bash scripts/md-recall-memory.sh "인증" "." 5 compact 2
 
 # hop=1: 직접 검색만
-bash .claude/hooks/md-recall-memory.sh "인증" "." 5 compact 1
+bash scripts/md-recall-memory.sh "인증" "." 5 compact 1
 ```
 
 ---
@@ -205,6 +205,20 @@ root-cause:
     prevents: [health-event]
     generates: [pattern-discovery]
 ```
+
+---
+
+## 스크립트 경로 전략
+
+메모리 스크립트는 `scripts/` 디렉토리를 **중립 경로**로 사용합니다.
+
+| 환경 | 실제 경로 | 방식 |
+|------|-----------|------|
+| 보일러플레이트 직접 사용 | `scripts/` → `../.claude/hooks/` | 심볼릭 링크 |
+| 플러그인(`gsd-plugin`) | `${CLAUDE_PLUGIN_ROOT}/scripts/` | `build-plugin.sh` 자동 치환 |
+
+> **이유**: SKILL.md 내 `.claude/hooks/` 하드코딩 경로가 플러그인 환경에서 exit 127을 유발.
+> `scripts/` 중립 경로로 통일하여 두 환경 모두 호환. ([DECISION-001](.gsd/DECISIONS.md) 참조)
 
 ---
 


### PR DESCRIPTION
## Summary
- PR #26 (메모리 스크립트 경로 정규화) 후속 문서 업데이트
- `docs/MEMORY.md` bash 예시를 `scripts/md-*.sh` 중립 경로로 통일
- 경로 전략 섹션 신규 추가 — 보일러플레이트(심볼릭 링크) vs 플러그인(자동 치환) 설명

## Changes
- `docs/MEMORY.md`
  - 메모리 저장/검색 bash 예시: `.claude/hooks/md-*.sh` → `scripts/md-*.sh`
  - 2-hop 검색 예시 경로 동일하게 수정
  - **스크립트 경로 전략** 섹션 추가: 환경별 동작 비교표 + 채택 이유 + DECISION-001 참조

## Note
- `.gsd/CHANGELOG.md`, `.gsd/DECISIONS.md`는 `.gitignore` 대상(런타임 로컬 데이터)이므로 로컬에만 작성됨