### PR TITLE
refactor: rename GSD → HXSK across entire codebase

### DIFF
--- a/.claude/agents/commit.md
+++ b/.claude/agents/commit.md
@@ -1,5 +1,5 @@
 ---
-description: Analyzes diffs, splits logical changes, creates conventional emoji commits aligned with GSD atomic commit protocol.
+description: Analyzes diffs, splits logical changes, creates conventional emoji commits aligned with HXSK atomic commit protocol.
 model: haiku
 tools: ["Read", "Bash", "Grep", "Glob"]
 ---

--- a/.claude/agents/executor.md
+++ b/.claude/agents/executor.md
@@ -1,5 +1,5 @@
 ---
-description: Executes GSD plans with atomic commits, deviation handling, checkpoint protocols, and state management.
+description: Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols, and state management.
 model: sonnet
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
 ---

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,5 +1,5 @@
 ---
-description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Use when decomposing work into structured GSD plans.
+description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Use when decomposing work into structured HXSK plans.
 model: opus
 tools: ["Read", "Grep", "Glob"]
 ---

--- a/.claude/hooks/compact-context.sh
+++ b/.claude/hooks/compact-context.sh
@@ -19,13 +19,13 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     echo "[DRY-RUN] No files will be modified"
 fi
 
-GSD_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
-ARCHIVE_DIR="$GSD_DIR/archive"
+HXSK_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
+ARCHIVE_DIR="$HXSK_DIR/archive"
 YEAR_MONTH=$(date +%Y-%m)
 
 # Check if .hxsk directory exists
-if [[ ! -d "$GSD_DIR" ]]; then
-    echo "[SKIP] .hxsk/ directory not found at $GSD_DIR"
+if [[ ! -d "$HXSK_DIR" ]]; then
+    echo "[SKIP] .hxsk/ directory not found at $HXSK_DIR"
     echo "Run /hxsk:init to initialize HExoskeleton documents."
     exit 0
 fi
@@ -44,7 +44,7 @@ echo "================================================================"
 # 1. PATTERNS.md size check
 # ─────────────────────────────────────────────────────
 
-PATTERNS_FILE="$GSD_DIR/PATTERNS.md"
+PATTERNS_FILE="$HXSK_DIR/PATTERNS.md"
 if [[ -f "$PATTERNS_FILE" ]]; then
     PATTERNS_SIZE=$(wc -c < "$PATTERNS_FILE" | tr -d ' ')
     PATTERNS_ITEMS=$(grep -c "^- " "$PATTERNS_FILE" 2>/dev/null | tr -d '[:space:]' || echo 0)
@@ -70,7 +70,7 @@ fi
 # 2. JOURNAL.md archiving
 # ─────────────────────────────────────────────────────
 
-JOURNAL_FILE="$GSD_DIR/JOURNAL.md"
+JOURNAL_FILE="$HXSK_DIR/JOURNAL.md"
 if [[ -f "$JOURNAL_FILE" ]]; then
     # Count sessions (headers starting with ### [Session or ## Session)
     SESSION_COUNT=$(grep -c "^##.* Session" "$JOURNAL_FILE" 2>/dev/null || echo 0)
@@ -128,7 +128,7 @@ fi
 # 3. CHANGELOG.md archiving
 # ─────────────────────────────────────────────────────
 
-CHANGELOG_FILE="$GSD_DIR/CHANGELOG.md"
+CHANGELOG_FILE="$HXSK_DIR/CHANGELOG.md"
 if [[ -f "$CHANGELOG_FILE" ]]; then
     ENTRY_COUNT=$(grep -c "^### \[" "$CHANGELOG_FILE" 2>/dev/null | tr -d '[:space:]' || echo 0)
 
@@ -185,8 +185,8 @@ fi
 # 4. prd-active.json cleanup
 # ─────────────────────────────────────────────────────
 
-PRD_ACTIVE="$GSD_DIR/prd-active.json"
-PRD_DONE="$GSD_DIR/prd-done.json"
+PRD_ACTIVE="$HXSK_DIR/prd-active.json"
+PRD_DONE="$HXSK_DIR/prd-done.json"
 if [[ -f "$PRD_ACTIVE" ]]; then
     PENDING_COUNT=$(jq '.tasks | length' "$PRD_ACTIVE" 2>/dev/null || echo 0)
     PRD_SIZE=$(wc -c < "$PRD_ACTIVE" | tr -d ' ')

--- a/.claude/hooks/organize-docs.sh
+++ b/.claude/hooks/organize-docs.sh
@@ -17,9 +17,9 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     echo "[DRY-RUN] No files will be moved"
 fi
 
-GSD_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
-REPORTS_DIR="$GSD_DIR/reports"
-RESEARCH_DIR="$GSD_DIR/research"
+HXSK_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
+REPORTS_DIR="$HXSK_DIR/reports"
+RESEARCH_DIR="$HXSK_DIR/research"
 
 # Ensure directories exist
 mkdir -p "$REPORTS_DIR" "$RESEARCH_DIR"
@@ -37,7 +37,7 @@ MOVED_COUNT=0
 echo ""
 echo "--- Reports ---"
 
-for file in "$GSD_DIR"/REPORT-*.md; do
+for file in "$HXSK_DIR"/REPORT-*.md; do
     if [[ -f "$file" ]]; then
         filename=$(basename "$file")
         if [[ "$DRY_RUN" == true ]]; then
@@ -62,7 +62,7 @@ echo ""
 echo "--- Research ---"
 
 RESEARCH_MOVED=0
-for file in "$GSD_DIR"/RESEARCH-*.md; do
+for file in "$HXSK_DIR"/RESEARCH-*.md; do
     if [[ -f "$file" ]]; then
         filename=$(basename "$file")
         if [[ "$DRY_RUN" == true ]]; then

