### PR TITLE
docs: 문서/스크립트 개수 최신화 (Skills 17, Agents 15, Hooks 17)

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -18,5 +18,5 @@
 | `.hxsk/SPEC.md` | 구현 명세 |
 | `.hxsk/PLAN.md` | 실행 계획 |
 | `.hxsk/STATE.md` | 진행 상태 |
-| `.claude/agents/` | Agent 정의 (14개) |
-| `.claude/skills/` | Skill 정의 (16개) |
+| `.claude/agents/` | Agent 정의 (15개) |
+| `.claude/skills/` | Skill 정의 (17개) |

--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ SPEC → PLAN → EXECUTE → VERIFY
 
 | 구성요소 | 개수 | 설명 |
 |----------|------|------|
-| **Skills** | 16 | Claude가 상황을 인식하여 자율 호출하는 기능 단위 (How) |
-| **Agents** | 14 | 스킬을 조합하고 오케스트레이션하는 서브에이전트 (When/With What) |
-| **Hooks** | 14 | 이벤트 기반 자동화 (가드레일, 상태 저장, 검증) |
+| **Skills** | 17 | Claude가 상황을 인식하여 자율 호출하는 기능 단위 (How) |
+| **Agents** | 15 | 스킬을 조합하고 오케스트레이션하는 서브에이전트 (When/With What) |
+| **Hooks** | 17 | 이벤트 기반 자동화 (가드레일, 상태 저장, 검증) |
 | **Memory System** | 14 types | A-Mem 확장 파일 기반 메모리 (2-hop 검색, 중복 방지) |
 
 ### 상세 문서
 
 | 문서 | 설명 |
 |------|------|
-| [Agents](docs/AGENTS.md) | 14개 서브에이전트 (역할, capabilities, 실행 흐름) |
-| [Skills](docs/SKILLS.md) | 16개 스킬 (트리거 조건, 도구 연동) |
-| [Hooks](docs/HOOKS.md) | 14개 훅 이벤트 (이벤트, 코드, 작동 예시) |
+| [Agents](docs/AGENTS.md) | 15개 서브에이전트 (역할, capabilities, 실행 흐름) |
+| [Skills](docs/SKILLS.md) | 17개 스킬 (트리거 조건, 도구 연동) |
+| [Hooks](docs/HOOKS.md) | 17개 훅 이벤트 (이벤트, 코드, 작동 예시) |
 | [Memory](docs/MEMORY.md) | 파일 기반 메모리 시스템 상세 |
 | [Build](docs/BUILD.md) | 빌드 가이드 (Claude Code Plugin, Antigravity, OpenCode) |
 | [GitHub Workflow](docs/GITHUB-WORKFLOW.md) | CI/CD 파이프라인 (release-please) |
