### PR TITLE
feat(rename): gsd-plugin → hxsk-plugin, /gsd: → /hxsk: 전면 적용

### DIFF
--- a/.claude/hooks/compact-context.sh
+++ b/.claude/hooks/compact-context.sh
@@ -26,7 +26,7 @@ YEAR_MONTH=$(date +%Y-%m)
 # Check if .gsd directory exists
 if [[ ! -d "$GSD_DIR" ]]; then
     echo "[SKIP] .gsd/ directory not found at $GSD_DIR"
-    echo "Run /gsd:init to initialize GSD documents."
+    echo "Run /hxsk:init to initialize HExoskeleton documents."
     exit 0
 fi
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -26,9 +26,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['gsd-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs['gsd-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs['gsd-plugin--version'] || steps.release.outputs['.--version'] || steps.release.outputs.version }}
+      release_created: ${{ steps.release.outputs['hxsk-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs['hxsk-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs['hxsk-plugin--version'] || steps.release.outputs['.--version'] || steps.release.outputs.version }}
     steps:
       - name: Release Please
         uses: googleapis/release-please-action@v4
@@ -43,8 +43,8 @@ jobs:
           echo "=== All outputs ==="
           echo '${{ toJSON(steps.release.outputs) }}'
           echo "=== Resolved ==="
-          echo "release_created: ${{ steps.release.outputs['gsd-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}"
-          echo "tag_name: ${{ steps.release.outputs['gsd-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}"
+          echo "release_created: ${{ steps.release.outputs['hxsk-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}"
+          echo "tag_name: ${{ steps.release.outputs['hxsk-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}"
 
   # ── Build: 항상 실행 (master push, release, workflow_dispatch) ──
   build:
@@ -66,12 +66,12 @@ jobs:
             echo "Resolved from release-please: $RP_VERSION"
           elif [ "${{ github.event_name }}" = "release" ]; then
             TAG="${{ github.event.release.tag_name }}"
-            VERSION=$(echo "$TAG" | sed 's/gsd-plugin-v//')
+            VERSION=$(echo "$TAG" | sed 's/hxsk-plugin-v//')
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "Resolved from release event: $VERSION"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName 2>/dev/null || echo "")
-            VERSION=$(echo "$TAG" | sed 's/gsd-plugin-v//')
+            VERSION=$(echo "$TAG" | sed 's/hxsk-plugin-v//')
             echo "version=${VERSION:-dev}" >> $GITHUB_OUTPUT
             echo "Resolved from latest release: ${VERSION:-dev}"
           else
@@ -89,7 +89,7 @@ jobs:
       - name: Create ZIPs
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          for dir in gsd-plugin antigravity-boilerplate opencode-boilerplate; do
+          for dir in hxsk-plugin antigravity-boilerplate opencode-boilerplate; do
             (cd "$dir" && zip -r "../${dir}-${VERSION}.zip" . \
               -x ".git/*" "__pycache__/*" "*.pyc" ".pytest_cache/*" \
                  "node_modules/*" ".env" ".venv/*" "*.log" ".DS_Store")
@@ -100,7 +100,7 @@ jobs:
         with:
           name: build-${{ steps.version.outputs.version }}
           path: |
-            gsd-plugin-${{ steps.version.outputs.version }}.zip
+            hxsk-plugin-${{ steps.version.outputs.version }}.zip
             antigravity-boilerplate-${{ steps.version.outputs.version }}.zip
             opencode-boilerplate-${{ steps.version.outputs.version }}.zip
           retention-days: 7
@@ -113,7 +113,7 @@ jobs:
           echo "- **Version**: ${VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Artifacts**:" >> $GITHUB_STEP_SUMMARY