--- a/.claude/hooks/pre-compact-save.sh
+++ b/.claude/hooks/pre-compact-save.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 # Hook: PreCompact — STATE.md 자동 백업
-# 컨텍스트 압축 전 GSD 상태 문서를 백업하여 컨텍스트 손실 방지
+# 컨텍스트 압축 전 HXSK 상태 문서를 백업하여 컨텍스트 손실 방지
 
 main() {
     set -uo pipefail
 
     PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-    GSD_DIR="$PROJECT_DIR/.hxsk"
-    STATE_FILE="$GSD_DIR/STATE.md"
-    JOURNAL_FILE="$GSD_DIR/JOURNAL.md"
-    PATTERNS_FILE="$GSD_DIR/PATTERNS.md"
-    CURRENT_FILE="$GSD_DIR/CURRENT.md"
+    HXSK_DIR="$PROJECT_DIR/.hxsk"
+    STATE_FILE="$HXSK_DIR/STATE.md"
+    JOURNAL_FILE="$HXSK_DIR/JOURNAL.md"
+    PATTERNS_FILE="$HXSK_DIR/PATTERNS.md"
+    CURRENT_FILE="$HXSK_DIR/CURRENT.md"
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 
     # Skip if .hxsk/ doesn't exist
-    if [ ! -d "$GSD_DIR" ]; then
+    if [ ! -d "$HXSK_DIR" ]; then
         exit 0
     fi
 
     # Clean old backup files (keep only latest)
-    rm -f "$GSD_DIR"/*.pre-compact.bak 2>/dev/null || true
+    rm -f "$HXSK_DIR"/*.pre-compact.bak 2>/dev/null || true
 
     # STATE.md 백업
     if [ -f "$STATE_FILE" ]; then

--- a/.claude/hooks/scaffold-hxsk.sh
+++ b/.claude/hooks/scaffold-hxsk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# scaffold-gsd.sh - Initialize GSD document structure in a project
+# scaffold-hxsk.sh - Initialize HXSK document structure in a project
 # 템플릿에서 working docs를 복사하여 초기화. 이미 존재하는 파일은 건너뜀.
 #
 set -euo pipefail
@@ -9,7 +9,7 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 TARGET="$PROJECT_DIR/.hxsk"
 TEMPLATES_SRC="$TARGET/templates"
 
-echo "Scaffolding GSD documents..."
+echo "Scaffolding HXSK documents..."
 echo "  Target: ${TARGET}"
 echo ""
 
@@ -127,7 +127,7 @@ elif [ -f "$TARGET/CHANGELOG.md" ]; then
 fi
 
 echo ""
-echo "GSD scaffolding complete! (created: $CREATED, skipped: $SKIPPED)"
+echo "HXSK scaffolding complete! (created: $CREATED, skipped: $SKIPPED)"
 echo "  Working docs: .hxsk/{SPEC,DECISIONS,JOURNAL,ROADMAP,PATTERNS,STATE,TODO,STACK,CHANGELOG}.md"
 echo "  Config:       .hxsk/context-config.yaml"
 echo "  Templates:    .hxsk/templates/"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Hook: SessionStart — GSD 상태 자동 로드
+# Hook: SessionStart — HXSK 상태 자동 로드
 # 세션 시작 시 .hxsk/STATE.md와 git status를 additionalContext로 주입
 
 main() {
     set -uo pipefail
 
     PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-    GSD_DIR="$PROJECT_DIR/.hxsk"
+    HXSK_DIR="$PROJECT_DIR/.hxsk"
     HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
     CONTEXT_PARTS=()
 
@@ -14,7 +14,7 @@ main() {
     source "$HOOK_DIR/_json_parse.sh"
 
     # 1. PATTERNS.md 로드 (핵심 패턴, 2KB 제한)
-    PATTERNS_FILE="$GSD_DIR/PATTERNS.md"
+    PATTERNS_FILE="$HXSK_DIR/PATTERNS.md"
     if [ -f "$PATTERNS_FILE" ]; then
         PATTERNS_CONTENT=$(head -60 "$PATTERNS_FILE" 2>/dev/null || true)
         if [ -n "$PATTERNS_CONTENT" ]; then
@@ -24,7 +24,7 @@ main() {
     fi
 
     # 2. CURRENT.md 로드 (현재 세션 컨텍스트)
-    CURRENT_FILE="$GSD_DIR/CURRENT.md"
+    CURRENT_FILE="$HXSK_DIR/CURRENT.md"
     if [ -f "$CURRENT_FILE" ]; then
         CURRENT_CONTENT=$(cat "$CURRENT_FILE" 2>/dev/null || true)
         if [ -n "$CURRENT_CONTENT" ] && ! grep -q "^<!-- Current task ID" "$CURRENT_FILE"; then
@@ -35,12 +35,12 @@ main() {
     fi
 
     # 3. STATE.md 로드 (상위 80줄)
-    STATE_FILE="$GSD_DIR/STATE.md"
+    STATE_FILE="$HXSK_DIR/STATE.md"
     if [ -f "$STATE_FILE" ]; then
         STATE_CONTENT=$(head -80 "$STATE_FILE" 2>/dev/null || true)
         if [ -n "$STATE_CONTENT" ]; then
             CONTEXT_PARTS+=("")
-            CONTEXT_PARTS+=("## GSD State (from .hxsk/STATE.md)")
+            CONTEXT_PARTS+=("## HXSK State (from .hxsk/STATE.md)")
             CONTEXT_PARTS+=("$STATE_CONTENT")
         fi
     fi

--- a/.claude/skills/clean/SKILL.md
+++ b/.claude/skills/clean/SKILL.md
@@ -11,7 +11,7 @@ description: Runs shell script quality checks (shellcheck, shfmt) across the cod
 
 ---
 
-# GSD Clean Skill
+# HXSK Clean Skill
 
 <role>
 You fix all shell script linting and formatting issues in the codebase.
@@ -87,7 +87,7 @@ go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 ---
 
-## GSD Integration
+## HXSK Integration
 
 - **Pre-execute**: Run `/clean` before `/execute` to ensure clean baseline
 - **Pre-commit**: Clean checks can be run before committing shell scripts

--- a/.claude/skills/codebase-mapper/SKILL.md
+++ b/.claude/skills/codebase-mapper/SKILL.md
@@ -12,10 +12,10 @@ description: Analyzes existing codebases to understand structure, patterns, and 
 
 ---
 
-# GSD Codebase Mapper Agent
+# HXSK Codebase Mapper Agent
 
 <role>
-You are a GSD codebase mapper. You analyze existing codebases to produce documentation that enables informed planning.
+You are a HXSK codebase mapper. You analyze existing codebases to produce documentation that enables informed planning.
 
 **Core responsibilities:**
 - Scan and understand project structure

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: commit
-description: Analyzes diffs, splits logical changes, creates conventional emoji commits aligned with GSD atomic commit protocol
+description: Analyzes diffs, splits logical changes, creates conventional emoji commits aligned with HXSK atomic commit protocol
 ---
 
 ## Quick Reference
 - **Pre-commit**: `shellcheck *.sh` (선택적), `git diff --stat` 확인
 - **Commit format**: `<emoji> <type>(<scope>): <description>`
 - **Types**: feat, fix, docs, style, refactor, perf, test, chore, ci
-- **GSD scope**: `(phase-N.M)` 형식 — 예: `feat(phase-1.2): add login endpoint`
+- **HXSK scope**: `(phase-N.M)` 형식 — 예: `feat(phase-1.2): add login endpoint`
 - **Split signals**: 다른 모듈, 혼합 유형(feature+config), 독립 버그 수정
 
 ---
 
-# GSD Commit Skill
+# HXSK Commit Skill
 
 <role>
 You create well-structured git commits following conventional commit format with emoji.
 You analyze diffs to detect multiple logical changes and suggest splitting into separate commits.
 
-This skill is the shipping mechanism for GSD executor's atomic commit requirement.
+This skill is the shipping mechanism for HXSK executor's atomic commit requirement.
 </role>
 
 ---
@@ -108,9 +108,9 @@ EOF
 | `chore` | Tooling, config, dependencies |
 | `ci` | CI/CD changes |
 
-### GSD-Specific Scopes
+### HXSK-Specific Scopes
 
-When executing GSD plans, use phase-plan scope:
+When executing HXSK plans, use phase-plan scope:
 
 ```
 feat(phase-1.2): implement login endpoint with JWT

--- a/.claude/skills/context-health-monitor/SKILL.md
+++ b/.claude/skills/context-health-monitor/SKILL.md
@@ -239,7 +239,7 @@ wc -c .hxsk/PATTERNS.md  # Should be < 2048
 This skill integrates with:
 - `/compact` — Proactive context compaction (Rule 4)
 - `/handoff` — Lightweight session transfer when context is beyond recovery
-- `/pause` — Full GSD session handoff with state archival
+- `/pause` — Full HXSK session handoff with state archival
 - `/resume` — Loads the state dump context
 - `PATTERNS.md` — Pattern extraction on session end
 - `.gemini/GEMINI.md` Rule 3 (Context Hygiene) — After 3 failed debug attempts: STOP, summarize to STATE.md, document blocker in DECISIONS.md, recommend fresh session

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -6,17 +6,17 @@ description: Analyzes changes, creates branch, splits commits logically, pushes 
 ## Quick Reference
 - **Branch naming**: `feat/<desc>`, `fix/<desc>`, `refactor/<desc>`, `docs/<desc>`
 - **PR 생성**: `gh pr create --title "..." --body "..."`
-- **PR Body**: Summary + Changes + Test Plan + GSD Context 섹션
+- **PR Body**: Summary + Changes + Test Plan + HXSK Context 섹션
 - **Push**: `git push -u origin $(git branch --show-current)`
 - **Output**: `PR_CREATED: #N`, `URL: <url>`, `BRANCH: <name>`, `COMMITS: N`
 
 ---
 
-# GSD Create PR Skill
+# HXSK Create PR Skill
 
 <role>
 You create pull requests by analyzing changes, organizing commits logically, and submitting via GitHub CLI.
-This is the shipping step of the GSD workflow — moving completed work from local to remote.
+This is the shipping step of the HXSK workflow — moving completed work from local to remote.
 </role>
 
 ---
@@ -49,7 +49,7 @@ git checkout -b feat/add-user-auth
 - `docs/<description>` — Documentation
 - `chore/<description>` — Maintenance
 
-For GSD phases:
+For HXSK phases:
 - `phase-1/implement-auth` — Phase-scoped work
 
 ### Step 3: Stage and Commit
@@ -80,7 +80,7 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 - [ ] Manual verification completed
 - [ ] <specific manual verification steps>
 
-## GSD Context
+## HXSK Context
 - Phase: <N>
 - Plans: <list of completed plans>
 - SPEC reference: `.hxsk/SPEC.md`
@@ -108,16 +108,16 @@ Keep under 70 characters.
 - **Summary**: What changed and why (not how — the diff shows how)
 - **Changes**: Key files/modules affected
 - **Test Plan**: How to verify the changes work
-- **GSD Context**: Phase/plan reference for traceability
+- **HXSK Context**: Phase/plan reference for traceability
 
 ---
 
 ## Multi-Phase PRs
 
-When a PR spans multiple GSD plans:
+When a PR spans multiple HXSK plans:
 
 ```markdown
-## GSD Context
+## HXSK Context
 - Phase 1, Plans 1-3: User authentication
   - Plan 1.1: Database schema + User model
   - Plan 1.2: Login/register endpoints

--- a/.claude/skills/debugger/SKILL.md
+++ b/.claude/skills/debugger/SKILL.md
@@ -18,10 +18,10 @@ allowed-tools:
 
 ---
 
-# GSD Debugger Agent
+# HXSK Debugger Agent
 
 <role>
-You are a GSD debugger. You systematically diagnose bugs using hypothesis testing, evidence gathering, and persistent state tracking.
+You are a HXSK debugger. You systematically diagnose bugs using hypothesis testing, evidence gathering, and persistent state tracking.
 
 Your job: Find the root cause, not just make symptoms disappear.
 </role>

--- a/.claude/skills/executor/SKILL.md
+++ b/.claude/skills/executor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executor
-description: Executes GSD plans with atomic commits, deviation handling, checkpoint protocols, and state management
+description: Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols, and state management
 allowed-tools:
   - Read
   - Write
@@ -19,10 +19,10 @@ allowed-tools:
 
 ---
 
-# GSD Executor Agent
+# HXSK Executor Agent
 
 <role>
-You are a GSD plan executor. You execute PLAN.md files atomically, creating per-task commits, handling deviations automatically, pausing at checkpoints, and producing SUMMARY.md files.
+You are a HXSK plan executor. You execute PLAN.md files atomically, creating per-task commits, handling deviations automatically, pausing at checkpoints, and producing SUMMARY.md files.
 
 You are spawned by `/execute` workflow.
 

--- a/.claude/skills/plan-checker/SKILL.md
+++ b/.claude/skills/plan-checker/SKILL.md
@@ -12,10 +12,10 @@ description: Validates plans before execution to catch issues early
 
 ---
 
-# GSD Plan Checker Agent
+# HXSK Plan Checker Agent
 
 <role>
-You are a GSD plan checker. You validate PLAN.md files before execution to catch issues that would cause execution failures or quality problems.
+You are a HXSK plan checker. You validate PLAN.md files before execution to catch issues that would cause execution failures or quality problems.
 
 Your job: Find problems BEFORE execution, not during.
 </role>

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -12,10 +12,10 @@ description: Creates executable phase plans with task breakdown, dependency anal
 
 ---
 
-# GSD Planner Agent
+# HXSK Planner Agent
 
 <role>
-You are a GSD planner. You create executable phase plans with task breakdown, dependency analysis, and goal-backward verification.
+You are a HXSK planner. You create executable phase plans with task breakdown, dependency analysis, and goal-backward verification.
 
 **Core responsibilities:**
 - Decompose phases into parallel-optimized plans with 2-3 tasks each

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -12,7 +12,7 @@ description: Multi-persona code review (Dev, QA, Security, Arch, DevOps, UX) wit
 
 ---
 
-# GSD PR Review Skill
+# HXSK PR Review Skill
 
 <role>
 You perform a structured code review from 6 expert perspectives.
@@ -168,7 +168,7 @@ Each persona reviews independently, producing findings with severity classificat
 
 ---
 
-## GSD Alignment
+## HXSK Alignment
 
 - **SPEC 검증**: 변경 사항이 `.hxsk/SPEC.md`의 must-haves를 충족하는지 확인
 - **DECISIONS 참조**: 아키텍처 변경이 `.hxsk/DECISIONS.md`에 기록된 ADR과 일치하는지 확인

--- a/.claude/skills/verifier/SKILL.md
+++ b/.claude/skills/verifier/SKILL.md
@@ -12,10 +12,10 @@ description: Validates implemented work against spec requirements with empirical
 
 ---
 
-# GSD Verifier Agent
+# HXSK Verifier Agent
 
 <role>
-You are a GSD verifier. You validate that implemented work achieves the stated phase goal through empirical evidence, not claims.
+You are a HXSK verifier. You validate that implemented work achieves the stated phase goal through empirical evidence, not claims.
 
 Your job: Verify must-haves, detect stubs, identify gaps, and produce VERIFICATION.md with structured findings.
 </role>

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,4 +1,4 @@
-# GSD Methodology for Gemini
+# HXSK Methodology for Gemini
 
 > 상세 규칙은 프로젝트 루트의 CLAUDE.md를 참조하세요.
 

--- a/.github/agents/agent.md
+++ b/.github/agents/agent.md
@@ -14,7 +14,7 @@ You are a **Senior Staff Engineer** specialized in this project's architecture.
 - Deep expertise in hybrid RAG architectures (Local + Global)
 - Committed to code quality, security, and documentation
 - Proactive about impact analysis before any code changes
-- Follows the GSD (Get Shit Done) methodology strictly
+- Follows the HXSK (Get Shit Done) methodology strictly
 
 **Communication Style**:
 - Concise and technical
@@ -31,14 +31,14 @@ You are a **Senior Staff Engineer** specialized in this project's architecture.
 | **Agent Orchestration** | LangChain v1.2+, LangGraph |
 | **Code Analysis** | 네이티브 Claude Code 도구(Grep, Glob, Read) + Python 스크립트 |
 | **Agent Memory** | 파일 기반 마크다운 (`.hxsk/memories/`) |
-| **Methodology** | Get Shit Done (GSD) |
+| **Methodology** | Get Shit Done (HXSK) |
 
 ### Key Directories
 | Directory | Purpose |
 |-----------|---------|
 | `.github/agents/` | This agent specification (6-Core) |
 | `.claude/skills/` | Modular skill definitions (SKILL.md) |
-| `.hxsk/` | GSD documents (SPEC, ROADMAP, STATE, DECISIONS, phases/) |
+| `.hxsk/` | HXSK documents (SPEC, ROADMAP, STATE, DECISIONS, phases/) |
 | `.hxsk/memories/` | File-based agent memory (14 type directories) |
 
 ---
@@ -78,7 +78,7 @@ bash scripts/bootstrap.sh
 make status
 ```
 
-### GSD Slash Commands (29 Total)
+### HXSK Slash Commands (29 Total)
 
 **Core Workflow**:
 | Command | Description |
@@ -119,7 +119,7 @@ make status
 | Command | Description |
 |---------|-------------|
 | `/progress` | Show current position and next steps |
-| `/pause` | State dump for clean session handoff (full GSD) |
+| `/pause` | State dump for clean session handoff (full HXSK) |
 | `/handoff` | Lightweight handoff → HANDOFF.md |
 | `/resume` | Restore context from previous session |
 | `/add-todo` | Quick capture to TODO.md |
@@ -129,9 +129,9 @@ make status
 **Utilities**:
 | Command | Description |
 |---------|-------------|
-| `/update` | Update GSD to latest from GitHub |
+| `/update` | Update HXSK to latest from GitHub |
 | `/web-search` | Search web for research needs |
-| `/whats-new` | Show GSD version changes |
+| `/whats-new` | Show HXSK version changes |
 
 ---
 
@@ -295,7 +295,7 @@ You MUST strictly adhere to these operational boundaries.
 
 ## 9. Workflows
 
-Follow GSD methodology for all tasks.
+Follow HXSK methodology for all tasks.
 
 ### Feature Development
 ```

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,4 +1,4 @@
-name: Release GSD Plugin
+name: Release HXSK Plugin
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
       # Source files (build outputs generated in CI)
       - '.claude/**'
       - '.agent/**'
-      - '.gsd/templates/**'
+      - '.hxsk/templates/**'
       - 'scripts/build-*.sh'
       - 'Makefile'
       - 'CLAUDE.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI 에이전트 기반 개발을 위한 경량 프로젝트 보일러플레이트. 네이티브 Claude Code 도구(Grep, Glob, Read)와 파일 기반 메모리 시스템(`.hxsk/memories/`)을 활용하며 GSD(Get Shit Done) 문서 기반 방법론을 결합.
+AI 에이전트 기반 개발을 위한 경량 프로젝트 보일러플레이트. 네이티브 Claude Code 도구(Grep, Glob, Read)와 파일 기반 메모리 시스템(`.hxsk/memories/`)을 활용하며 HXSK(Get Shit Done) 문서 기반 방법론을 결합.
 
 **외부 종속성 없음**: 순수 bash 스크립트 + 마크다운 파일 기반. Documentation is bilingual (Korean/English).
 
@@ -16,7 +16,7 @@ AI 에이전트 기반 개발을 위한 경량 프로젝트 보일러플레이�
   - `hooks/` — Event hooks and utility scripts
   - `settings.json` — Claude Code project settings
 - **.github/agents/** — GitHub Agent specification
-- **.hxsk/** — GSD documents and context management:
+- **.hxsk/** — HXSK documents and context management:
   - `SPEC.md`, `PLAN.md`, `DECISIONS.md`, `STATE.md` — Core working docs
   - `PATTERNS.md` — Distilled learnings for fresh sessions (2KB limit)
   - `memories/` — File-based agent memory (14 type directories)
@@ -53,7 +53,7 @@ make patch-clean              # Patch workspace 삭제
 - **코드 분석**: 네이티브 Claude Code 도구(Grep, Glob, Read)
 - **에이전트 메모리**: `.hxsk/memories/{type}/` 마크다운 파일 기반. 14개 타입 디렉토리 + `_schema/` 스키마 디렉토리
 - **메모리 도구**: `scripts/md-store-memory.sh` (저장, A-Mem 확장), `scripts/md-recall-memory.sh` (검색, 2-hop)
-- **GSD Workflow**: SPEC.md → PLAN.md → EXECUTE → VERIFY. Working docs in `.hxsk/`
+- **HXSK Workflow**: SPEC.md → PLAN.md → EXECUTE → VERIFY. Working docs in `.hxsk/`
 
 ## Memory Protocol
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ SPEC → PLAN → EXECUTE → VERIFY
 │   ├── skills/                # 스킬 정의 (16)
 │   ├── hooks/                 # 훅 스크립트 (14 이벤트)
 │   └── settings.json          # 훅 설정
-├── .hxsk/                      # GSD 작업 문서
+├── .hxsk/                      # HXSK 작업 문서
 │   ├── STATE.md               # 현재 작업 상태 (git 추적)
 │   ├── PATTERNS.md            # 핵심 패턴/학습 (2KB, git 추적)
 │   ├── SPEC.md                # 프로젝트 명세
@@ -84,7 +84,7 @@ SPEC → PLAN → EXECUTE → VERIFY
 │   └── workflows/             # CI/CD (release-please)
 ├── docs/                      # 상세 문서
 ├── scripts/                   # 빌드 및 유틸리티 스크립트
-│   ├── build-plugin.sh        # GSD 플러그인 빌드
+│   ├── build-plugin.sh        # HXSK 플러그인 빌드
 │   ├── build-antigravity.sh   # Antigravity 워크스페이스 빌드
 │   ├── build-opencode.sh      # OpenCode 워크스페이스 빌드
 │   └── bootstrap.sh           # 프로젝트 부트스트랩
@@ -102,7 +102,7 @@ SPEC → PLAN → EXECUTE → VERIFY
 git clone https://github.com/SukbeomH/HExoskeleton.git
 cd HExoskeleton
 
-# GSD 문서 초기화
+# HXSK 문서 초기화
 make setup
 ```
 
@@ -283,13 +283,13 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 |----------|------|
 | `md-store-memory.sh` | 파일 기반 메모리 저장 |
 | `md-recall-memory.sh` | 파일 기반 메모리 검색 |
-| `scaffold-gsd.sh` | GSD 문서 초기화 |
+| `scaffold-hxsk.sh` | HXSK 문서 초기화 |
 | `compact-context.sh` | 컨텍스트 압축 |
 | `organize-docs.sh` | 문서 정리/아카이브 |
 
 ---
 
-## GSD 워크플로우
+## HXSK 워크플로우
 
 ### 핵심 사이클
 
@@ -343,7 +343,7 @@ make help                   # 전체 명령어 목록
 
 | 명령어 | 설명 |
 |--------|------|
-| `make setup` | GSD 문서 초기화 |
+| `make setup` | HXSK 문서 초기화 |
 | `make status` | 환경 상태 확인 |
 | `make build` | 3개 빌드 아티팩트 생성 |
 | `make build-plugin` | Claude Code 플러그인 빌드 |
@@ -417,7 +417,7 @@ make help                   # 전체 명령어 목록
 
 | 패턴 | 논문 | 본 시스템 적용 |
 |------|------|---------------|
-| 계획-실행 분리 | ReWOO (5x 효율) | GSD: `SPEC.md` → `PLAN.md` → `EXECUTE` 분리 |
+| 계획-실행 분리 | ReWOO (5x 효율) | HXSK: `SPEC.md` → `PLAN.md` → `EXECUTE` 분리 |
 | 적응적 탐색 깊이 | System-1.x | planner의 Discovery Level (0-3) |
 | 가설 가지치기 | Tree of Thoughts | `debug-eliminated` 메모리 타입 |
 | 도구 문서 압축 | EASYTOOL | 스킬 2단계 로딩 (요약 → 상세) |

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -35,7 +35,7 @@ hxsk-plugin/
 │   └── hooks.json           # 훅 설정 (경로 변환됨)
 ├── scripts/                  # 훅 스크립트
 ├── .mcp.json                # MCP 설정 (선택적 - 순수 bash 모드 지원)
-├── templates/gsd/           # GSD 템플릿 + 예제
+├── templates/hxsk/           # HXSK 템플릿 + 예제
 ├── references/              # 인프라 레퍼런스 파일
 └── README.md
 ```
@@ -54,7 +54,7 @@ hxsk-plugin/
    - 순수 bash 모드에서는 `[SKIP]` 메시지 출력
 7. **템플릿 복사**: `.hxsk/templates/`, `.hxsk/examples/`
 8. **레퍼런스 복사**: `pyproject.toml`, `Makefile`, `.gitignore` 등
-9. **스캐폴딩 스크립트 생성**: `scaffold-gsd.sh`, `scaffold-infra.sh`, `README.md`
+9. **스캐폴딩 스크립트 생성**: `scaffold-hxsk.sh`, `scaffold-infra.sh`, `README.md`
 10. **검증**: 구조, 카운트, 경로 변환, 권한, JSON 유효성
 
 ### 플러그인 사용
@@ -112,10 +112,10 @@ antigravity-boilerplate/
 │   └── rules/               # 패시브 규칙 (항상 적용)
 │       ├── code-style.md    # Python/코드 스타일 규칙
 │       ├── safety.md        # 안전 규칙 (금지/필수 사항)
-│       └── gsd-workflow.md  # GSD 워크플로우 규칙
-├── templates/gsd/           # GSD 템플릿 + 예제
+│       └── hxsk-workflow.md  # HXSK 워크플로우 규칙
+├── templates/hxsk/           # HXSK 템플릿 + 예제
 ├── scripts/
-│   ├── scaffold-gsd.sh      # GSD 문서 초기화
+│   ├── scaffold-hxsk.sh      # HXSK 문서 초기화
 │   ├── bash-guard.py        # Bash 명령 가드
 │   └── file-protect.py      # 파일 보호
 ├── mcp-settings.json        # MCP 서버 설정 (선택적)
@@ -135,10 +135,10 @@ antigravity-boilerplate/
    - `CLAUDE.md`에서 규칙 추출
    - `code-style.md`: Python 표준, 패키지 관리, 코드 품질
    - `safety.md`: 금지 사항, 필수 사항, 터미널 안전
-   - `gsd-workflow.md`: 검증 철학, GSD 사이클, MCP 우선순위
+   - `hxsk-workflow.md`: 검증 철학, HXSK 사이클, MCP 우선순위
 5. **MCP 변환**: `.mcp.json` → `mcp-settings.json` (Antigravity 표준)
 6. **템플릿 복사**: `.hxsk/templates/`, `.hxsk/examples/`
-7. **유틸리티 스크립트**: `scaffold-gsd.sh`, Python 훅
+7. **유틸리티 스크립트**: `scaffold-hxsk.sh`, Python 훅
 8. **검증**: 구조, 스킬 description, JSON 유효성
 
 ### Antigravity 주요 개념
@@ -186,10 +186,10 @@ cp -r antigravity-boilerplate/.agent /path/to/project/
 cp antigravity-boilerplate/mcp-settings.json /path/to/project/
 ```
 
-**방법 3: GSD 문서 초기화**
+**방법 3: HXSK 문서 초기화**
 ```bash
 cd /path/to/project
-zsh antigravity-boilerplate/scripts/scaffold-gsd.sh
+zsh antigravity-boilerplate/scripts/scaffold-hxsk.sh
 ```
 
 ---
@@ -214,9 +214,9 @@ opencode-boilerplate/
 │   ├── commands/            # 워크플로우 명령어
 │   ├── plugins/             # TypeScript 플러그인 (빈 디렉토리)
 │   └── skill/               # 16개 스킬
-├── templates/gsd/           # GSD 템플릿 + 예제
+├── templates/hxsk/           # HXSK 템플릿 + 예제
 ├── scripts/
-│   ├── scaffold-gsd.sh      # GSD 문서 초기화
+│   ├── scaffold-hxsk.sh      # HXSK 문서 초기화
 │   └── *.py                 # 유틸리티 스크립트
 ├── opencode.json            # 메인 설정 (에이전트별 모델 매핑)
 ├── AGENTS.md                # 프로젝트 규칙 (CLAUDE.md에서 복사)
@@ -238,7 +238,7 @@ opencode-boilerplate/
 6. **MCP 변환**: `.mcp.json` → `.mcp.json`
 7. **AGENTS.md 생성**: `CLAUDE.md`에서 복사
 8. **템플릿 복사**: `.hxsk/templates/`, `.hxsk/examples/`
-9. **유틸리티 스크립트**: `scaffold-gsd.sh`
+9. **유틸리티 스크립트**: `scaffold-hxsk.sh`
 10. **검증**: 구조, 모델 설정, JSON 유효성
 
 ### 모델 매핑
@@ -286,8 +286,8 @@ cp opencode-boilerplate/opencode.json /path/to/project/
 cp opencode-boilerplate/AGENTS.md /path/to/project/
 cp opencode-boilerplate/.mcp.json /path/to/project/
 
-# GSD 문서 초기화
-bash opencode-boilerplate/scripts/scaffold-gsd.sh
+# HXSK 문서 초기화
+bash opencode-boilerplate/scripts/scaffold-hxsk.sh
 
 # OpenCode 실행
 cd /path/to/project && opencode
@@ -333,10 +333,10 @@ Phase 4a: 에이전트
 Phase 4b: 훅 설정 (hooks.json 경로 변환)
 Phase 4c: 훅 스크립트
 Phase 5a: MCP 설정 (선택적)
-Phase 5b: GSD 템플릿
+Phase 5b: HXSK 템플릿
 Phase 5c: 인프라 레퍼런스
 Phase 5d: 유틸리티 스크립트 (compact-context.sh, organize-docs.sh)
-Phase 6a: scaffold-gsd.sh 생성
+Phase 6a: scaffold-hxsk.sh 생성
 Phase 6b: scaffold-infra.sh 생성
 Phase 6c: README.md 생성
 Phase 7:  (설치 스크립트 불필요 — --plugin-dir 방식)
@@ -352,7 +352,7 @@ Phase 2: 스킬 마이그레이션 (description 검증)
 Phase 3: 워크플로우 (description 자동 추가)
 Phase 4: 규칙 생성 (CLAUDE.md → rules/*.md)
 Phase 5: MCP 설정
-Phase 6: GSD 템플릿
+Phase 6: HXSK 템플릿
 Phase 7: 유틸리티 스크립트
 Phase 8: README
 Phase 9: 검증

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -38,7 +38,7 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
 
 | 이벤트 | 스크립트 | 타입 | 기능 | 타임아웃 |
 |--------|----------|------|------|----------|
-| **SessionStart** | `session-start.sh` | command | GSD STATE.md 로드, git status 주입 | 10s |
+| **SessionStart** | `session-start.sh` | command | HXSK STATE.md 로드, git status 주입 | 10s |
 | **PreToolUse** (Edit/Write/Read) | `file-protect.py` | command | .env, 시크릿 파일 보호 | 5s |
 | **PreToolUse** (Bash) | `bash-guard.py` | command | 위험한 명령어 차단 | 5s |
 | **PostToolUse** (Edit/Write) | `auto-format.sh` | command | Python 파일 자동 포맷 (ruff) | 30s |
@@ -56,7 +56,7 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
 |----------|------|
 | `md-store-memory.sh` | 파일 기반 메모리 저장 |
 | `md-recall-memory.sh` | 파일 기반 메모리 검색 |
-| `scaffold-gsd.sh` | GSD 문서 초기화 |
+| `scaffold-hxsk.sh` | HXSK 문서 초기화 |
 | `compact-context.sh` | 컨텍스트 압축 |
 | `organize-docs.sh` | 문서 정리/아카이브 |
 | `scaffold-infra.sh` | 인프라 스캐폴딩 |
@@ -299,7 +299,7 @@ bash .claude/hooks/md-recall-memory.sh \
 ### 1. session-start.sh
 
 **이벤트**: SessionStart
-**역할**: 세션 시작 시 GSD 상태와 git status를 컨텍스트에 주입
+**역할**: 세션 시작 시 HXSK 상태와 git status를 컨텍스트에 주입
 
 ```bash
 #!/bin/bash
@@ -308,7 +308,7 @@ set -euo pipefail
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 STATE_FILE="$PROJECT_DIR/.hxsk/STATE.md"
 
-# 1. GSD STATE.md 로드 (상위 80줄)
+# 1. HXSK STATE.md 로드 (상위 80줄)
 if [ -f "$STATE_FILE" ]; then
     STATE_CONTENT=$(head -80 "$STATE_FILE" 2>/dev/null || true)
 fi

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -77,7 +77,7 @@ Claude Code의 **Skills**는 Claude가 작업 컨텍스트를 기반으로 **자
 ```yaml
 ---
 name: executor
-description: Executes GSD plans with atomic commits, deviation handling, checkpoint protocols, and state management
+description: Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols, and state management
 ---
 ```
 
@@ -321,7 +321,7 @@ description: Helps with planning
 
 ```markdown
 <role>
-You are a GSD executor. You execute PLAN.md files atomically, creating per-task commits, handling deviations automatically.
+You are a HXSK executor. You execute PLAN.md files atomically, creating per-task commits, handling deviations automatically.
 </role>
 ```
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,6 +1,6 @@
 # Workflows (Commands) 상세 문서
 
-Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 구조화된 작업 흐름입니다. GSD(Get Shit Done) 방법론의 핵심 인터페이스를 제공합니다.
+Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 구조화된 작업 흐름입니다. HXSK(Get Shit Done) 방법론의 핵심 인터페이스를 제공합니다.
 
 ---
 
@@ -54,7 +54,7 @@ Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 
 | 명령어 | 파일 | 역할 | 인자 |
 |--------|------|------|------|
 | `/progress` | `progress.md` | 현재 진행 상황 | - |
-| `/pause` | `pause.md` | 상태 저장 (full GSD) | - |
+| `/pause` | `pause.md` | 상태 저장 (full HXSK) | - |
 | `/handoff` | `handoff.md` | 경량 핸드오프 문서 | - |
 | `/resume` | `resume.md` | 마지막 세션 복원 | - |
 | `/add-todo` | `add-todo.md` | TODO 추가 | `<description>` |
@@ -66,7 +66,7 @@ Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 
 |--------|------|------|------|
 | `/help` | `help.md` | 도움말 | - |
 | `/quick-check` | `quick-check.md` | 빠른 상태 체크 | - |
-| `/update` | `update.md` | GSD 문서 업데이트 | - |
+| `/update` | `update.md` | HXSK 문서 업데이트 | - |
 | `/web-search` | `web-search.md` | 웹 검색 | `<query>` |
 | `/whats-new` | `whats-new.md` | 최근 변경사항 | - |
 | `/feature-dev` | `feature-dev.md` | 기능 개발 워크플로우 | `<description>` |
@@ -153,7 +153,7 @@ argument-hint: "[phase] [--research] [--skip-research] [--gaps]"
 **출력 예시**:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- GSD ► PHASE 1 PLANNED ✓
+ HXSK ► PHASE 1 PLANNED ✓
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 3 plans created across 2 waves
@@ -279,7 +279,7 @@ Phase Verification
 **출력 예시**:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- GSD ► PROGRESS
+ HXSK ► PROGRESS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Project: My App
@@ -306,11 +306,11 @@ Implementing user authentication
 
 ---
 
-## GSD 사이클
+## HXSK 사이클
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                     GSD Cycle                           │
+│                     HXSK Cycle                           │
 ├─────────────────────────────────────────────────────────┤
 │                                                         │
 │   /new-project                                          │
@@ -403,7 +403,7 @@ Extract from $ARGUMENTS:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- GSD ► {COMMAND} {STATUS}
+ HXSK ► {COMMAND} {STATUS}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 

--- a/scripts/build-antigravity.sh
+++ b/scripts/build-antigravity.sh
@@ -143,13 +143,13 @@ split_large_skill() {
 echo "[Phase 1] Creating directory structure..."
 rm -rf "$ANTIGRAVITY"
 mkdir -p "$ANTIGRAVITY"/.agent/{skills,workflows,rules}
-mkdir -p "$ANTIGRAVITY"/templates/gsd/{templates,examples}
+mkdir -p "$ANTIGRAVITY"/templates/hxsk/{templates,examples}
 mkdir -p "$ANTIGRAVITY"/scripts
 
 echo "  [+] .agent/skills/"
 echo "  [+] .agent/workflows/"
 echo "  [+] .agent/rules/"
-echo "  [+] templates/gsd/"
+echo "  [+] templates/hxsk/"
 echo "  [+] scripts/"
 
 # ================================================================
@@ -278,10 +278,10 @@ echo "  [+] agent-boundaries.md"
 } > "$ANTIGRAVITY/.agent/rules/validation.md"
 echo "  [+] validation.md"
 
-# Rule 3: gsd-workflow.md — from ## Architecture + GSD cycle summary
+# Rule 3: hxsk-workflow.md — from ## Architecture + HXSK cycle summary
 {
     echo "---"
-    echo 'description: "GSD workflow rules — architecture principles and execution cycle"'
+    echo 'description: "HXSK workflow rules — architecture principles and execution cycle"'
     echo "---"
     echo ""
     extract_section "$CLAUDE_MD" "Architecture" | transform_tool_refs | sed \
@@ -290,14 +290,14 @@ echo "  [+] validation.md"
         -e 's/네이티브 Claude Code/에이전트 내장/g' \
         -e 's/Claude Code/Antigravity IDE/g'
     echo ""
-    echo "## GSD Cycle"
+    echo "## HXSK Cycle"
     echo ""
     echo "1. **SPEC.md** (Planning Lock) — Project specification"
     echo "2. **PLAN.md** — Implementation plans with atomic tasks"
     echo "3. **EXECUTE** — Execute with atomic commits"
     echo "4. **VERIFY** — Verify with empirical evidence"
-} > "$ANTIGRAVITY/.agent/rules/gsd-workflow.md"
-echo "  [+] gsd-workflow.md"
+} > "$ANTIGRAVITY/.agent/rules/hxsk-workflow.md"
+echo "  [+] hxsk-workflow.md"
 
 # Rule 4: memory-protocol.md — from ## Memory Protocol
 {
@@ -350,7 +350,7 @@ GEMINIHEADER
   - `skills/` — Modular skill definitions (16 skills, SKILL.md format)
   - `workflows/` — Workflow commands (triggered via `/` commands)
   - `rules/` — Always-on passive rules (4 rule files)
-- **.hxsk/** — GSD documents and context management:
+- **.hxsk/** — HXSK documents and context management:
   - `SPEC.md`, `PLAN.md`, `DECISIONS.md`, `STATE.md` — Core working docs
   - `PATTERNS.md` — Distilled learnings for fresh sessions (2KB limit)
   - `memories/` — File-based agent memory (14 type directories)
@@ -398,19 +398,19 @@ for script in md-recall-memory.sh md-store-memory.sh _json_parse.sh; do
     fi
 done
 
-# scaffold-gsd.sh — inline generation (same as before)
-cat > "$ANTIGRAVITY/scripts/scaffold-gsd.sh" << 'SCAFFOLDEOF'
+# scaffold-hxsk.sh — inline generation (same as before)
+cat > "$ANTIGRAVITY/scripts/scaffold-hxsk.sh" << 'SCAFFOLDEOF'
 #!/usr/bin/env bash
 #
-# scaffold-gsd.sh - Initialize GSD document structure
+# scaffold-hxsk.sh - Initialize HXSK document structure
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATE_DIR="${SCRIPT_DIR}/../templates/gsd"
+TEMPLATE_DIR="${SCRIPT_DIR}/../templates/hxsk"
 TARGET="${1:-.hxsk}"
 
-echo "Scaffolding GSD documents to ${TARGET}..."
+echo "Scaffolding HXSK documents to ${TARGET}..."
 
 mkdir -p "$TARGET"/{templates,examples,archive,reports,research,memories}
 
@@ -457,34 +457,34 @@ for f in "$TEMPLATE_DIR"/examples/*.md; do
 done
 
 echo ""
-echo "GSD scaffolding complete!"
+echo "HXSK scaffolding complete!"
 SCAFFOLDEOF
-chmod +x "$ANTIGRAVITY/scripts/scaffold-gsd.sh"
-echo "  [+] scaffold-gsd.sh (generated)"
+chmod +x "$ANTIGRAVITY/scripts/scaffold-hxsk.sh"
+echo "  [+] scaffold-hxsk.sh (generated)"
 SCRIPT_COUNT=$((SCRIPT_COUNT + 1))
 echo "  [=] Total scripts: ${SCRIPT_COUNT}"
 
 # ================================================================
-# Phase 7: GSD Templates
+# Phase 7: HXSK Templates
 # ================================================================
 echo ""
-echo "[Phase 7] Copying GSD templates..."
+echo "[Phase 7] Copying HXSK templates..."
 
 # Templates
-cp "$BOILERPLATE"/.hxsk/templates/*.md "$ANTIGRAVITY/templates/gsd/templates/" 2>/dev/null || true
-cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$ANTIGRAVITY/templates/gsd/templates/" 2>/dev/null || true
-TEMPLATES_COUNT=$(find "$ANTIGRAVITY/templates/gsd/templates" -type f 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/templates/*.md "$ANTIGRAVITY/templates/hxsk/templates/" 2>/dev/null || true
+cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$ANTIGRAVITY/templates/hxsk/templates/" 2>/dev/null || true
+TEMPLATES_COUNT=$(find "$ANTIGRAVITY/templates/hxsk/templates" -type f 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] ${TEMPLATES_COUNT} templates"
 
 # Examples
-cp "$BOILERPLATE"/.hxsk/examples/*.md "$ANTIGRAVITY/templates/gsd/examples/" 2>/dev/null || true
-EXAMPLES_COUNT=$(find "$ANTIGRAVITY/templates/gsd/examples" -type f 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/examples/*.md "$ANTIGRAVITY/templates/hxsk/examples/" 2>/dev/null || true
+EXAMPLES_COUNT=$(find "$ANTIGRAVITY/templates/hxsk/examples" -type f 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] ${EXAMPLES_COUNT} examples"
 
 # Working document shells
 for doc in SPEC DECISIONS JOURNAL ROADMAP PATTERNS STATE TODO STACK CHANGELOG; do
     doc_lower=$(echo "$doc" | tr '[:upper:]' '[:lower:]')
-    cat > "$ANTIGRAVITY/templates/gsd/${doc}.md" << EOF
+    cat > "$ANTIGRAVITY/templates/hxsk/${doc}.md" << EOF
 # ${doc}
 
 <!-- Initialize with /init workflow -->
@@ -513,9 +513,9 @@ AI agent development boilerplate for **Google Antigravity IDE**.
    antigravity .
    ```
 
-2. **Initialize GSD Documents**
+2. **Initialize HXSK Documents**
    ```bash
-   bash scripts/scaffold-gsd.sh
+   bash scripts/scaffold-hxsk.sh
    ```
 
 ## Directory Structure
@@ -533,10 +533,10 @@ AI agent development boilerplate for **Google Antigravity IDE**.
 └── rules/           # 4 always-on passive rules
     ├── agent-boundaries.md
     ├── validation.md
-    ├── gsd-workflow.md
+    ├── hxsk-workflow.md
     └── memory-protocol.md
 
-templates/gsd/       # GSD document templates
+templates/hxsk/       # HXSK document templates
 scripts/             # Utility scripts (memory system)
 GEMINI.md            # Project instructions for Antigravity agents
 ```
@@ -597,10 +597,10 @@ Rules in `.agent/rules/*.md` are always-on passive guidelines.
 |------|---------|
 | `agent-boundaries.md` | Always/Ask First/Never behavioral rules |
 | `validation.md` | Empirical evidence requirements |
-| `gsd-workflow.md` | Architecture + GSD cycle |
+| `hxsk-workflow.md` | Architecture + HXSK cycle |
 | `memory-protocol.md` | Memory search/store protocol |
 
-## GSD Methodology
+## HXSK Methodology
 
 Get Shit Done workflow:
 
@@ -790,7 +790,7 @@ if [ $errors -eq 0 ]; then
     echo ""
     echo "To use:"
     echo "  1. Open $ANTIGRAVITY in Antigravity IDE"
-    echo "  2. Run: bash scripts/scaffold-gsd.sh"
+    echo "  2. Run: bash scripts/scaffold-hxsk.sh"
     echo ""
     echo "Or copy to an existing project:"
     echo "  cp -r $ANTIGRAVITY/.agent /path/to/project/"

--- a/scripts/build-antigravity.sh
+++ b/scripts/build-antigravity.sh
@@ -284,7 +284,11 @@ echo "  [+] validation.md"
     echo 'description: "GSD workflow rules — architecture principles and execution cycle"'
     echo "---"
     echo ""
-    extract_section "$CLAUDE_MD" "Architecture" | transform_tool_refs
+    extract_section "$CLAUDE_MD" "Architecture" | transform_tool_refs | sed \
+        -e 's/네이티브 Claude Code 도구(Grep, Glob, Read)/에이전트 내장 검색 도구(search, find_files, read_file)/g' \
+        -e 's/네이티브 Claude Code 도구만/에이전트 내장 도구만/g' \
+        -e 's/네이티브 Claude Code/에이전트 내장/g' \
+        -e 's/Claude Code/Antigravity IDE/g'
     echo ""
     echo "## GSD Cycle"
     echo ""

--- a/scripts/build-opencode.sh
+++ b/scripts/build-opencode.sh
@@ -18,14 +18,14 @@ echo ""
 echo "[Phase 1] Creating directory structure..."
 rm -rf "$OPENCODE"
 mkdir -p "$OPENCODE"/.opencode/{agents,plugins,commands,skill}
-mkdir -p "$OPENCODE"/templates/gsd/{templates,examples}
+mkdir -p "$OPENCODE"/templates/hxsk/{templates,examples}
 mkdir -p "$OPENCODE"/scripts
 
 echo "  [+] .opencode/agents/"
 echo "  [+] .opencode/plugins/"
 echo "  [+] .opencode/commands/"
 echo "  [+] .opencode/skill/"
-echo "  [+] templates/gsd/"
+echo "  [+] templates/hxsk/"
 echo "  [+] scripts/"
 
 # --- Phase 2: Agents Migration (with model field) ---
@@ -318,25 +318,25 @@ AGENTSEOF
     echo "  [+] AGENTS.md created (default template)"
 fi
 
-# --- Phase 8: GSD Templates ---
+# --- Phase 8: HXSK Templates ---
 echo ""
-echo "[Phase 8] Copying GSD templates..."
+echo "[Phase 8] Copying HXSK templates..."
 
 # Templates
-cp "$BOILERPLATE"/.hxsk/templates/*.md "$OPENCODE/templates/gsd/templates/" 2>/dev/null || true
-cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$OPENCODE/templates/gsd/templates/" 2>/dev/null || true
-TEMPLATES_COUNT=$(find "$OPENCODE/templates/gsd/templates" -type f 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/templates/*.md "$OPENCODE/templates/hxsk/templates/" 2>/dev/null || true
+cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$OPENCODE/templates/hxsk/templates/" 2>/dev/null || true
+TEMPLATES_COUNT=$(find "$OPENCODE/templates/hxsk/templates" -type f 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] ${TEMPLATES_COUNT} templates"
 
 # Examples
-cp "$BOILERPLATE"/.hxsk/examples/*.md "$OPENCODE/templates/gsd/examples/" 2>/dev/null || true
-EXAMPLES_COUNT=$(find "$OPENCODE/templates/gsd/examples" -type f 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/examples/*.md "$OPENCODE/templates/hxsk/examples/" 2>/dev/null || true
+EXAMPLES_COUNT=$(find "$OPENCODE/templates/hxsk/examples" -type f 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] ${EXAMPLES_COUNT} examples"
 
 # Working document shells
 for doc in SPEC DECISIONS JOURNAL ROADMAP PATTERNS STATE TODO STACK CHANGELOG; do
     doc_lower=$(echo "$doc" | tr '[:upper:]' '[:lower:]')
-    cat > "$OPENCODE/templates/gsd/${doc}.md" << EOF
+    cat > "$OPENCODE/templates/hxsk/${doc}.md" << EOF
 # ${doc}
 
 <!-- Initialize with /init command -->
@@ -349,19 +349,19 @@ echo "  [+] 9 working document shells"
 echo ""
 echo "[Phase 9] Creating utility scripts..."
 
-# scaffold-gsd.sh
-cat > "$OPENCODE/scripts/scaffold-gsd.sh" << 'SCAFFOLDEOF'
+# scaffold-hxsk.sh
+cat > "$OPENCODE/scripts/scaffold-hxsk.sh" << 'SCAFFOLDEOF'
 #!/usr/bin/env bash
 #
-# scaffold-gsd.sh - Initialize GSD document structure
+# scaffold-hxsk.sh - Initialize HXSK document structure
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TEMPLATE_DIR="${SCRIPT_DIR}/../templates/gsd"
+TEMPLATE_DIR="${SCRIPT_DIR}/../templates/hxsk"
 TARGET="${1:-.hxsk}"
 
-echo "Scaffolding GSD documents to ${TARGET}..."
+echo "Scaffolding HXSK documents to ${TARGET}..."
 
 mkdir -p "$TARGET"/{templates,examples,archive,reports,research}
 
@@ -408,10 +408,10 @@ for f in "$TEMPLATE_DIR"/examples/*.md; do
 done
 
 echo ""
-echo "GSD scaffolding complete!"
+echo "HXSK scaffolding complete!"
 SCAFFOLDEOF
-chmod +x "$OPENCODE/scripts/scaffold-gsd.sh"
-echo "  [+] scaffold-gsd.sh"
+chmod +x "$OPENCODE/scripts/scaffold-hxsk.sh"
+echo "  [+] scaffold-hxsk.sh"
 
 # Copy ALL hook scripts (Python and Shell)
 echo "  Copying hook scripts..."
@@ -505,9 +505,9 @@ AI agent development boilerplate for **OpenCode**.
    cp opencode-boilerplate/AGENTS.md /path/to/project/
    ```
 
-2. **Initialize GSD Documents**
+2. **Initialize HXSK Documents**
    ```bash
-   bash scripts/scaffold-gsd.sh
+   bash scripts/scaffold-hxsk.sh
    ```
 
 3. **Start OpenCode**

--- a/scripts/build-opencode.sh
+++ b/scripts/build-opencode.sh
@@ -452,7 +452,7 @@ fi
 
 # Ensure package.json exists
 cat > "$OPENCODE/.opencode/package.json" << 'PKGEOF'
-{"name":"opencode-plugins","type":"module","dependencies":{"@opencode-ai/plugin":"latest"}}
+{"name":"opencode-plugins","type":"module","dependencies":{"@opencode-ai/plugin":"^1.2.10"}}
 PKGEOF
 
 # Create migration guide

--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -18,7 +18,7 @@ echo ""
 echo "[Phase 1] Creating directory structure..."
 rm -rf "$PLUGIN"
 mkdir -p "$PLUGIN"/{.claude-plugin,commands,skills,agents,hooks,scripts}
-mkdir -p "$PLUGIN"/templates/gsd/{templates,examples}
+mkdir -p "$PLUGIN"/templates/hxsk/{templates,examples}
 mkdir -p "$PLUGIN"/references/issue-templates
 
 # Get version from release-please manifest or default to 1.0.0
@@ -48,7 +48,7 @@ if [ -d "$BOILERPLATE/.agent/workflows" ]; then
     echo "  [+] Copied ${COMMANDS_COUNT} workflow commands"
 else
     echo "  [SKIP] .agent/workflows/ not found — generating from skills"
-    # Generate command stubs from skills (each skill becomes a /gsd:command)
+    # Generate command stubs from skills (each skill becomes a /hxsk:command)
     for skill_dir in "$BOILERPLATE"/.claude/skills/*/; do
         skill_name=$(basename "$skill_dir")
         skill_file="$skill_dir/SKILL.md"
@@ -98,18 +98,18 @@ Initialize the HExoskeleton document system in the current project.
 
 ## What This Command Does
 
-1. **Scaffold GSD Documents**: Creates `.hxsk/` directory with working documents and templates
+1. **Scaffold HXSK Documents**: Creates `.hxsk/` directory with working documents and templates
 2. **Compare Infrastructure**: Shows diff between plugin references and project files
 3. **Interactive Setup**: If SPEC.md is empty, guides you through project information collection
 
 ## Execution Steps
 
-### Step 1: Scaffold GSD Directory
+### Step 1: Scaffold HXSK Directory
 
-Run the scaffolding script to create the GSD document structure:
+Run the scaffolding script to create the HXSK document structure:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-gsd.sh"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-hxsk.sh"
 ```
 
 This creates:
@@ -128,7 +128,7 @@ Run the infrastructure comparison script:
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-infra.sh"
 ```
 
-This compares your project files against GSD reference configurations:
+This compares your project files against HXSK reference configurations:
 - `pyproject.toml` - Python project config
 - `Makefile` - Build automation
 - `.gitignore` - Git ignore patterns
@@ -155,7 +155,7 @@ If `.hxsk/SPEC.md` is empty or contains only placeholder content:
 
 ## After Initialization
 
-Once initialized, you can use GSD commands:
+Once initialized, you can use HXSK commands:
 - `/hxsk:plan` - Create implementation plans
 - `/hxsk:execute` - Execute planned work
 - `/hxsk:verify` - Verify completed work
@@ -301,28 +301,28 @@ else
     echo "  [SKIP] .mcp.json not found (pure bash mode)"
 fi
 
-# --- Phase 5b: GSD Templates ---
+# --- Phase 5b: HXSK Templates ---
 echo ""
-echo "[Phase 5b] Copying GSD templates..."
+echo "[Phase 5b] Copying HXSK templates..."
 # Templates (md files)
-cp "$BOILERPLATE"/.hxsk/templates/*.md "$PLUGIN/templates/gsd/templates/"
-TEMPLATES_COUNT=$(ls "$PLUGIN/templates/gsd/templates/"*.md 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/templates/*.md "$PLUGIN/templates/hxsk/templates/"
+TEMPLATES_COUNT=$(ls "$PLUGIN/templates/hxsk/templates/"*.md 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] Copied ${TEMPLATES_COUNT} templates"
 
 # Templates (yaml files)
-cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$PLUGIN/templates/gsd/templates/" 2>/dev/null || true
-YAML_COUNT=$(ls "$PLUGIN/templates/gsd/templates/"*.yaml 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/templates/*.yaml "$PLUGIN/templates/hxsk/templates/" 2>/dev/null || true
+YAML_COUNT=$(ls "$PLUGIN/templates/hxsk/templates/"*.yaml 2>/dev/null | wc -l | tr -d ' ')
 [ "$YAML_COUNT" -gt 0 ] && echo "  [+] Copied ${YAML_COUNT} yaml configs"
 
 # Examples
-cp "$BOILERPLATE"/.hxsk/examples/*.md "$PLUGIN/templates/gsd/examples/"
-EXAMPLES_COUNT=$(ls "$PLUGIN/templates/gsd/examples/"*.md 2>/dev/null | wc -l | tr -d ' ')
+cp "$BOILERPLATE"/.hxsk/examples/*.md "$PLUGIN/templates/hxsk/examples/"
+EXAMPLES_COUNT=$(ls "$PLUGIN/templates/hxsk/examples/"*.md 2>/dev/null | wc -l | tr -d ' ')
 echo "  [+] Copied ${EXAMPLES_COUNT} examples"
 
 # Working document shells (complete set)
 for doc in SPEC DECISIONS JOURNAL ROADMAP PATTERNS STATE TODO STACK CHANGELOG; do
     # Create empty shell files for scaffolding
-    cat > "$PLUGIN/templates/gsd/${doc}.md" << EOF
+    cat > "$PLUGIN/templates/hxsk/${doc}.md" << EOF
 # ${doc}
 
 <!-- This file will be populated during /hxsk:init -->
@@ -367,13 +367,13 @@ for util in compact-context.sh organize-docs.sh; do
     fi
 done
 
-# --- Phase 6a: Scaffold GSD Script ---
+# --- Phase 6a: Scaffold HXSK Script ---
 echo ""
-echo "[Phase 6a] Creating scaffold-gsd.sh..."
-cat > "$PLUGIN/scripts/scaffold-gsd.sh" << 'SCAFFOLDEOF'
+echo "[Phase 6a] Creating scaffold-hxsk.sh..."
+cat > "$PLUGIN/scripts/scaffold-hxsk.sh" << 'SCAFFOLDEOF'
 #!/usr/bin/env bash
 #
-# scaffold-gsd.sh - Initialize GSD document structure in a project
+# scaffold-hxsk.sh - Initialize HXSK document structure in a project
 #
 set -euo pipefail
 
@@ -381,7 +381,7 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 TARGET="$PROJECT_DIR/.hxsk"
 
-echo "Scaffolding GSD documents..."
+echo "Scaffolding HXSK documents..."
 echo "  Plugin: ${PLUGIN_ROOT}"
 echo "  Target: ${TARGET}"
 echo ""
@@ -390,7 +390,7 @@ echo ""
 mkdir -p "$TARGET" "$TARGET/templates" "$TARGET/examples" "$TARGET/archive" "$TARGET/reports" "$TARGET/research"
 
 # Copy working documents (all shell files)
-for f in "$PLUGIN_ROOT"/templates/gsd/*.md; do
+for f in "$PLUGIN_ROOT"/templates/hxsk/*.md; do
     [ -f "$f" ] || continue
     dst="$TARGET/$(basename "$f")"
     if [ -f "$dst" ]; then
@@ -402,7 +402,7 @@ for f in "$PLUGIN_ROOT"/templates/gsd/*.md; do
 done
 
 # Copy yaml configs
-for f in "$PLUGIN_ROOT"/templates/gsd/templates/*.yaml; do
+for f in "$PLUGIN_ROOT"/templates/hxsk/templates/*.yaml; do
     [ -f "$f" ] || continue
     dst="$TARGET/$(basename "$f")"
     if [ -f "$dst" ]; then
@@ -414,7 +414,7 @@ for f in "$PLUGIN_ROOT"/templates/gsd/templates/*.yaml; do
 done
 
 # Copy templates
-for f in "$PLUGIN_ROOT"/templates/gsd/templates/*.md; do
+for f in "$PLUGIN_ROOT"/templates/hxsk/templates/*.md; do
     [ -f "$f" ] || continue
     dst="$TARGET/templates/$(basename "$f")"
     if [ -f "$dst" ]; then
@@ -426,7 +426,7 @@ for f in "$PLUGIN_ROOT"/templates/gsd/templates/*.md; do
 done
 
 # Copy examples
-for f in "$PLUGIN_ROOT"/templates/gsd/examples/*.md; do
+for f in "$PLUGIN_ROOT"/templates/hxsk/examples/*.md; do
     [ -f "$f" ] || continue
     dst="$TARGET/examples/$(basename "$f")"
     if [ -f "$dst" ]; then
@@ -438,15 +438,15 @@ for f in "$PLUGIN_ROOT"/templates/gsd/examples/*.md; do
 done
 
 echo ""
-echo "GSD scaffolding complete!"
+echo "HXSK scaffolding complete!"
 echo "  Working docs: .hxsk/{SPEC,DECISIONS,JOURNAL,ROADMAP,PATTERNS,STATE,TODO,STACK,CHANGELOG}.md"
 echo "  Config:       .hxsk/context-config.yaml"
 echo "  Templates:    .hxsk/templates/"
 echo "  Examples:     .hxsk/examples/"
 echo "  Directories:  .hxsk/{archive,reports,research}/"
 SCAFFOLDEOF
-chmod +x "$PLUGIN/scripts/scaffold-gsd.sh"
-echo "  [+] Created scaffold-gsd.sh"
+chmod +x "$PLUGIN/scripts/scaffold-hxsk.sh"
+echo "  [+] Created scaffold-hxsk.sh"
 
 # --- Phase 6b: Scaffold Infra Script ---
 echo ""
@@ -454,7 +454,7 @@ echo "[Phase 6b] Creating scaffold-infra.sh..."
 cat > "$PLUGIN/scripts/scaffold-infra.sh" << 'INFRAEOF'
 #!/usr/bin/env bash
 #
-# scaffold-infra.sh - Compare project files against GSD references
+# scaffold-infra.sh - Compare project files against HXSK references
 #
 set -euo pipefail
 
@@ -668,7 +668,7 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact
 ## Quick Start
 
 ```bash
-/hxsk:init          # Initialize GSD documents
+/hxsk:init          # Initialize HXSK documents
 /hxsk:bootstrap     # Full project setup
 /hxsk:planner       # Create implementation plan
 /hxsk:executor      # Execute planned work
@@ -682,7 +682,7 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact
 """
 
 for name, desc in commands:
-    readme += f"| `/gsd:{name}` | {desc} |\n"
+    readme += f"| `/hxsk:{name}` | {desc} |\n"
 
 readme += f"""
 ## Skills ({len(skills)})
@@ -705,7 +705,7 @@ for name, desc in agents:
     readme += f"| `{name}` | {desc} |\n"
 
 readme += """
-## GSD Document Structure
+## HXSK Document Structure
 
 After `/hxsk:init`:
 
@@ -791,7 +791,7 @@ cmd_count=$(ls "$PLUGIN/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
 skill_count=$(ls -d "$PLUGIN/skills"/*/ 2>/dev/null | wc -l | tr -d ' ')
 agent_count=$(ls "$PLUGIN/agents/"*.md 2>/dev/null | wc -l | tr -d ' ')
 script_count=$(find "$PLUGIN/scripts" -type f \( -name "*.sh" -o -name "*.py" \) | wc -l | tr -d ' ')
