### PR TITLE
chore(gitignore): rename gsd-plugin → hxsk-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,7 @@ logs_llm/
 .patch-workspace/
 
 # Build outputs (make build - generated in CI)
-gsd-plugin/
+hxsk-plugin/
 antigravity-boilerplate/
 opencode-boilerplate/
 


### PR DESCRIPTION
## Summary
- `.gitignore`의 빌드 출력 경로 `gsd-plugin/` → `hxsk-plugin/` 변경

## Changes
- `.gitignore`: line 111 경로명 업데이트