### PR TITLE
chore: gitignore에 워크트리 및 빌드 산출물 경로 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,9 @@ temp/
 settings.local.json
 .hxsk/.modified-this-session
 .worktrees/
+.claude/worktrees/
+
+# Build artifacts
+antigravity-boilerplate/
+hxsk-plugin/
+opencode-boilerplate/


### PR DESCRIPTION
## Summary
- `.claude/worktrees/` 경로 추가
- 빌드 산출물 디렉토리 (`antigravity-boilerplate/`, `hxsk-plugin/`, `opencode-boilerplate/`) 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)