### PR TITLE
docs: 메모리 스크립트 경로 및 빌드 Phase 목록 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ make setup
 ### 저장
 
 ```bash
-bash .claude/hooks/md-store-memory.sh \
+bash scripts/md-store-memory.sh \
   "제목" \
   "내용" \
   "태그1,태그2" \
@@ -112,13 +112,13 @@ bash .claude/hooks/md-store-memory.sh \
 
 ```bash
 # compact 모드 (요약)
-bash .claude/hooks/md-recall-memory.sh "검색어" "." 5 compact
+bash scripts/md-recall-memory.sh "검색어" "." 5 compact
 
 # full 모드 (전체 내용)
-bash .claude/hooks/md-recall-memory.sh "검색어" "." 5 full
+bash scripts/md-recall-memory.sh "검색어" "." 5 full
 
 # 2-hop 검색 (related 필드 추적)
-bash .claude/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
+bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 ```
 
 ### 메모리 타입 (14개)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -43,19 +43,19 @@ gsd-plugin/
 ### 빌드 과정
 
 1. **디렉토리 생성**: 플러그인 구조 생성
-2. **명령어 복사**: `.agent/workflows/*.md` → `commands/`
-3. **스킬 복사**: `.claude/skills/` → `skills/`
+2. **명령어 복사**: `.agent/workflows/*.md` → `commands/` (없으면 skills에서 자동 생성)
+3. **스킬 복사**: `.claude/skills/` → `skills/` + SKILL.md 경로 치환 (`scripts/md-*.sh` → `${CLAUDE_PLUGIN_ROOT}/scripts/md-*.sh`)
 4. **에이전트 복사**: `.claude/agents/` → `agents/`
 5. **훅 변환**:
    - `settings.json` → `hooks/hooks.json`
    - 경로 변환: `$CLAUDE_PROJECT_DIR/.claude/hooks/` → `${CLAUDE_PLUGIN_ROOT}/scripts/`
 6. **MCP 변환** (선택적):
    - `.mcp.json` 존재 시만 처리
-   - args `.` → `${CLAUDE_PROJECT_DIR:-.}`
    - 순수 bash 모드에서는 `[SKIP]` 메시지 출력
 7. **템플릿 복사**: `.gsd/templates/`, `.gsd/examples/`
 8. **레퍼런스 복사**: `pyproject.toml`, `Makefile`, `.gitignore` 등
-9. **검증**: 구조, 카운트, JSON 유효성
+9. **스캐폴딩 스크립트 생성**: `scaffold-gsd.sh`, `scaffold-infra.sh`, `README.md`
+10. **검증**: 구조, 카운트, 경로 변환, 권한, JSON 유효성
 
 ### 플러그인 사용
 
@@ -325,19 +325,22 @@ cd /path/to/project && opencode
 ### scripts/build-plugin.sh
 
 ```bash
-# 7단계 빌드 프로세스
-Phase 1: 디렉토리 구조 + 매니페스트
-Phase 2: 명령어 (워크플로우)
-Phase 3: 스킬
+# 8단계 빌드 프로세스
+Phase 1:  디렉토리 구조 + 매니페스트
+Phase 2:  명령어 (워크플로우)
+Phase 3:  스킬 복사 + SKILL.md 경로 치환 (scripts/ → ${CLAUDE_PLUGIN_ROOT}/scripts/)
 Phase 4a: 에이전트
-Phase 4b: 훅 (경로 변환)
+Phase 4b: 훅 설정 (hooks.json 경로 변환)
 Phase 4c: 훅 스크립트
-Phase 5a: MCP 설정
+Phase 5a: MCP 설정 (선택적)
 Phase 5b: GSD 템플릿
 Phase 5c: 인프라 레퍼런스
-Phase 5d: 유틸리티 스크립트
-Phase 6: 스캐폴딩 스크립트
-Phase 7: 검증
+Phase 5d: 유틸리티 스크립트 (compact-context.sh, organize-docs.sh)
+Phase 6a: scaffold-gsd.sh 생성
+Phase 6b: scaffold-infra.sh 생성
+Phase 6c: README.md 생성
+Phase 7:  (설치 스크립트 불필요 — --plugin-dir 방식)
+Phase 8:  검증 (구조/카운트/경로 변환/권한/JSON)
 ```
 
 ### scripts/build-antigravity.sh


### PR DESCRIPTION
## Summary
PR #26 (메모리 스크립트 경로 정규화) 이후 문서가 구버전 경로를 참조하던 문제 수정

## Changes

### README.md
- 메모리 저장/검색 bash 예시: `.claude/hooks/md-*.sh` → `scripts/md-*.sh`

### docs/BUILD.md
- `build-plugin.sh` Phase 목록: 7단계 → 8단계로 업데이트
  - Phase 3: SKILL.md 경로 치환 단계 명시 (신규 추가)
  - Phase 5d: 유틸리티 스크립트 복사 추가
  - Phase 6a/6b/6c: scaffold-gsd.sh, scaffold-infra.sh, README.md 생성 추가
  - Phase 7/8: 설치 불필요 메시지 + 검증 구분 명시
- 빌드 과정 설명에 step 3 경로 치환, step 9/10 추가