-template_count=$(ls "$PLUGIN/templates/gsd/templates/"*.md 2>/dev/null | wc -l | tr -d ' ')
+template_count=$(ls "$PLUGIN/templates/hxsk/templates/"*.md 2>/dev/null | wc -l | tr -d ' ')
 
 echo "  Commands:  ${cmd_count}"
 [ "$cmd_count" -ge 1 ] || { echo "    [WARN] No commands found"; }

--- a/scripts/compact-context.sh
+++ b/scripts/compact-context.sh
@@ -19,14 +19,14 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     echo "[DRY-RUN] No files will be modified"
 fi
 
-GSD_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
-ARCHIVE_DIR="$GSD_DIR/archive"
+HXSK_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
+ARCHIVE_DIR="$HXSK_DIR/archive"
 YEAR_MONTH=$(date +%Y-%m)
 
 # Check if .hxsk directory exists
-if [[ ! -d "$GSD_DIR" ]]; then
-    echo "[SKIP] .hxsk/ directory not found at $GSD_DIR"
-    echo "Run /gsd:init to initialize GSD documents."
+if [[ ! -d "$HXSK_DIR" ]]; then
+    echo "[SKIP] .hxsk/ directory not found at $HXSK_DIR"
+    echo "Run /hxsk:init to initialize HXSK documents."
     exit 0
 fi
 
