### PR TITLE
feat: 에이전트별 자동 로드 경로에 AGENTS.md 심볼릭 링크

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -111,12 +111,19 @@ HExoskeleton은 **하나의 프로젝트를 여러 AI 에이전트가 동시에 
 - **Lock-in 없음** — 특정 에이전트에 종속되지 않습니다. 순수 마크다운 파일이므로 어떤 에이전트든 읽고 쓸 수 있습니다.
 - **동시 사용 가능** — 같은 프로젝트에서 Claude Code로 백엔드를, Cursor로 프론트엔드를 동시에 작업할 수 있습니다.
 
-### Setup
+### 에이전트별 지침 자동 로드
 
-```bash
-# 하나의 프로젝트에 여러 에이전트 지원 구성
-# 에이전트에게 아래 프롬프트를 전달하면 자동 구성됩니다
-```
+`AGENTS.md`를 각 에이전트의 자동 로드 경로에 심볼릭 링크로 연결합니다. 별도 옵션 없이 에이전트를 실행하면 자동으로 지침을 읽습니다.
+
+| 에이전트 | 지침 파일 | 자동 로드 경로 |
+|----------|----------|--------------|
+| Claude Code | `CLAUDE.md` | (루트에서 자동 로드) |
+| Gemini CLI | `GEMINI.md` | (루트에서 자동 로드) |
+| GitHub Copilot | `AGENTS.md` | `.github/copilot-instructions.md` → symlink |
+| Cursor | `AGENTS.md` | `.cursorrules` → symlink |
+| Windsurf | `AGENTS.md` | `.windsurfrules` → symlink |
+
+### Setup
 
 | 프롬프트 | 대상 | 설명 |
 |----------|------|------|

--- a/prompts/setup.md
+++ b/prompts/setup.md
@@ -38,7 +38,25 @@
 
 권장 필수 스킬: `planner`, `executor`, `verifier`, `memory-protocol`
 
-## Step 5: 훅 설치 (Claude Code만, 선택)
+## Step 5: 에이전트별 자동 로드 경로 연결
+
+`AGENTS.md`를 각 에이전트의 자동 로드 경로에 심볼릭 링크로 연결하세요:
+
+```bash
+# GitHub Copilot
+mkdir -p .github
+ln -sf ../AGENTS.md .github/copilot-instructions.md
+
+# Cursor
+ln -sf AGENTS.md .cursorrules
+
+# Windsurf
+ln -sf AGENTS.md .windsurfrules
+```
+
+이렇게 하면 별도 옵션 없이 에이전트를 실행해도 HXSK 지침이 자동 로드됩니다.
+
+## Step 6: 훅 설치 (Claude Code만, 선택)
 
 훅은 Claude Code에서만 동작합니다. 다른 에이전트는 AGENTS.md의 Agent Boundaries 규칙으로 대체됩니다.
 
@@ -49,4 +67,5 @@
 - [ ] 에이전트 지침 파일이 프로젝트 루트에 존재
 - [ ] `.hxsk/` 디렉토리에 SPEC.md, STATE.md, PATTERNS.md 존재
 - [ ] (선택) 스킬이 에이전트 설정 디렉토리에 배치됨
+- [ ] (선택) 에이전트별 심볼릭 링크 생성됨 (.cursorrules, .windsurfrules 등)
 - [ ] (선택, Claude Code) 훅이 설치되고 settings.json에 등록됨


### PR DESCRIPTION
## Summary
- AGENTS.md를 Cursor(.cursorrules), Windsurf(.windsurfrules), Copilot(.github/copilot-instructions.md) 자동 로드 경로에 symlink
- README 멀티 에이전트 섹션에 자동 로드 경로 테이블 추가
- setup.md에 심볼릭 링크 생성 Step 추가

## Test Plan
- [ ] `ls -la .cursorrules .windsurfrules .github/copilot-instructions.md` 심볼릭 링크 확인
- [ ] 각 링크가 AGENTS.md를 정상 참조하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)