### PR TITLE
fix: antigravity P0 critical fixes + opencode plugin warnings

### DIFF
--- a/scripts/build-antigravity.sh
+++ b/scripts/build-antigravity.sh
@@ -284,7 +284,11 @@ echo "  [+] validation.md"
     echo 'description: "GSD workflow rules — architecture principles and execution cycle"'
     echo "---"
     echo ""
-    extract_section "$CLAUDE_MD" "Architecture" | transform_tool_refs
+    extract_section "$CLAUDE_MD" "Architecture" | transform_tool_refs | sed \
+        -e 's/네이티브 Claude Code 도구(Grep, Glob, Read)/에이전트 내장 검색 도구(search, find_files, read_file)/g' \
+        -e 's/네이티브 Claude Code 도구만/에이전트 내장 도구만/g' \
+        -e 's/네이티브 Claude Code/에이전트 내장/g' \
+        -e 's/Claude Code/Antigravity IDE/g'
     echo ""
     echo "## GSD Cycle"
     echo ""

--- a/scripts/build-opencode.sh
+++ b/scripts/build-opencode.sh
@@ -452,7 +452,7 @@ fi
 
 # Ensure package.json exists
 cat > "$OPENCODE/.opencode/package.json" << 'PKGEOF'
-{"name":"opencode-plugins","type":"module","dependencies":{"@opencode-ai/plugin":"latest"}}
+{"name":"opencode-plugins","type":"module","dependencies":{"@opencode-ai/plugin":"^1.2.10"}}
 PKGEOF
 
 # Create migration guide

--- a/scripts/convert-hooks-to-plugins.py
+++ b/scripts/convert-hooks-to-plugins.py
@@ -57,15 +57,36 @@ def oc_event_to_name(oc_event: str) -> str:
     return "".join(p.capitalize() for p in oc_event.replace(".", "-").split("-")) + "Plugin"
 
 
+def generate_script_exec(fname: str, oc_event: str) -> str:
+    """Generate the TypeScript execution call for a single hook script."""
+    ext = os.path.splitext(fname)[1]
+    runner = "python3" if ext == ".py" else "bash"
+    script_path = f"${{import.meta.dir}}/../../scripts/{fname}"
+
+    if oc_event == "tool.execute.before":
+        # Guard hooks: run with tool context, throw on non-zero exit to block
+        return (
+            f"    const r_{fname.replace('-','_').replace('.','_')} = "
+            f"await $`{runner} {script_path}`"
+            f".env({{ TOOL_NAME: (input as any)?.tool ?? \"\", "
+            f"TOOL_INPUT: JSON.stringify(input) }}).nothrow();\n"
+            f"    if (r_{fname.replace('-','_').replace('.','_')}.exitCode !== 0) "
+            f"throw new Error(r_{fname.replace('-','_').replace('.','_')}.stderr.toString().trim() "
+            f"|| \"{fname} blocked execution\");"
+        )
+    else:
+        # Non-blocking hooks: run and ignore exit code
+        return f"    await $`{runner} {script_path}`.nothrow();"
+
+
 def generate_plugin(oc_event: str, hooks: list) -> str:
-    """Generate a TypeScript plugin stub for one OpenCode event group."""
+    """Generate a functional TypeScript plugin for one OpenCode event group."""
     claude_event = hooks[0][1]
     hook_comments = "\n".join(
         f" *   - {fname}: {desc}" for fname, _, desc in hooks
     )
     script_execs = "\n".join(
-        f"    // await $`bash ${{import.meta.dir}}/../../scripts/{fname}`"
-        for fname, _, _ in hooks
+        generate_script_exec(fname, oc_event) for fname, _, _ in hooks
     )
     plugin_name = oc_event_to_name(oc_event)
 