@@ -44,7 +44,7 @@ echo "================================================================"
 # 1. PATTERNS.md size check
 # ─────────────────────────────────────────────────────
 
-PATTERNS_FILE="$GSD_DIR/PATTERNS.md"
+PATTERNS_FILE="$HXSK_DIR/PATTERNS.md"
 if [[ -f "$PATTERNS_FILE" ]]; then
     PATTERNS_SIZE=$(wc -c < "$PATTERNS_FILE" | tr -d ' ')
     PATTERNS_ITEMS=$(grep -c "^- " "$PATTERNS_FILE" 2>/dev/null | tr -d '[:space:]' || echo 0)
@@ -70,7 +70,7 @@ fi
 # 2. JOURNAL.md archiving
 # ─────────────────────────────────────────────────────
 
-JOURNAL_FILE="$GSD_DIR/JOURNAL.md"
+JOURNAL_FILE="$HXSK_DIR/JOURNAL.md"
 if [[ -f "$JOURNAL_FILE" ]]; then
     # Count sessions (headers starting with ### [Session or ## Session)
     SESSION_COUNT=$(grep -c "^##.* Session" "$JOURNAL_FILE" 2>/dev/null || echo 0)
@@ -128,7 +128,7 @@ fi
 # 3. CHANGELOG.md archiving
 # ─────────────────────────────────────────────────────
 