-          for dir in gsd-plugin antigravity-boilerplate opencode-boilerplate; do
+          for dir in hxsk-plugin antigravity-boilerplate opencode-boilerplate; do
             echo "  - ${dir}-${VERSION}.zip" >> $GITHUB_STEP_SUMMARY
           done
 

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,11 @@ build: build-plugin build-antigravity build-opencode ## Build all targets
 	@echo "========================================="
 	@echo "  All builds complete!"
 	@echo "========================================="
-	@echo "  - gsd-plugin/              (Claude Code)"
+	@echo "  - hxsk-plugin/             (Claude Code)"
 	@echo "  - antigravity-boilerplate/ (Antigravity IDE)"
 	@echo "  - opencode-boilerplate/    (OpenCode)"
 
-build-plugin: ## Build Claude Code plugin (gsd-plugin/)
+build-plugin: ## Build Claude Code plugin (hxsk-plugin/)
 	@bash scripts/build-plugin.sh
 
 build-antigravity: ## Build Antigravity workspace (antigravity-boilerplate/)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ claude .
 
 # 또는 플러그인으로 배포 후 사용
 make build-plugin
-claude --plugin-dir ./gsd-plugin
+claude --plugin-dir ./hxsk-plugin
 ```
 
 ### 3. 워크플로우 시작
@@ -304,7 +304,7 @@ SPEC → PLAN → EXECUTE → VERIFY
 
 | 타겟 | 명령어 | 출력 |
 |------|--------|------|
-| Claude Code Plugin | `make build-plugin` | `gsd-plugin/` |
+| Claude Code Plugin | `make build-plugin` | `hxsk-plugin/` |
 | Google Antigravity | `make build-antigravity` | `antigravity-boilerplate/` |
 | OpenCode | `make build-opencode` | `opencode-boilerplate/` |
 
@@ -320,9 +320,9 @@ feat: 새 기능 추가 → push to master → Release PR 생성 → 머지 → 
 
 ```bash
 # 최신 버전
-VERSION=$(gh release view --json tagName -q .tagName | sed 's/gsd-plugin-v//')
-curl -L "https://github.com/SukbeomH/LLM_Bolierplate_Pack/releases/latest/download/gsd-plugin-${VERSION}.zip" -o gsd-plugin.zip
-unzip gsd-plugin.zip -d ~/.claude/plugins/gsd
+VERSION=$(gh release view --json tagName -q .tagName | sed 's/hxsk-plugin-v//')
+curl -L "https://github.com/SukbeomH/LLM_Bolierplate_Pack/releases/latest/download/hxsk-plugin-${VERSION}.zip" -o hxsk-plugin.zip
+unzip hxsk-plugin.zip -d ~/.claude/plugins/hxsk
 ```
 
 ---

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -8,7 +8,7 @@
 
 | 명령어 | 출력 | 용도 |
 |--------|------|------|
-| `make build-plugin` | `gsd-plugin/` | Claude Code 플러그인 |
+| `make build-plugin` | `hxsk-plugin/` | Claude Code 플러그인 |
 | `make build-antigravity` | `antigravity-boilerplate/` | Google Antigravity IDE 워크스페이스 |
 | `make build-opencode` | `opencode-boilerplate/` | OpenCode 워크스페이스 (모델 설정 지원) |
 
@@ -25,7 +25,7 @@ make build-plugin
 ### 출력 구조
 
 ```
-gsd-plugin/
+hxsk-plugin/
 ├── .claude-plugin/
 │   └── plugin.json          # 매니페스트 (name, version, description)
 ├── commands/                 # 워크플로우 명령어
@@ -61,13 +61,13 @@ gsd-plugin/
 
 ```bash
 # 테스트
-claude --plugin-dir ./gsd-plugin
+claude --plugin-dir ./hxsk-plugin
 
 # 글로벌 설치
-cp -r gsd-plugin ~/.claude/plugins/gsd
+cp -r hxsk-plugin ~/.claude/plugins/hxsk
 
 # 명령어 확인
-/gsd:help
+/hxsk:help
 ```
 
 ### 자동 릴리즈
