### PR TITLE
fix(build): sed -i 크로스 플랫폼 호환 (macOS/Linux)

### DIFF
--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -177,8 +177,16 @@ echo "  [+] Copied ${SKILLS_COUNT} skills"
 
 # Transform memory script refs in SKILL.md files:
 #   scripts/md-*.sh → ${CLAUDE_PLUGIN_ROOT}/scripts/md-*.sh
+# Use portable sed: macOS requires -i '', Linux requires -i
+_sed_inplace() {
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
 while IFS= read -r f; do
-    sed -i '' \
+    _sed_inplace \
         -e 's|bash scripts/md-store-memory\.sh|bash ${CLAUDE_PLUGIN_ROOT}/scripts/md-store-memory.sh|g' \
         -e 's|bash scripts/md-recall-memory\.sh|bash ${CLAUDE_PLUGIN_ROOT}/scripts/md-recall-memory.sh|g' \
         -e 's|\.claude/skills/\([^/]*\)/scripts/|${CLAUDE_PLUGIN_ROOT}/skills/\1/scripts/|g' \


### PR DESCRIPTION
## Summary
CI(ubuntu-latest)에서 `make build` 실패 수정 — Phase 3 SKILL.md 경로 치환 시 `sed: can't read` 오류

## Root Cause
`sed -i ''` 는 macOS 전용 문법. Linux(GNU sed)에서는 빈 suffix가 별도 인자로 파일명으로 해석됨.

## Fix
GNU sed 여부를 감지하는 `_sed_inplace` 헬퍼 함수 추가:
- GNU sed(Linux CI): `sed -i`
- BSD sed(macOS): `sed -i ''`

## Test
- [x] 로컬(macOS) `make build-plugin` → BUILD SUCCESSFUL
- [ ] CI(ubuntu-latest) 재실행으로 검증