-CHANGELOG_FILE="$GSD_DIR/CHANGELOG.md"
+CHANGELOG_FILE="$HXSK_DIR/CHANGELOG.md"
 if [[ -f "$CHANGELOG_FILE" ]]; then
     ENTRY_COUNT=$(grep -c "^## \[" "$CHANGELOG_FILE" 2>/dev/null | tr -d '[:space:]' || echo 0)
 
@@ -185,8 +185,8 @@ fi
 # 4. prd-active.json cleanup
 # ─────────────────────────────────────────────────────
 
-PRD_ACTIVE="$GSD_DIR/prd-active.json"
-PRD_DONE="$GSD_DIR/prd-done.json"
+PRD_ACTIVE="$HXSK_DIR/prd-active.json"
+PRD_DONE="$HXSK_DIR/prd-done.json"
 if [[ -f "$PRD_ACTIVE" ]]; then
     PENDING_COUNT=$(jq '.tasks | length' "$PRD_ACTIVE" 2>/dev/null || echo 0)
     PRD_SIZE=$(wc -c < "$PRD_ACTIVE" | tr -d ' ')

--- a/scripts/convert-hooks-to-plugins.py
+++ b/scripts/convert-hooks-to-plugins.py
@@ -40,7 +40,7 @@ SKIP_FILES = {
     "md-store-memory.sh",
     "md-recall-memory.sh",
     "_json_parse.sh",
-    "scaffold-gsd.sh",
+    "scaffold-hxsk.sh",
     "scaffold-hxsk.sh",
     "scaffold-infra.sh",
     "compact-context.sh",

--- a/scripts/convert-hooks-to-plugins.py
+++ b/scripts/convert-hooks-to-plugins.py
@@ -57,15 +57,36 @@ def oc_event_to_name(oc_event: str) -> str:
     return "".join(p.capitalize() for p in oc_event.replace(".", "-").split("-")) + "Plugin"
 
 
+def generate_script_exec(fname: str, oc_event: str) -> str:
+    """Generate the TypeScript execution call for a single hook script."""
+    ext = os.path.splitext(fname)[1]
+    runner = "python3" if ext == ".py" else "bash"
+    script_path = f"${{import.meta.dir}}/../../scripts/{fname}"
+
+    if oc_event == "tool.execute.before":
+        # Guard hooks: run with tool context, throw on non-zero exit to block
+        return (
+            f"    const r_{fname.replace('-','_').replace('.','_')} = "
+            f"await $`{runner} {script_path}`"
+            f".env({{ TOOL_NAME: (input as any)?.tool ?? \"\", "
+            f"TOOL_INPUT: JSON.stringify(input) }}).nothrow();\n"
+            f"    if (r_{fname.replace('-','_').replace('.','_')}.exitCode !== 0) "
+            f"throw new Error(r_{fname.replace('-','_').replace('.','_')}.stderr.toString().trim() "
+            f"|| \"{fname} blocked execution\");"
+        )
+    else:
+        # Non-blocking hooks: run and ignore exit code
+        return f"    await $`{runner} {script_path}`.nothrow();"
+
+
 def generate_plugin(oc_event: str, hooks: list) -> str:
-    """Generate a TypeScript plugin stub for one OpenCode event group."""
+    """Generate a functional TypeScript plugin for one OpenCode event group."""
     claude_event = hooks[0][1]
     hook_comments = "\n".join(
         f" *   - {fname}: {desc}" for fname, _, desc in hooks
     )
     script_execs = "\n".join(
-        f"    // await $`bash ${{import.meta.dir}}/../../scripts/{fname}`"
-        for fname, _, _ in hooks
+        generate_script_exec(fname, oc_event) for fname, _, _ in hooks
     )
     plugin_name = oc_event_to_name(oc_event)
 

--- a/scripts/convert-hooks-to-plugins.py
+++ b/scripts/convert-hooks-to-plugins.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Convert Claude Code hooks to OpenCode TypeScript plugin stubs.
+
+Usage:
+  python3 convert-hooks-to-plugins.py <hooks_src_dir> <plugins_dst_dir>
+
+Each Claude Code hook is mapped to the equivalent OpenCode plugin event
+and a TypeScript stub is generated that wraps the original shell script.
+"""
+
+import os
+import sys
+
+# Claude Code event → OpenCode event mapping
+EVENT_MAP = {
+    "SessionStart":  "session.created",
+    "PreToolUse":    "tool.execute.before",
+    "PostToolUse":   "tool.execute.after",
+    "Stop":          "session.idle",
+    "SessionEnd":    "session.idle",
+    "PreCompact":    "session.idle",
+}
+
+# Hook filename → (Claude event, description)
+HOOK_META = {
+    "bash-guard.py":           ("PreToolUse",  "Block dangerous bash commands (force push, rm -rf, etc.)"),
+    "file-protect.py":         ("PreToolUse",  "Protect sensitive files (.env, credentials, secrets)"),
+    "auto-format.sh":          ("PostToolUse", "Auto-format Python files after edit"),
+    "track-modifications.sh":  ("PostToolUse", "Track file modifications for session summary"),
+    "pre-compact-save.sh":     ("PreCompact",  "Save context state before compaction"),
+    "session-start.sh":        ("SessionStart","Initialize session: load STATE.md, inject git status"),
+    "post-turn-verify.sh":     ("Stop",        "Verify task completion after each turn"),
+    "stop-context-save.sh":    ("Stop",        "Save context and memory on session stop"),
+    "save-session-changes.sh": ("SessionEnd",  "Record changed files on session end"),
+    "save-transcript.sh":      ("SessionEnd",  "Save conversation transcript on session end"),
+}
+
+# Skip these utility scripts — not event hooks
+SKIP_FILES = {
+    "md-store-memory.sh",
+    "md-recall-memory.sh",
+    "_json_parse.sh",
+    "scaffold-gsd.sh",
+    "scaffold-hxsk.sh",
+    "scaffold-infra.sh",
+    "compact-context.sh",
+    "organize-docs.sh",
+}
+
+
+def to_camel(name: str) -> str:
+    base = os.path.splitext(name)[0]
+    return "".join(p.capitalize() for p in base.replace("-", "_").split("_")) + "Plugin"
+
+
+def oc_event_to_name(oc_event: str) -> str:
+    return "".join(p.capitalize() for p in oc_event.replace(".", "-").split("-")) + "Plugin"
+
+
+def generate_plugin(oc_event: str, hooks: list) -> str:
+    """Generate a TypeScript plugin stub for one OpenCode event group."""
+    claude_event = hooks[0][1]
+    hook_comments = "\n".join(
+        f" *   - {fname}: {desc}" for fname, _, desc in hooks
+    )
+    script_execs = "\n".join(
+        f"    // await $`bash ${{import.meta.dir}}/../../scripts/{fname}`"
+        for fname, _, _ in hooks
+    )
+    plugin_name = oc_event_to_name(oc_event)
+
+    return f"""import type {{ Plugin }} from "@opencode-ai/plugin"
+
+/**
+ * Claude Code event : {claude_event}
+ * OpenCode event    : {oc_event}
+ *
+ * Converted hooks:
+{hook_comments}
+ *
+ * Original scripts are in scripts/ directory.
+ * See MIGRATION-GUIDE.md for conversion patterns.
+ */
+export const {plugin_name}: Plugin = async ({{ $ }}) => ({{
+  "{oc_event}": async (input: unknown, _output: unknown) => {{
+{script_execs}
+  }},
+}})
+"""
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("Usage: convert-hooks-to-plugins.py <hooks_dir> <plugins_dir>")
+        return 1
+
+    hooks_src = sys.argv[1]
+    plugins_dst = sys.argv[2]
+
+    if not os.path.isdir(hooks_src):
+        print(f"Error: hooks directory not found: {hooks_src}")
+        return 1
+
+    os.makedirs(plugins_dst, exist_ok=True)
+
+    # Group hooks by OpenCode event
+    groups: dict[str, list] = {}
+    unclassified: list[str] = []
+
+    for fname in sorted(os.listdir(hooks_src)):
+        if fname in SKIP_FILES or fname.startswith("_"):
+            continue
+        if not (fname.endswith(".sh") or fname.endswith(".py")):
+            continue
+
+        meta = HOOK_META.get(fname)
+        if meta:
+            claude_event, desc = meta
+            oc_event = EVENT_MAP[claude_event]
+            groups.setdefault(oc_event, []).append((fname, claude_event, desc))
+        else:
+            unclassified.append(fname)
+
+    # Write one .ts file per OpenCode event
+    count = 0
+    for oc_event, hooks in sorted(groups.items()):
+        plugin_filename = oc_event.replace(".", "-") + ".ts"
+        out_path = os.path.join(plugins_dst, plugin_filename)
+        content = generate_plugin(oc_event, hooks)
+        with open(out_path, "w") as f:
+            f.write(content)
+        hook_names = ", ".join(h[0] for h in hooks)
+        print(f"  [+] {plugin_filename} ({len(hooks)} hooks: {hook_names})")
+        count += 1
+
+    if unclassified:
+        print(f"  [?] Unclassified (skipped): {', '.join(unclassified)}")
+
+    print(f"  Total: {count} plugin files generated")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate-claude-md.sh
+++ b/scripts/generate-claude-md.sh
@@ -116,7 +116,7 @@ $(generate_make_section)
 
 - **code-graph-rag** (MCP): Tree-sitter + SQLite based AST code analysis
 - **memory-graph** (MCP): Agent persistent memory
-- **GSD Workflow**: SPEC.md → PLAN.md → EXECUTE → VERIFY
+- **HXSK Workflow**: SPEC.md → PLAN.md → EXECUTE → VERIFY
 
 ## Code Style
 

--- a/scripts/organize-docs.sh
+++ b/scripts/organize-docs.sh
@@ -17,9 +17,9 @@ if [[ "${1:-}" == "--dry-run" ]]; then
     echo "[DRY-RUN] No files will be moved"
 fi
 
-GSD_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
-REPORTS_DIR="$GSD_DIR/reports"
-RESEARCH_DIR="$GSD_DIR/research"
+HXSK_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk"
+REPORTS_DIR="$HXSK_DIR/reports"
+RESEARCH_DIR="$HXSK_DIR/research"
 
 # Ensure directories exist
 mkdir -p "$REPORTS_DIR" "$RESEARCH_DIR"
@@ -37,7 +37,7 @@ MOVED_COUNT=0
 echo ""
 echo "--- Reports ---"
 
-for file in "$GSD_DIR"/REPORT-*.md; do
+for file in "$HXSK_DIR"/REPORT-*.md; do
     if [[ -f "$file" ]]; then
         filename=$(basename "$file")
         if [[ "$DRY_RUN" == true ]]; then
@@ -62,7 +62,7 @@ echo ""
 echo "--- Research ---"
 
 RESEARCH_MOVED=0
-for file in "$GSD_DIR"/RESEARCH-*.md; do
+for file in "$HXSK_DIR"/RESEARCH-*.md; do
     if [[ -f "$file" ]]; then
         filename=$(basename "$file")
         if [[ "$DRY_RUN" == true ]]; then


### PR DESCRIPTION
## Summary
- 코드베이스 전체에서 `GSD`/`gsd` 단어를 `HXSK`/`hxsk`로 전면 교체
- 파일명/디렉토리명 변경 포함

## Changes
- **파일 내용**: 모든 `.sh`, `.py`, `.md`, `.json`, `.yaml`, `.ts` 파일에서 GSD→HXSK, gsd→hxsk 교체 (35개 파일, 220곳)
- **파일명**: `scaffold-gsd.sh` → `scaffold-hxsk.sh` (hxsk-plugin, antigravity, opencode, .claude/hooks)
- **파일명**: `gsd-workflow.md` → `hxsk-workflow.md` (antigravity rules)
- **디렉토리명**: `templates/gsd/` → `templates/hxsk/` (모든 boilerplate + plugin)
- **제거**: 빈 `.gsd/` 디렉토리 삭제 (이전 PR #40에서 `.hxsk/`로 이미 이동됨)

## Test Plan
- [x] `make build` — 3개 빌드 모두 BUILD SUCCESSFUL, WARN 없음
- [x] `grep -rn "GSD\|gsd" ... | wc -l` → 0 (CHANGELOG.md 제외)
- [x] 파일명 변경 확인: `scaffold-hxsk.sh`, `hxsk-workflow.md`, `templates/hxsk/`

## Notes
- `CHANGELOG.md`는 히스토리 파일이므로 변경 제외
- `.hxsk/` 메모리 디렉토리는 이전 PR #40에서 이미 처리됨

## GSD Context
- SPEC reference: `.hxsk/SPEC.md`