### PR TITLE
ci(workflow): fix Debug outputs shell syntax error

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Debug outputs
         run: |
           echo "=== All outputs ==="
-          echo '${{ toJSON(steps.release.outputs) }}'
+          cat << 'DEBUGEOF'
+          ${{ toJSON(steps.release.outputs) }}
+          DEBUGEOF
           echo "=== Resolved ==="
-          echo "release_created: ${{ steps.release.outputs['hxsk-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}"
-          echo "tag_name: ${{ steps.release.outputs['hxsk-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}"
+          printf 'release_created: %s\n' "${{ steps.release.outputs['hxsk-plugin--release_created'] || steps.release.outputs['.--release_created'] || steps.release.outputs.release_created }}"
+          printf 'tag_name: %s\n' "${{ steps.release.outputs['hxsk-plugin--tag_name'] || steps.release.outputs['.--tag_name'] || steps.release.outputs.tag_name }}"
 
   # ── Build: 항상 실행 (master push, release, workflow_dispatch) ──
   build:


### PR DESCRIPTION
## Summary
- `echo '${{ toJSON(...) }}'`에서 JSON body 내 `(` 문자가 shell syntax 에러 유발
- heredoc + `printf` 방식으로 교체하여 특수문자 안전 처리

## Changes
- `.github/workflows/release-plugin.yml`: Debug outputs 스텝 수정

## Test Plan
- [ ] release-please job의 Debug outputs 스텝이 정상 완료되는지 확인

## GSD Context
- Fix: CI Debug outputs step shell syntax error