@@ -57,9 +57,9 @@ SPEC → PLAN → EXECUTE → VERIFY
 ```
 .
 ├── .claude/                   # Claude Code 설정 (Single Source of Truth)
-│   ├── agents/                # 서브에이전트 정의 (14)
-│   ├── skills/                # 스킬 정의 (16)
-│   ├── hooks/                 # 훅 스크립트 (14 이벤트)
+│   ├── agents/                # 서브에이전트 정의 (15)
+│   ├── skills/                # 스킬 정의 (17)
+│   ├── hooks/                 # 훅 스크립트 (17)
 │   └── settings.json          # 훅 설정
 ├── .hxsk/                      # HXSK 작업 문서
 │   ├── STATE.md               # 현재 작업 상태 (git 추적)
@@ -209,7 +209,7 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 
 ---
 
-## Skills (16)
+## Skills (17)
 
 **Skills**는 Claude가 작업 컨텍스트를 기반으로 **자율적으로 호출**하는 전문 기능입니다.
 
@@ -231,10 +231,11 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 | `empirical-validation` | 경험적 증거 요구 | 완료 확인 시 |
 | `bootstrap` | 프로젝트 초기 설정 | 부트스트랩 요청 시 |
 | `memory-protocol` | 메모리 검색/저장 프로토콜 | 메모리 작업 시 |
+| `write-report` | 솔루션 비교 보고서 작성 | 기술 선정/벤더 평가 시 |
 
 ---
 
-## Agents (14)
+## Agents (15)
 
 **Agents**는 특정 작업에 특화된 **서브에이전트**입니다.
 
@@ -254,10 +255,11 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 | `clean` | 코드 품질 | clean |
 | `context-health-monitor` | 컨텍스트 모니터링 | context-health-monitor |
 | `bootstrap` | 프로젝트 초기화 | bootstrap, memory-protocol |
+| `write-report` | 솔루션 비교 보고서 | write-report |
 
 ---
 
-## Hooks (14)
+## Hooks (17)
 
 **Hooks**는 Claude Code 이벤트에 자동으로 응답하는 스크립트입니다. AI의 자율성을 유지하면서도 **위험 행동을 원천 차단**하는 가드레일 역할을 합니다.
 
@@ -267,6 +269,7 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 | **PreToolUse** | `bash-guard.py` | 위험한 명령어 차단 |
 | **PreToolUse** | `file-protect.py` | .env, 시크릿 파일 보호 |
 | **PostToolUse** | `auto-format.sh` | Python 파일 자동 포맷 |
+| **PostToolUse** | `track-modifications.sh` | 변경 파일 추적 |
 | **PreCompact** | `pre-compact-save.sh` | 컴팩트 전 상태 저장 |
 | **Stop** | `stop-context-save.sh` | 세션 컨텍스트 저장 |
 | **Stop** | `post-turn-verify.sh` | 작업 검증 |
@@ -280,8 +283,10 @@ Claude는 작업 성격을 인식하여 적절한 스킬을 **스스로 판단�
 | `md-store-memory.sh` | 파일 기반 메모리 저장 |
 | `md-recall-memory.sh` | 파일 기반 메모리 검색 |
 | `scaffold-hxsk.sh` | HXSK 문서 초기화 |
+| `scaffold-infra.sh` | 인프라 스캐폴딩 |
 | `compact-context.sh` | 컨텍스트 압축 |
 | `organize-docs.sh` | 문서 정리/아카이브 |
+| `_json_parse.sh` | JSON 파싱 유틸리티 |
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,7 +9,7 @@ Claude Code의 **Agents**는 특정 작업에 특화된 서브프로세스입니
 | 항목 | 설명 |
 |------|------|
 | **위치** | `.claude/agents/*.md` |
-| **개수** | 14개 |
+| **개수** | 15개 |
 | **호출 방식** | Claude가 필요 시 자동 위임 또는 Task 도구로 명시적 호출 |
 | **컨텍스트** | 메인 대화와 분리된 별도 서브프로세스 |
 
@@ -50,6 +50,12 @@ Claude Code의 **Agents**는 특정 작업에 특화된 서브프로세스입니
 | Agent | 파일 | 역할 | Capabilities |
 |-------|------|------|--------------|
 | `clean` | `clean.md` | 코드 품질 도구 실행 | Read, Write, Edit, Bash, Grep, Glob |
+
+### 보고서 에이전트
+
+| Agent | 파일 | 역할 | Capabilities |
+|-------|------|------|--------------|
+| `write-report` | `write-report.md` | 솔루션 비교 보고서 작성 | Read, Grep, Glob, WebSearch, WebFetch |
 
 ---
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -29,8 +29,8 @@ hxsk-plugin/
 ├── .claude-plugin/
 │   └── plugin.json          # 매니페스트 (name, version, description)
 ├── commands/                 # 워크플로우 명령어
-├── skills/                   # 16개 스킬
-├── agents/                   # 14개 에이전트
+├── skills/                   # 17개 스킬
+├── agents/                   # 15개 에이전트
 ├── hooks/
 │   └── hooks.json           # 훅 설정 (경로 변환됨)
 ├── scripts/                  # 훅 스크립트
@@ -101,7 +101,7 @@ make build-antigravity
 ```
 antigravity-boilerplate/
 ├── .agent/
-│   ├── skills/              # 16개 스킬 (SKILL.md format)
+│   ├── skills/              # 17개 스킬 (SKILL.md format)
 │   │   ├── planner/
 │   │   ├── executor/
 │   │   └── ...
@@ -207,13 +207,13 @@ make build-opencode
 ```
 opencode-boilerplate/
 ├── .opencode/
-│   ├── agents/              # 14개 에이전트 (모델 설정 포함)
+│   ├── agents/              # 15개 에이전트 (모델 설정 포함)
 │   │   ├── planner.md       # model: anthropic/claude-opus-4-20250514
 │   │   ├── executor.md      # model: anthropic/claude-sonnet-4-20250514
 │   │   └── ...
 │   ├── commands/            # 워크플로우 명령어
 │   ├── plugins/             # TypeScript 플러그인 (빈 디렉토리)
-│   └── skill/               # 16개 스킬
+│   └── skill/               # 17개 스킬
 ├── templates/hxsk/           # HXSK 템플릿 + 예제
 ├── scripts/
 │   ├── scaffold-hxsk.sh      # HXSK 문서 초기화

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -10,7 +10,7 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
 |------|------|
 | **설정 파일** | `.claude/settings.json` |
 | **스크립트 위치** | `.claude/hooks/` |
-| **개수** | 15개 스크립트 |
+| **개수** | 17개 스크립트 |
 | **이벤트 종류** | SessionStart, PreToolUse, PostToolUse, PreCompact, Stop, SubagentStop, SessionEnd |
 
 ---

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -9,7 +9,7 @@ Claude Code의 **Skills**는 Claude가 작업 컨텍스트를 기반으로 **자
 | 항목 | 설명 |
 |------|------|
 | **위치** | `.claude/skills/*/SKILL.md` |
-| **개수** | 16개 |
+| **개수** | 17개 |
 | **호출 방식** | Claude가 작업 컨텍스트 기반으로 자율적 결정 |
 | **컨텍스트** | 메인 대화에서 실행 (컨텍스트 공유) |
 
@@ -52,6 +52,7 @@ Claude Code의 **Skills**는 Claude가 작업 컨텍스트를 기반으로 **자
 |-------|----------|------|-------------|
 | `clean` | `clean/` | 코드 품질 도구 실행 (shellcheck) | 품질 체크 요청 시 |
 | `memory-protocol` | `memory-protocol/` | 메모리 검색/저장 프로토콜 | 메모리 작업 시 |
+| `write-report` | `write-report/` | 솔루션 비교 보고서 작성 | 기술 선정/벤더 평가 시 |
 
 ---
 

--- a/scripts/build-antigravity.sh
+++ b/scripts/build-antigravity.sh
@@ -347,7 +347,7 @@ GEMINIHEADER
 ## Repository Layout
 
 - **.agent/** — Agent configuration (Antigravity format):
-  - `skills/` — Modular skill definitions (16 skills, SKILL.md format)
+  - `skills/` — Modular skill definitions (17 skills, SKILL.md format)
   - `workflows/` — Workflow commands (triggered via `/` commands)
   - `rules/` — Always-on passive rules (4 rule files)
 - **.hxsk/** — HXSK documents and context management:
@@ -522,11 +522,11 @@ AI agent development boilerplate for **Google Antigravity IDE**.
 
 ```
 .agent/