--- a/scripts/convert-hooks-to-plugins.py
+++ b/scripts/convert-hooks-to-plugins.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Convert Claude Code hooks to OpenCode TypeScript plugin stubs.
+
+Usage:
+  python3 convert-hooks-to-plugins.py <hooks_src_dir> <plugins_dst_dir>
+
+Each Claude Code hook is mapped to the equivalent OpenCode plugin event
+and a TypeScript stub is generated that wraps the original shell script.
+"""
+
+import os
+import sys
+
+# Claude Code event → OpenCode event mapping
+EVENT_MAP = {
+    "SessionStart":  "session.created",
+    "PreToolUse":    "tool.execute.before",
+    "PostToolUse":   "tool.execute.after",
+    "Stop":          "session.idle",
+    "SessionEnd":    "session.idle",
+    "PreCompact":    "session.idle",
+}
+
+# Hook filename → (Claude event, description)
+HOOK_META = {
+    "bash-guard.py":           ("PreToolUse",  "Block dangerous bash commands (force push, rm -rf, etc.)"),
+    "file-protect.py":         ("PreToolUse",  "Protect sensitive files (.env, credentials, secrets)"),
+    "auto-format.sh":          ("PostToolUse", "Auto-format Python files after edit"),
+    "track-modifications.sh":  ("PostToolUse", "Track file modifications for session summary"),
+    "pre-compact-save.sh":     ("PreCompact",  "Save context state before compaction"),
+    "session-start.sh":        ("SessionStart","Initialize session: load STATE.md, inject git status"),
+    "post-turn-verify.sh":     ("Stop",        "Verify task completion after each turn"),
+    "stop-context-save.sh":    ("Stop",        "Save context and memory on session stop"),
+    "save-session-changes.sh": ("SessionEnd",  "Record changed files on session end"),
+    "save-transcript.sh":      ("SessionEnd",  "Save conversation transcript on session end"),
+}
+
+# Skip these utility scripts — not event hooks
+SKIP_FILES = {
+    "md-store-memory.sh",
+    "md-recall-memory.sh",
+    "_json_parse.sh",
+    "scaffold-gsd.sh",
+    "scaffold-hxsk.sh",
+    "scaffold-infra.sh",
+    "compact-context.sh",
+    "organize-docs.sh",
+}
+
+
+def to_camel(name: str) -> str:
+    base = os.path.splitext(name)[0]
+    return "".join(p.capitalize() for p in base.replace("-", "_").split("_")) + "Plugin"
+
+
+def oc_event_to_name(oc_event: str) -> str:
+    return "".join(p.capitalize() for p in oc_event.replace(".", "-").split("-")) + "Plugin"
+
+
+def generate_plugin(oc_event: str, hooks: list) -> str:
+    """Generate a TypeScript plugin stub for one OpenCode event group."""
+    claude_event = hooks[0][1]
+    hook_comments = "\n".join(
+        f" *   - {fname}: {desc}" for fname, _, desc in hooks
+    )
+    script_execs = "\n".join(
+        f"    // await $`bash ${{import.meta.dir}}/../../scripts/{fname}`"
+        for fname, _, _ in hooks
+    )
+    plugin_name = oc_event_to_name(oc_event)
+
+    return f"""import type {{ Plugin }} from "@opencode-ai/plugin"
+
+/**
+ * Claude Code event : {claude_event}
+ * OpenCode event    : {oc_event}
+ *
+ * Converted hooks:
+{hook_comments}
+ *
+ * Original scripts are in scripts/ directory.
+ * See MIGRATION-GUIDE.md for conversion patterns.
+ */
+export const {plugin_name}: Plugin = async ({{ $ }}) => ({{
+  "{oc_event}": async (input: unknown, _output: unknown) => {{
+{script_execs}
+  }},
+}})
+"""
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("Usage: convert-hooks-to-plugins.py <hooks_dir> <plugins_dir>")
+        return 1
+
+    hooks_src = sys.argv[1]
+    plugins_dst = sys.argv[2]
+
+    if not os.path.isdir(hooks_src):
+        print(f"Error: hooks directory not found: {hooks_src}")
+        return 1
+
+    os.makedirs(plugins_dst, exist_ok=True)
+
+    # Group hooks by OpenCode event
+    groups: dict[str, list] = {}
+    unclassified: list[str] = []
+
+    for fname in sorted(os.listdir(hooks_src)):
+        if fname in SKIP_FILES or fname.startswith("_"):
+            continue
+        if not (fname.endswith(".sh") or fname.endswith(".py")):
+            continue
+
+        meta = HOOK_META.get(fname)
+        if meta:
+            claude_event, desc = meta
+            oc_event = EVENT_MAP[claude_event]
+            groups.setdefault(oc_event, []).append((fname, claude_event, desc))
+        else:
+            unclassified.append(fname)
+
+    # Write one .ts file per OpenCode event
+    count = 0
+    for oc_event, hooks in sorted(groups.items()):
+        plugin_filename = oc_event.replace(".", "-") + ".ts"
+        out_path = os.path.join(plugins_dst, plugin_filename)
+        content = generate_plugin(oc_event, hooks)
+        with open(out_path, "w") as f:
+            f.write(content)
+        hook_names = ", ".join(h[0] for h in hooks)
+        print(f"  [+] {plugin_filename} ({len(hooks)} hooks: {hook_names})")
+        count += 1
+
+    if unclassified:
+        print(f"  [?] Unclassified (skipped): {', '.join(unclassified)}")
+
+    print(f"  Total: {count} plugin files generated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- **Antigravity P0-1**: `gsd-workflow.md` 생성 시 "Claude Code 도구(Grep, Glob, Read)" → "에이전트 내장 검색 도구(search, find_files, read_file)" 변환 누락 수정
- **OpenCode 경고-1**: plugin TypeScript 파일에 commented-out 스텁 대신 실제 동작하는 구현 생성
- **OpenCode 경고-2**: `@opencode-ai/plugin: "latest"` → `"^1.2.10"` 버전 핀 고정

## Changes
- `scripts/build-antigravity.sh`: Phase 5 gsd-workflow.md 생성에 sed transform 추가 (특정→일반 순서)
- `scripts/convert-hooks-to-plugins.py`: `generate_script_exec()` 추가 — `tool.execute.before`는 에러 throw, 나머지는 `.nothrow()`
- `scripts/build-opencode.sh`: package.json 의존성 버전 `"latest"` → `"^1.2.10"`

## Test Plan
- [x] `make build-opencode` — WARN 없이 BUILD SUCCESSFUL
- [x] `make build-antigravity` — 생성된 `gsd-workflow.md`에 "Claude Code" 문자열 없음
- [x] `.opencode/plugins/tool-execute-before.ts` — 실제 `await $\`...\`` 코드 생성 확인
- [x] `.opencode/package.json` — `"^1.2.10"` 버전 핀 고정 확인

## GSD Context
- Fixes: official docs review에서 발견된 P0 (antigravity) + ⚠️ (opencode) 이슈
- SPEC reference: `.hxsk/SPEC.md`