@@ -75,7 +75,7 @@ cp -r gsd-plugin ~/.claude/plugins/gsd
 플러그인은 **release-please** 기반 GitHub Actions로 자동 릴리즈됩니다.
 
 ```
-feat(gsd-plugin): 새 기능
+feat(hxsk-plugin): 새 기능
     ↓
 push to master
     ↓
@@ -83,7 +83,7 @@ Release PR 자동 생성
     ↓
 PR 머지 → 자동 릴리즈
     ↓
-gsd-plugin-v1.x.0 태그 + ZIP 첨부
+hxsk-plugin-v1.x.0 태그 + ZIP 첨부
 ```
 
 ---
@@ -316,7 +316,7 @@ cd /path/to/project && opencode
 | **Agents** | 서브에이전트 | Agent Manager 통합 |
 | **Hooks** | 이벤트 기반 | Rules로 대체 |
 | **MCP** | settings.json | UI 기반 MCP Store |
-| **워크플로우** | `/gsd:*` 명령어 | `/` 명령어 |
+| **워크플로우** | `/hxsk:*` 명령어 | `/` 명령어 |
 
 ---
 
@@ -433,7 +433,7 @@ cp mcp-settings.json ~/.gemini/antigravity/
 
 ## 관련 문서
 
-- [README - 플러그인 빌드](../README.md#gsd-plugin-빌드)
-- [README - 자동 릴리즈](../README.md#gsd-plugin-자동-릴리즈)
+- [README - 플러그인 빌드](../README.md#hxsk-plugin-빌드)
+- [README - 자동 릴리즈](../README.md#hxsk-plugin-자동-릴리즈)
 - [GITHUB-WORKFLOW.md](./GITHUB-WORKFLOW.md) - CI/CD 파이프라인
 - [.gsd/research/RESEARCH-google-antigravity-migration.md](../.gsd/research/RESEARCH-google-antigravity-migration.md) - Antigravity 리서치

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -215,7 +215,7 @@ root-cause:
 | 환경 | 실제 경로 | 방식 |
 |------|-----------|------|
 | 보일러플레이트 직접 사용 | `scripts/` → `../.claude/hooks/` | 심볼릭 링크 |
-| 플러그인(`gsd-plugin`) | `${CLAUDE_PLUGIN_ROOT}/scripts/` | `build-plugin.sh` 자동 치환 |
+| 플러그인(`hxsk-plugin`) | `${CLAUDE_PLUGIN_ROOT}/scripts/` | `build-plugin.sh` 자동 치환 |
 
 > **이유**: SKILL.md 내 `.claude/hooks/` 하드코딩 경로가 플러그인 환경에서 exit 127을 유발.
 > `scripts/` 중립 경로로 통일하여 두 환경 모두 호환. ([DECISION-001](.gsd/DECISIONS.md) 참조)

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -10,7 +10,7 @@ Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 
 |------|------|
 | **위치** | `.agent/workflows/*.md` |
 | **개수** | 30개 (+ init.md = 31개 in plugin) |
-| **호출 방식** | `/gsd:<command>` 또는 `/<command>` |
+| **호출 방식** | `/hxsk:<command>` 또는 `/<command>` |
 | **인자 전달** | `$ARGUMENTS` 변수로 전달 |
 
 ---

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,13 +8,13 @@
   "tag-separator": "-",
   "packages": {
     ".": {
-      "component": "gsd-plugin",
+      "component": "hxsk-plugin",
       "changelog-path": "CHANGELOG.md",
       "release-type": "simple",
       "extra-files": [
         {
           "type": "json",
-          "path": "gsd-plugin/.claude-plugin/plugin.json",
+          "path": "hxsk-plugin/.claude-plugin/plugin.json",
           "jsonpath": "$.version"
         }
       ]

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 #
-# GSD Plugin Build Script
+# HExoskeleton Plugin Build Script
 # Converts boilerplate to Claude Code plugin format
 #
 set -euo pipefail
 
 # --- Configuration ---
 BOILERPLATE="$(cd "$(dirname "$0")/.." && pwd)"
-PLUGIN="${BOILERPLATE}/gsd-plugin"
+PLUGIN="${BOILERPLATE}/hxsk-plugin"
 
-echo "=== GSD Plugin Builder ==="
+echo "=== HExoskeleton Plugin Builder ==="
 echo "Source: ${BOILERPLATE}"
 echo "Target: ${PLUGIN}"
 echo ""
@@ -25,15 +25,15 @@ mkdir -p "$PLUGIN"/references/issue-templates
 VERSION="1.0.0"
 MANIFEST="${BOILERPLATE}/.release-please-manifest.json"
 if [ -f "$MANIFEST" ]; then
-    VERSION=$(python3 -c "import json; m=json.load(open('$MANIFEST')); print(m.get('.', m.get('gsd-plugin', '1.0.0')))")
+    VERSION=$(python3 -c "import json; m=json.load(open('$MANIFEST')); print(m.get('.', m.get('hxsk-plugin', '1.0.0')))")
 fi
 
 # Create plugin.json manifest (minimal - default directories auto-discovered)
 cat > "$PLUGIN/.claude-plugin/plugin.json" << EOF
 {
-  "name": "gsd",
+  "name": "hxsk",
   "version": "${VERSION}",
-  "description": "Get Shit Done - AI agent development methodology with code-graph-rag and memory-graph integration"
+  "description": "HExoskeleton - AI agent development methodology with code-graph-rag and memory-graph integration"
 }
 EOF
 echo "  [+] plugin.json created (version: ${VERSION})"
@@ -69,7 +69,7 @@ allowed-tools:
   - Grep
 ---
 
-# /gsd:${skill_name}
+# /hxsk:${skill_name}
 
 ${desc}
 
@@ -83,7 +83,7 @@ fi
 # Create init.md (new scaffolding command)
 cat > "$PLUGIN/commands/init.md" << 'INITEOF'
 ---
-description: Initialize GSD document system and compare infrastructure files
+description: Initialize HExoskeleton document system and compare infrastructure files
 allowed-tools:
   - Read
   - Write
@@ -92,9 +92,9 @@ allowed-tools:
   - Grep
 ---
 
-# /gsd:init - GSD Initialization
+# /hxsk:init - HExoskeleton Initialization
 
-Initialize the GSD (Get Shit Done) document system in the current project.
+Initialize the HExoskeleton document system in the current project.
 
 ## What This Command Does
 
@@ -156,10 +156,10 @@ If `.gsd/SPEC.md` is empty or contains only placeholder content:
 ## After Initialization
 
 Once initialized, you can use GSD commands:
-- `/gsd:plan` - Create implementation plans
-- `/gsd:execute` - Execute planned work
-- `/gsd:verify` - Verify completed work
-- `/gsd:help` - List all available commands
+- `/hxsk:plan` - Create implementation plans
+- `/hxsk:execute` - Execute planned work
+- `/hxsk:verify` - Verify completed work
+- `/hxsk:help` - List all available commands
 INITEOF
 echo "  [+] Created init.md command"
 COMMANDS_COUNT=$((COMMANDS_COUNT + 1))
@@ -325,7 +325,7 @@ for doc in SPEC DECISIONS JOURNAL ROADMAP PATTERNS STATE TODO STACK CHANGELOG; d
     cat > "$PLUGIN/templates/gsd/${doc}.md" << EOF
 # ${doc}
 
-<!-- This file will be populated during /gsd:init -->
+<!-- This file will be populated during /hxsk:init -->
 <!-- See templates/${doc,,}.md for the full template -->
 EOF
 done
@@ -612,7 +612,7 @@ if os.path.isdir(agent_dir):
         agents.append((name, desc or f"{name} agent"))
 
 # Build README
-readme = f"""# GSD Plugin for Claude Code
+readme = f"""# HExoskeleton for Claude Code
 
 **Get Shit Done** v{version} — AI agent development methodology with pure bash-based memory system.
 
@@ -622,19 +622,19 @@ readme = f"""# GSD Plugin for Claude Code
 
 ```bash
 # Use with --plugin-dir flag
-claude --plugin-dir /path/to/gsd-plugin
+claude --plugin-dir /path/to/hxsk-plugin
 
 # Or set a shell alias for convenience (~/.zshrc or ~/.bashrc)
-alias claude='claude --plugin-dir /path/to/gsd-plugin'
+alias claude='claude --plugin-dir /path/to/hxsk-plugin'
 ```
 
 ### GitHub Release에서 설치
 
 ```bash
 # 최신 버전
-VERSION=$(gh release view --json tagName -q .tagName | sed 's/gsd-plugin-v//')
-curl -L "https://github.com/SukbeomH/LLM_Bolierplate_Pack/releases/latest/download/gsd-plugin-${{VERSION}}.zip" -o gsd-plugin.zip
-unzip gsd-plugin.zip -d ~/.claude/plugins/gsd
+VERSION=$(gh release view --json tagName -q .tagName | sed 's/hxsk-plugin-v//')
+curl -L "https://github.com/SukbeomH/LLM_Bolierplate_Pack/releases/latest/download/hxsk-plugin-${{VERSION}}.zip" -o hxsk-plugin.zip
+unzip hxsk-plugin.zip -d ~/.claude/plugins/hxsk
 ```
 
 ## Prerequisites
@@ -668,11 +668,11 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact
 ## Quick Start
 
 ```bash
-/gsd:init          # Initialize GSD documents
-/gsd:bootstrap     # Full project setup
-/gsd:planner       # Create implementation plan
-/gsd:executor      # Execute planned work
-/gsd:verifier      # Verify completed work
+/hxsk:init          # Initialize GSD documents
+/hxsk:bootstrap     # Full project setup
+/hxsk:planner       # Create implementation plan
+/hxsk:executor      # Execute planned work
+/hxsk:verifier      # Verify completed work
 ```
 
 ## Commands ({len(commands)})
@@ -707,7 +707,7 @@ for name, desc in agents:
 readme += """
 ## GSD Document Structure
 
-After `/gsd:init`:
+After `/hxsk:init`:
 
 ```
 .gsd/


### PR DESCRIPTION
## Summary
프로젝트명 **HExoskeleton** 반영 — 플러그인 식별자 및 명령어 prefix 전면 교체

## Changes

| 항목 | 이전 | 이후 |
|------|------|------|
| Plugin name | `"gsd"` | `"hxsk"` |
| 출력 디렉토리 | `gsd-plugin/` | `hxsk-plugin/` |
| 명령어 prefix | `/gsd:*` | `/hxsk:*` |
| 릴리즈 태그 | `gsd-plugin-v*` | `hxsk-plugin-v*` |
| 설치 경로 | `~/.claude/plugins/gsd` | `~/.claude/plugins/hxsk` |

## 변경 파일
- `scripts/build-plugin.sh` — 출력 디렉토리, plugin.json name, 명령어 prefix
- `release-please-config.json` — component명, extra-files 경로
- `Makefile` — build-plugin 설명
- `.github/workflows/release-plugin.yml` — release-please output key, ZIP 파일명
- `.claude/hooks/compact-context.sh` — 안내 메시지
- `docs/BUILD.md`, `docs/WORKFLOWS.md`, `docs/MEMORY.md`, `README.md` — 문서

## 검증
- `make build-plugin` → `BUILD SUCCESSFUL`
- `plugin.json`: `"name": "hxsk"`
- 명령어: `/hxsk:planner`, `/hxsk:init` 등 정상 생성