-├── skills/          # 16 AI skills (SKILL.md format)
+├── skills/          # 17 AI skills (SKILL.md format)
 │   ├── planner/     # Planning skill
 │   ├── executor/    # Execution skill
 │   └── ...
-├── workflows/       # 14 workflow commands (from agent orchestrations)
+├── workflows/       # 15 workflow commands (from agent orchestrations)
 │   ├── planner.md   # /planner command
 │   ├── executor.md  # /executor command
 │   └── ...
@@ -555,7 +555,7 @@ bash scripts/md-recall-memory.sh "query" "." 5 compact
 
 14 memory types: `architecture-decision`, `root-cause`, `session-summary`, etc.
 
-## Skills (16)
+## Skills (17)
 
 | Skill | Description |
 |-------|-------------|
@@ -654,11 +654,11 @@ skill_count=$(find "$ANTIGRAVITY/.agent/skills" -mindepth 1 -maxdepth 1 -type d 
 workflow_count=$(find "$ANTIGRAVITY/.agent/workflows" -name "*.md" | wc -l | tr -d ' ')
 rules_count=$(find "$ANTIGRAVITY/.agent/rules" -name "*.md" | wc -l | tr -d ' ')
 
-echo "  Skills:    ${skill_count} (expected: 16)"
-[ "$skill_count" -ge 16 ] || { echo "    [WARN] Low skill count"; warnings=$((warnings + 1)); }
+echo "  Skills:    ${skill_count} (expected: 17)"
+[ "$skill_count" -ge 17 ] || { echo "    [WARN] Low skill count"; warnings=$((warnings + 1)); }
 
-echo "  Workflows: ${workflow_count} (expected: 14)"
-[ "$workflow_count" -ge 14 ] || { echo "    [WARN] Low workflow count"; warnings=$((warnings + 1)); }
+echo "  Workflows: ${workflow_count} (expected: 15)"
+[ "$workflow_count" -ge 15 ] || { echo "    [WARN] Low workflow count"; warnings=$((warnings + 1)); }
 
 echo "  Rules:     ${rules_count} (expected: 4)"
 [ "$rules_count" -ge 4 ] || { echo "    [WARN] Missing rules"; warnings=$((warnings + 1)); }

--- a/scripts/build-opencode.sh
+++ b/scripts/build-opencode.sh
@@ -536,13 +536,13 @@ AI agent development boilerplate for **OpenCode**.
 
 ```
 .opencode/
-├── agents/          # 14 agents with model config
+├── agents/          # 15 agents with model config
 │   ├── planner.md   # model: anthropic/claude-opus-4-20250514
 │   ├── executor.md  # model: anthropic/claude-sonnet-4-20250514
 │   └── ...
 ├── commands/        # Workflow commands (/plan, /execute, etc.)
 ├── plugins/         # TypeScript plugins
-└── skill/           # 16 skills (SKILL.md format)
+└── skill/           # 17 skills (SKILL.md format)
 
 scripts/             # Utility scripts (메모리 포함)
 opencode.json        # Main config with agent model mapping
@@ -671,14 +671,14 @@ agent_count=$(ls "$OPENCODE/.opencode/agents/"*.md 2>/dev/null | wc -l | tr -d '
 command_count=$(ls "$OPENCODE/.opencode/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
 skill_count=$(ls -d "$OPENCODE/.opencode/skill"/*/ 2>/dev/null | wc -l | tr -d ' ')
 
-echo "  Agents:   ${agent_count} (expected: 14)"
-[ "$agent_count" -ge 14 ] || echo "    [WARN] Low agent count"
+echo "  Agents:   ${agent_count} (expected: 15)"
+[ "$agent_count" -ge 15 ] || echo "    [WARN] Low agent count"
 
 echo "  Commands: ${command_count}"
 [ "$command_count" -ge 1 ] || echo "    [WARN] No commands found"
 
-echo "  Skills:   ${skill_count} (expected: 16)"
-[ "$skill_count" -ge 16 ] || echo "    [WARN] Low skill count"
+echo "  Skills:   ${skill_count} (expected: 17)"
+[ "$skill_count" -ge 17 ] || echo "    [WARN] Low skill count"
 
 # Model field check
 echo ""


### PR DESCRIPTION
## Summary
- **README.md**: Skills 16→17, Agents 14→15, Hooks 14→17, write-report 항목 추가
- **docs/**: AGENTS.md, SKILLS.md, HOOKS.md, BUILD.md 개수 및 테이블 업데이트
- **빌드 스크립트**: build-opencode.sh, build-antigravity.sh expected count 업데이트 + 주석 수정
- **.gemini/GEMINI.md**: 개수 업데이트

## Test plan
- [x] `grep -rn "Skills.*16\b"` → 잔존 없음 확인
- [x] `grep -rn "Agents.*14\b"` → 잔존 없음 확인
- [x] 8개 파일, 48 insertions, 36 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)