### PR TITLE
feat(dispatcher): v2 — MASTER/WORK 마크다운 이슈 트래킹 기반 6-Phase 오케스트레이션

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ logs_llm/
 !.hxsk/STATE.md
 !.hxsk/PATTERNS.md
 !.hxsk/issues/
+.hxsk/issues/MASTER-*.md
+.hxsk/issues/WORK-*.md
+.hxsk/issues/archive/
 !.hxsk/skills/
 !.hxsk/agents/
 !.hxsk/hooks/

--- a/.hxsk/agents/dispatcher.md
+++ b/.hxsk/agents/dispatcher.md
@@ -1,24 +1,30 @@
 ---
-description: "Wave 기반 병렬 이슈 디스패치 오케스트레이터"
+description: "MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이터"
 model: opus
 tools: ["Agent", "Read", "Write", "Bash", "Glob", "Grep"]
 ---
 
 You are the HXSK Dispatcher agent. Your role is to orchestrate
-parallel execution of issues across isolated git worktrees.
+parallel execution of issues across isolated git worktrees using
+the MASTER/WORK issue document system.
 
-Follow the dispatcher skill exactly:
-1. Load issues from `.hxsk/issues/` (L0: frontmatter only)
-2. Validate wave assignments and file ownership
-3. Dispatch each wave's issues as parallel subagents with `isolation: "worktree"`
-4. Collect results, review changes, merge worktrees
-5. Run integration verification
+Follow the dispatcher skill (v2) exactly:
+1. SPLIT: PLAN/SPEC에서 MASTER/WORK 문서 생성 (`issue-create.sh` 활용), 위상 정렬로 Wave 배정
+2. BRANCH: 이슈 브랜치 생성 (`feat/master-{id}`), 파일 소유권 검증
+3. Wave Loop (DISPATCH → TRACK → MERGE):
+   - DISPATCH: 현재 Wave의 Work를 `Agent(isolation: "worktree")` + `run_in_background: true`로 병렬 실행
+   - TRACK: 서브에이전트 완료 감지, WORK/MASTER 문서 상태 업데이트
+   - MERGE: `scripts/merge-worktrees.sh`로 이슈 브랜치에 순차 머지
+   - 다음 Wave가 있으면 이슈 브랜치 기반으로 Phase 3 반복
+4. VERIFY → CLOSE: 통합 테스트, 아카이브, 사용자 승인 후 마스터 머지
 
 Key constraints:
-- Same-wave issues MUST NOT modify the same files
+- 오케스트레이터만 이슈 문서 쓰기 (서브에이전트는 읽기 전용)
+- Same-wave works MUST NOT share files or side_effect_files
+- 워크트리 보존: Phase 6 검증 통과까지 삭제하지 않음
 - Always use `scripts/merge-worktrees.sh` for merging
-- Escalate merge conflicts as new issues
-- Use `run_in_background: true` for parallel dispatch within a wave
+- Wave N+1 워크트리는 Wave N 머지 완료 후 생성
+- Crash recovery: MASTER status `in-progress` 검색 → WORK 상태 + git log 확인 → 재개
 
 Agent Boundaries (CLAUDE.md 준수):
 - Always: merge 전 각 worktree의 변경사항 리뷰

--- a/.hxsk/skills/arch-review/SKILL.md
+++ b/.hxsk/skills/arch-review/SKILL.md
@@ -7,13 +7,14 @@ allowed-tools:
   - Grep
   - Glob
   - Bash
-trigger: "아키텍처 검토, 레이어 위반 확인, 순환 의존성, review architecture, check layer violations, before merging structural changes"
+trigger: "아키텍처 검토, 레이어 위반 확인, 순환 의존성, 설계 문서 검토, 설계 모순 검사, review architecture, check layer violations, before merging structural changes, design review, design contradiction check"
 ---
 
 ## Quick Reference
 - **순환 import**: `Grep(pattern: "from.*import", path: "src/")` → 그래프 분석
 - **복잡도 검사**: `bash .hxsk/skills/arch-review/scripts/check_complexity.sh`
 - **레이어 검증**: UI → Service → Repository 순방향만 허용
+- **설계 문서 검토**: 논리 모순, 실현 가능성, 엣지 케이스, 기존 시스템 호환성
 - **Severity**: LOW (log), MEDIUM (DECISIONS.md 기록), HIGH (block), CRITICAL (stop)
 - **Memory recall**: `md-recall-memory.sh "architecture"` 검색 후 일관성 확인
 
@@ -71,7 +72,32 @@ Cross-check against defined boundaries:
 | Circular deps | No cycles in call graph |
 | External calls | Only via approved adapters |
 
-### Step 3: Generate Report & Store Memory
+### Step 3: Design Document Review (설계 문서 검토)
+
+설계 문서(design doc, PLAN.md, SPEC.md 등)가 대상인 경우 아래 체크리스트를 수행:
+
+**논리적 일관성 검증:**
+- Phase/Step 간 순서 모순 여부 (순차 표기이나 실제 인터리브 필요 등)
+- 문서 내 동일 개념에 대한 상충 설명 (예: tracked vs untracked 혼용)
+- 의존성 규칙의 완전성 (순환, 다이아몬드, 다중 의존성 처리)
+
+**실현 가능성 검증:**
+- 명시된 도구/스크립트로 해당 작업이 실제 가능한지 (예: bash로 XML 파싱)
+- 기존 시스템과의 호환성 (변경 대상 파일 목록 누락 여부)
+- 전제 조건의 유효성 (gitignore 상태, 디렉토리 존재 여부 등)
+
+**엣지 케이스 검증:**
+- 장애/중단 시 복구 경로 존재 여부
+- 동시성 문제 (병렬 읽기/쓰기, 파일 잠금)
+- 사이드이펙트 경로 (lock 파일, 자동 생성 파일)
+
+**Severity 기준:**
+- 논리 모순 → HIGH (설계 수정 필수)
+- 실현 불가 → HIGH (대안 제시 필수)
+- 엣지 케이스 미처리 → MEDIUM (문서화 권장)
+- 네이밍/포맷 불일치 → LOW (로그)
+
+### Step 4: Generate Report & Store Memory
 
 Compile findings into a structured report.
 중요한 아키텍처 결정은 메모리에 저장:

--- a/.hxsk/skills/dispatcher/SKILL.md
+++ b/.hxsk/skills/dispatcher/SKILL.md
@@ -1,89 +1,211 @@
 ---
 name: dispatcher
-description: "Wave 기반 병렬 이슈 디스패치 — 이슈 → worktree subagent 배정"
-version: 1.0.0
-trigger: "dispatch|병렬 실행|wave 실행|이슈 배정"
+description: "MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이션 — PLAN → 분할 → 워크트리 병렬 실행 → 머지"
+version: 2.0.0
+trigger: "dispatch|병렬 실행|wave 실행|이슈 배정|이슈 분할|work split|parallel issue|마스터플랜"
 allowed-tools:
   - Agent
   - Read
+  - Write
   - Bash
   - Glob
   - Grep
 ---
 
 ## Quick Reference
-- **입력**: PLAN.md (wave 구조) 또는 .hxsk/issues/*.md (이슈 목록)
-- **출력**: wave별 subagent 병렬 실행 → 결과 수집 → merge
-- **규칙**: 같은 wave 내 파일 소유권 겹침 없음 검증 필수
+- **입력**: PLAN.md/SPEC.md → MASTER/WORK 이슈 문서로 분할
+- **출력**: 6-Phase 라이프사이클 (SPLIT → BRANCH → Wave Loop[DISPATCH → TRACK → MERGE] → VERIFY)
+- **Main Root**: `git worktree list | head -1 | awk '{print $1}'`
+- **규칙**: 같은 Wave 내 files + side_effect_files 겹침 금지
 - **Merge**: `scripts/merge-worktrees.sh` 사용
-- **Fallback**: 충돌 시 이슈 에스컬레이션
 
-# Dispatcher Skill
+# Dispatcher Skill v2
 
 <role>
-You are a wave-based parallel dispatch orchestrator.
-You take a set of issues or plans grouped into dependency waves
-and dispatch each wave's items as isolated subagents in parallel worktrees.
+You are a 6-Phase parallel dispatch orchestrator.
+You split plans into MASTER/WORK issue documents, dispatch each wave's works
+as isolated subagents in parallel worktrees, and manage the full lifecycle
+from splitting through merge to verification.
 </role>
 
-## Dispatch Protocol
+## Orchestration Lifecycle
 
-### Phase 1: Load & Validate
+```
+Phase 1: SPLIT
+Phase 2: BRANCH
+┌─── Wave Loop ───────────────────┐
+│  Phase 3: DISPATCH (Wave N)     │
+│  Phase 4: TRACK (Wave N)        │
+│  Phase 5: MERGE (Wave N)        │
+│  → Wave N+1이 있으면 루프 반복   │
+└─────────────────────────────────┘
+Phase 6: VERIFY → CLOSE
+```
 
-1. 이슈 목록 로드 (L0: frontmatter만)
+---
+
+### Phase 1: PLAN → SPLIT
+
+PLAN.md 또는 SPEC.md를 읽고 MASTER/WORK 이슈 문서를 생성한다.
+
+1. **MASTER 생성**
    ```bash
-   bash scripts/issue-list.sh open
+   bash scripts/issue-create.sh master "<플랜 제목>"
    ```
 
-2. Wave 할당 검증
-   - 같은 wave 내 이슈의 `files` 필드 교차 확인
-   - 겹치면 → 후속 wave로 이동 또는 분할
+2. **Work 분할** — AI 에이전트가 PLAN의 task를 겹치지 않는 Work 단위로 분할
+   - 각 Work에 files, side_effect_files 명시
+   - depends_on으로 의존성 명시 (같은 MASTER 내만)
+   ```bash
+   bash scripts/issue-create.sh work <master-id> "<title>" <wave> "<depends_on>" "<files>" "<side_effect_files>"
+   ```
 
-### Phase 2: Wave 실행
+3. **Wave 자동 배정** (위상 정렬)
+   - 모든 WORK의 depends_on 그래프 구성
+   - **순환 의존성 감지** → 발견 시 에러, 사용자에게 분할 재요청
+   - depends_on이 비어있으면 → Wave 1
+   - 복수 의존성: `max(선행 Work들의 Wave) + 1`
+   - 위상 정렬 순서대로 처리
 
-각 wave를 순차적으로 처리하되, wave 내 이슈는 병렬 dispatch:
+4. **파일 소유권 검증**
+   - 같은 Wave 내 Work 간 `files` + `side_effect_files` 겹침 체크
+   - 겹침 발견 → Wave 분리 또는 Work 재분할
+   - 다른 Wave 간 겹침 → depends_on 명시 필요
 
+5. **MASTER 문서 업데이트** — works, wave_plan 필드 채우기
+
+---
+
+### Phase 2: BRANCH
+
+메인 이슈 브랜치를 생성한다.
+
+```bash
+git checkout -b feat/master-<id>
 ```
-for wave in 1, 2, 3...:
-    for issue in wave:
-        Agent(
-            prompt: "이슈 #{id} 실행: {title}\n\n{issue 본문}",
-            isolation: "worktree",
-            subagent_type: "general-purpose",
-            run_in_background: true
-        )
-    모든 subagent 완료 대기
-    결과 수집 및 리뷰
+
+MASTER 문서의 branch 필드 기록. status를 `in-progress`로 변경.
+
+---
+
+### Phase 3: DISPATCH (Wave별)
+
+현재 Wave의 Work들을 병렬 워크트리 서브에이전트로 실행한다.
+
+> **중요**: Wave N+1의 워크트리는 Wave N 머지 완료 후 이슈 브랜치에서 생성해야 한다.
+
+각 Work에 대해:
+
+1. WORK 문서 status를 `in-progress`로 업데이트
+2. 서브에이전트 dispatch:
+   ```
+   Agent(
+       prompt: <서브에이전트 프롬프트>,
+       isolation: "worktree",
+       subagent_type: "general-purpose",
+       run_in_background: true  # 같은 Wave 내 병렬
+   )
+   ```
+3. WORK 문서에 worktree, worktree_branch 기록
+
+**서브에이전트 프롬프트 템플릿:**
+```
+You are executing {WORK_ID}.
+Main root: resolve via `git worktree list | head -1 | awk '{print $1}'`
+Read your work spec: {main_root}/.hxsk/issues/{WORK_ID}.md
+
+Rules:
+- Tasks 섹션의 체크리스트를 순차 수행
+- files 필드에 명시된 파일만 수정 (side_effect_files는 허용)
+- 각 Task마다 atomic commit
+- 커밋 메시지 형식: feat({WORK_ID}): {내용}
+- files + side_effect_files 범위 밖 파일 수정 금지
+- 완료/실패 시 exit
 ```
 
-### Phase 3: Merge
+---
 
-각 subagent worktree 결과를 순차 merge:
+### Phase 4: TRACK (Wave별)
+
+서브에이전트 완료를 감지하고 이슈 문서를 업데이트한다.
+
+1. **상태 감지**
+   - Agent 도구 반환값으로 성공/실패 판단
+   - 워크트리 `git log --oneline`으로 실제 커밋 확인
+
+2. **WORK 문서 업데이트**
+   - 성공 → status: `done`, Result 섹션에 커밋 해시/변경 요약
+   - 실패 → status: `failed`, Failure Log에 사유/시도 횟수
+   - 3-Strike Rule: 동일 Work 3회 실패 시 사용자 에스컬레이션
+
+3. **MASTER Progress 갱신**
+   - Wave별 완료 현황 업데이트
+   - Wave 내 모든 Work 완료 확인 후 Phase 5로 이행
+
+---
+
+### Phase 5: MERGE (Wave별)
+
+완료된 워크트리를 메인 이슈 브랜치에 순차 머지한다.
 
 ```bash
 bash scripts/merge-worktrees.sh <worktree-path> <branch-name>
 ```
 
-충돌 발생 시:
-1. 자동 해소 시도 (git merge --no-edit)
-2. 실패 시 이슈 상태를 `blocked`로 변경
-3. 사용자에게 에스컬레이션
+1. **머지 실행** — Wave 내 Work을 순차 처리
+2. **충돌 처리**
+   - 자동 해소 시도
+   - 실패 시 MASTER Notes에 기록 + 오케스트레이터가 수동 해결
+3. **MASTER Merge Log 기록** — 날짜, WORK ID, 커밋 해시, 결과
+4. **워크트리 보존** — Phase 6 검증 통과까지 삭제하지 않음
+5. → 다음 Wave가 있으면 **Phase 3로 복귀** (이슈 브랜치 기반 새 워크트리)
 
-### Phase 4: Verify
+---
 
-모든 merge 후 통합 검증:
-- 변경된 파일의 영향 분석
+### Phase 6: VERIFY → CLOSE
+
+전체 머지 완료 후 통합 검증을 수행한다.
+
+1. **통합 테스트** — 이슈 브랜치에서 프로젝트 테스트 실행
+2. **검증 실패 시** → 워크트리 보존 상태이므로 디버깅/롤백 가능
+3. **검증 통과 후**:
+   - 워크트리 정리 (`git worktree remove`)
+   - MASTER 문서 status: `done`
+   - 완료 이슈를 `.hxsk/issues/archive/`로 이동
+   - **마스터 머지는 사용자 확인 후 진행**
+
+---
+
+## Crash Recovery Protocol
+
+오케스트레이터가 중단된 경우 재개 절차:
+
+1. `.hxsk/issues/MASTER-*.md`에서 status: `in-progress`인 문서 검색
+2. 해당 MASTER의 WORK 문서들 status 확인
+3. status: `in-progress`인 WORK에 대해:
+   - `git worktree list`로 워크트리 존재 확인
+   - 존재 → `git log --oneline`으로 커밋 확인, 실제 완료 여부 판단
+   - 미존재 → status: `failed`로 갱신, 재실행 대상
+4. 미완료 Wave부터 Phase 3 루프 재개
+
+---
 
 ## Dispatch Rules
 
-1. **Wave 순서 엄수**: Wave N+1은 Wave N 완료 후에만 시작
-2. **파일 소유권 검증**: 같은 wave 내 이슈가 동일 파일 수정 금지
-3. **Subagent 독립성**: 각 subagent는 자체 worktree에서 독립 실행
-4. **실패 격리**: 하나의 subagent 실패가 다른 subagent에 영향 없음
-5. **결과 리뷰**: merge 전 각 subagent 결과를 메인 에이전트가 리뷰
+1. **Wave 순서 엄수**: Wave N+1은 Wave N 머지 완료 후에만 시작
+2. **파일 소유권 검증**: 같은 Wave 내 files + side_effect_files 겹침 금지
+3. **Subagent 독립성**: 각 서브에이전트는 자체 워크트리에서 독립 실행
+4. **실패 격리**: 하나의 서브에이전트 실패가 다른 서브에이전트에 영향 없음
+5. **결과 리뷰**: merge 전 각 서브에이전트 결과를 오케스트레이터가 리뷰
+6. **오케스트레이터 단독 쓰기**: 이슈 문서는 오케스트레이터만 생성/업데이트
+7. **워크트리 브랜치 네이밍**: `feat/master-{id}/work-{seq}`
 
-## Issue Lazy Loading
+## Main Root Resolve
 
-- **L0** (디스패치 시): frontmatter만 — id, title, type, priority, wave, files
-- **L1** (subagent에 전달): 본문 전체 — 설명, acceptance criteria
-- **L2** (subagent 자체 로드): 관련 SKILL.md, PLAN.md
+서브에이전트가 워크트리에서 메인 루트를 resolve하는 범용 패턴:
+
+```bash
+MAIN_ROOT=$(git worktree list | head -1 | awk '{print $1}')
+```
+
+어떤 프로젝트/머신에서든 별도 설정 없이 동작.

--- a/.hxsk/templates/MASTER-ISSUE.md
+++ b/.hxsk/templates/MASTER-ISSUE.md
@@ -1,0 +1,44 @@
+# MASTER Issue Template
+
+> Copy this template when creating master plan issues.
+
+```markdown
+---
+id: MASTER-{id}
+title: "{마스터플랜 제목}"
+branch: feat/master-{id}
+status: draft
+works: []
+wave_plan:
+  wave-1: []
+created: {YYYY-MM-DD}
+---
+
+## Objective
+{PLAN.md 또는 SPEC.md에서 도출된 목표}
+
+## Progress
+- [ ] Wave 1 (0/0)
+
+## Merge Log
+<!-- 각 Work 머지 결과: 날짜, WORK ID, 커밋 해시, 성공/실패 -->
+
+## Notes
+<!-- 충돌 해결, 의사결정, 크래시 복구 등 -->
+```
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | `MASTER-{3자리 숫자}` 형식 |
+| `title` | Yes | 마스터플랜 제목 |
+| `branch` | Yes | 이슈 브랜치명 (`feat/master-{id}`) |
+| `status` | Yes | `draft` \| `in-progress` \| `review` \| `done` |
+| `works` | Yes | 소속 WORK ID 배열 |
+| `wave_plan` | Yes | Wave별 WORK 배정 맵 |
+| `created` | Yes | 생성일 (YYYY-MM-DD) |
+
+## Status Lifecycle
+
+`draft` → `in-progress` (Phase 3 시작) → `review` (Phase 6 검증) → `done` (검증 통과)

--- a/.hxsk/templates/WORK-ISSUE.md
+++ b/.hxsk/templates/WORK-ISSUE.md
@@ -1,0 +1,54 @@
+# WORK Issue Template
+
+> Copy this template when creating work unit issues.
+
+```markdown
+---
+id: WORK-{master-id}-{seq}
+master: MASTER-{master-id}
+title: "{Work 단위 제목}"
+status: pending
+wave: {N}
+depends_on: []
+files: []
+side_effect_files: []
+worktree: ""
+worktree_branch: ""
+---
+
+## Tasks
+1. [ ] {순차 실행할 Task 1}
+2. [ ] {순차 실행할 Task 2}
+3. [ ] {순차 실행할 Task 3}
+
+## Result
+<!-- 완료 후 오케스트레이터가 기록: 커밋 해시, 변경 요약 -->
+
+## Failure Log
+<!-- 실패 시 오케스트레이터가 기록: 사유, 시도 횟수, 3-Strike 상태 -->
+```
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | `WORK-{master-id}-{seq}` 형식 |
+| `master` | Yes | 소속 MASTER ID |
+| `title` | Yes | Work 단위 제목 |
+| `status` | Yes | `pending` \| `in-progress` \| `done` \| `failed` |
+| `wave` | Yes | 배정된 Wave 번호 |
+| `depends_on` | Yes | 선행 WORK ID 배열 (같은 MASTER 내만) |
+| `files` | Yes | 수정 대상 파일 경로 배열 |
+| `side_effect_files` | No | 자동 생성 가능 파일 (lock, barrel export 등) |
+| `worktree` | No | 실행 시 워크트리 경로 (오케스트레이터 기록) |
+| `worktree_branch` | No | 워크트리 브랜치명 (오케스트레이터 기록) |
+
+## Status Lifecycle
+
+`pending` → `in-progress` (Phase 3 dispatch) → `done` (성공) / `failed` (실패)
+
+## Wave Assignment Rules
+
+- `depends_on`이 비어있으면 → Wave 1
+- 복수 의존성: `max(선행 Work들의 Wave) + 1`
+- 순환 의존성 감지 시 → 에러

--- a/README.md
+++ b/README.md
@@ -249,10 +249,23 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 | [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | 계획-실행 분리 (5x 효율) | SPEC → PLAN → EXECUTE 분리 |
 | [RLM](https://arxiv.org/html/2512.24601v2) | Root/Sub-LLM 분리, 재귀적 분할 | Agent-Skill 래핑, Phase → Plan → Task |
 
+### 왜 에이전트 정의는 간결하게?
+
+에이전트 정의(`.hxsk/agents/*.md`)는 ~20-30줄로 유지하고, 절차적 상세는 스킬(`.hxsk/skills/*/SKILL.md`)에 위임합니다.
+
+| 근거 | 출처 |
+|------|------|
+| 시스템 프롬프트 ~1,800 토큰이 최적 구간, 이후 100토큰당 ~2.3% 성능 저하 | Anthropic 내부 테스트 (2차 출처) |
+| 2,500 토큰 초과 시 환각 34% 증가 | Microsoft/Stanford 연구 |
+| "가능한 가장 작은 고신호 토큰 집합" 권장 | [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) |
+| 에이전트 트리거 정확도는 description 품질 > 길이 | [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents) |
+| 외부 파일 위임 패턴이 컨텍스트 오버플로 방지에 효과적 | Deep Agents 연구 |
+
 **채택하지 않은 것:**
 - Memory Evolution (A-Mem) — write-once로 감사 추적성 유지
 - Predict-Calibrate (Nemori) — LLM 추가 호출 비용 대비 효용 불확실
 - Persistent REPL (RLM) — 현재 사용 사례에서 필요성 낮음
+- 상세 에이전트 프롬프트 (100+줄) — 컨텍스트 예산 비효율, 스킬 위임으로 동등 성능 달성
 
 > 상세 리서치 문서: [.hxsk/research/INDEX.md](.hxsk/research/INDEX.md)
 

--- a/docs/plans/2026-03-26-dispatcher-v2-design.md
+++ b/docs/plans/2026-03-26-dispatcher-v2-design.md
@@ -1,0 +1,263 @@
+# Dispatcher v2: 로컬 마크다운 이슈 트래킹 기반 병렬 오케스트레이션
+
+> Date: 2026-03-26
+> Status: DRAFT
+> Scope: `.hxsk/skills/dispatcher/` 개선 + 신규 템플릿/스크립트
+
+## Background
+
+기존 dispatcher 스킬은 Wave 기반 병렬 실행 + 워크트리 격리를 지원하지만, 진행상황 추적이 부재하고 이슈 레지스트리(L0→L1→L2)가 불필요하게 복잡하다. GitHub Issues 없이 로컬 마크다운으로 동일한 협업 워크플로우를 구현한다.
+
+## Core Concept
+
+**로컬 마크다운 이슈 트래킹**이 핵심. 오케스트레이터가 단일 쓰기 주체로 이슈 문서를 관리하고, 서브에이전트는 `git worktree list`로 메인 루트를 resolve하여 읽기 전용으로 참조한다.
+
+## Document Structure
+
+```
+.hxsk/issues/
+├── MASTER-{id}.md          # 마스터플랜 (전체 진행상황)
+├── WORK-{id}-{seq}.md      # 분할된 Work 단위
+└── archive/                # 완료된 이슈 아카이브
+```
+
+> **gitignore 정책**: `.hxsk/issues/*.md`를 `.gitignore`에 추가하여 untracked로 유지한다.
+> 기존 `!.hxsk/issues/` 규칙은 `.gitkeep`만 tracked되도록 조정.
+> 이유: 워크트리에서 stale 복사본이 보이는 문제를 방지하고,
+> 서브에이전트가 항상 메인 루트의 최신 문서를 참조하도록 보장.
+
+### MASTER Document
+
+```yaml
+---
+id: MASTER-{id}
+title: "{마스터플랜 제목}"
+branch: feat/master-{id}
+status: draft | in-progress | review | done
+works: [WORK-{id}-1, WORK-{id}-2, ...]
+wave_plan:
+  wave-1: [WORK-{id}-1, WORK-{id}-2]
+  wave-2: [WORK-{id}-3]
+created: {YYYY-MM-DD}
+---
+
+## Objective
+{PLAN.md 또는 SPEC.md에서 도출된 목표}
+
+## Progress
+- [ ] Wave 1 (0/2)
+- [ ] Wave 2 (0/1)
+
+## Merge Log
+{각 Work 머지 결과 기록}
+
+## Notes
+{충돌 해결, 의사결정 등}
+```
+
+### WORK Document
+
+```yaml
+---
+id: WORK-{id}-{seq}
+master: MASTER-{id}
+title: "{Work 단위 제목}"
+status: pending | in-progress | done | failed
+wave: {N}
+depends_on: [WORK-{id}-{seq}, ...]   # 의존성 명시 (같은 MASTER 내만 참조)
+files: [path/to/file1, path/to/file2]  # 수정 대상 파일
+side_effect_files: []                   # 자동 생성 가능 파일 (lock, barrel export 등)
+worktree: ""                            # 실행 시 경로 기록
+worktree_branch: ""                     # 워크트리 브랜치명 기록
+---
+
+## Tasks
+1. [ ] {순차 실행할 Task 1}
+2. [ ] {순차 실행할 Task 2}
+3. [ ] {순차 실행할 Task 3}
+
+## Result
+{완료 후 오케스트레이터가 기록: 커밋 해시, 변경 요약}
+
+## Failure Log
+{실패 시 오케스트레이터가 기록: 사유, 시도 횟수}
+```
+
+## Orchestration Lifecycle
+
+### Phase 구조
+
+Phase 1 (SPLIT)과 Phase 2 (BRANCH)는 1회 실행.
+Phase 3-5는 **Wave별 루프**로 실행. Phase 6은 전체 완료 후 1회 실행.
+
+```
+Phase 1: SPLIT
+Phase 2: BRANCH
+┌─── Wave Loop ───────────────────┐
+│  Phase 3: DISPATCH (Wave N)     │
+│  Phase 4: TRACK (Wave N)        │
+│  Phase 5: MERGE (Wave N)        │
+│  → Wave N+1이 있으면 루프 반복   │
+└─────────────────────────────────┘
+Phase 6: VERIFY → CLOSE
+```
+
+> **핵심**: Wave N+1의 워크트리는 Wave N 머지 완료 후 이슈 브랜치에서 생성한다.
+> 이렇게 해야 Wave N+1 서브에이전트가 Wave N의 변경사항을 기반으로 작업한다.
+
+### Phase 1: PLAN → SPLIT
+- PLAN.md 또는 SPEC.md를 읽고 Work 단위로 분할
+- MASTER-{id}.md 생성, WORK-{id}-{seq}.md 일괄 생성
+- 파일 소유권 검증:
+  - `files`와 `side_effect_files` 모두 포함하여 겹침 체크
+  - 같은 Wave 내 겹침 → 에러, Wave 분리 필요
+  - 다른 Wave 간 겹침 → depends_on에 선행 Work 명시 필요
+- depends_on 기반 Wave 자동 배정 (위상 정렬):
+  1. 모든 WORK의 depends_on 그래프 구성
+  2. **순환 의존성 감지** → 발견 시 에러, 사용자에게 분할 재요청
+  3. depends_on이 비어있으면 → Wave 1
+  4. 복수 의존성: `max(선행 Work들의 Wave) + 1`로 배정
+  5. 위상 정렬 순서대로 처리 (미할당 선행 Work 문제 방지)
+
+### Phase 2: BRANCH
+- 메인 이슈 브랜치 생성: `git checkout -b feat/master-{id}`
+- MASTER 문서에 branch 필드 기록
+
+### Phase 3: DISPATCH (Wave별)
+- 현재 Wave의 Work들만 실행
+- 각 Work → `Agent(isolation: "worktree")` 생성
+  - 워크트리 브랜치명: `feat/master-{id}/work-{seq}`
+- 동일 Wave 내 Work은 `run_in_background: true`로 병렬
+- 서브에이전트 프롬프트에 WORK 문서 경로 + 메인 루트 resolve 방법 주입
+- WORK 문서에 worktree 경로 및 worktree_branch 기록
+
+### Phase 4: TRACK (Wave별)
+- 각 Work 완료 시 WORK 문서 status 업데이트
+- MASTER 문서 Progress 섹션 갱신
+- 실패 시 status: failed + Failure Log 기록, 3-Strike Rule 적용
+- Wave 내 모든 Work 완료 확인 후 Phase 5로 이행
+
+### Phase 5: MERGE (Wave별)
+- 완료된 워크트리를 메인 이슈 브랜치에 순차 머지
+- `scripts/merge-worktrees.sh` 활용 (기존 스크립트 재사용)
+- **워크트리 보존**: 머지 후 즉시 삭제하지 않고 Phase 6 검증 통과까지 유지
+- 충돌 발생 시 MASTER 문서 Notes에 기록 + 오케스트레이터가 해결
+- MASTER 문서 Merge Log에 결과 기록
+- → 다음 Wave가 있으면 Phase 3로 복귀 (이슈 브랜치 기반으로 새 워크트리 생성)
+
+### Phase 6: VERIFY → CLOSE
+- 메인 이슈 브랜치에서 통합 테스트 실행
+- 검증 실패 시 → 워크트리가 보존되어 있으므로 디버깅/롤백 가능
+- 검증 통과 후 → 워크트리 정리, MASTER 문서 status: done
+- 완료 이슈를 `archive/`로 이동
+- 마스터 머지는 사용자 확인 후 진행
+
+## Crash Recovery Protocol
+
+오케스트레이터가 중단된 경우 재개 절차:
+
+1. `.hxsk/issues/MASTER-*.md`에서 status: in-progress인 문서 검색
+2. 해당 MASTER의 WORK 문서들의 status 확인
+3. status: in-progress인 WORK에 대해:
+   - `git worktree list`로 워크트리 존재 확인
+   - 존재하면 → `git log --oneline`으로 커밋 확인하여 실제 완료 여부 판단
+   - 존재하지 않으면 → status: failed로 갱신, 재실행 대상
+4. 미완료 Wave부터 Phase 3 루프 재개
+
+## Subagent Interface
+
+### Prompt Injection Template
+```
+You are executing {WORK_ID}.
+Main root: resolve via `git worktree list | head -1 | awk '{print $1}'`
+Read your work spec: {main_root}/.hxsk/issues/{WORK_ID}.md
+
+Rules:
+- Tasks 섹션의 체크리스트를 순차 수행
+- files 필드에 명시된 파일만 수정 (side_effect_files는 허용)
+- 각 Task마다 atomic commit
+- 커밋 메시지 형식: feat({WORK_ID}): {내용}
+- files + side_effect_files 범위 밖 파일 수정 금지
+- 완료/실패 시 exit
+```
+
+### Main Root Resolve (범용)
+```bash
+MAIN_ROOT=$(git worktree list | head -1 | awk '{print $1}')
+```
+어떤 프로젝트/머신에서든 별도 설정 없이 동작.
+
+### Orchestrator Status Detection
+- Agent 도구의 반환값으로 성공/실패 판단
+- 워크트리의 `git log --oneline`으로 실제 커밋 확인
+- WORK 문서 status를 done 또는 failed로 업데이트
+
+## File Ownership Validation
+
+```
+Phase 1에서 수행:
+1. 모든 WORK 문서의 files + side_effect_files 필드 추출
+2. 같은 Wave 내 겹침 → 에러, Wave 분리 필요
+3. 다른 Wave 간 겹침 → depends_on에 선행 Work 명시 필요
+4. side_effect_files 간 겹침도 동일 규칙 적용
+```
+
+## Integration with Existing System
+
+### 변경 파일
+| 파일 | 변경 유형 |
+|------|-----------|
+| `.hxsk/skills/dispatcher/SKILL.md` | 확장: 4-Phase → 6-Phase (Wave 루프) |
+| `.hxsk/agents/dispatcher.md` | 업데이트: 오케스트레이션 단계 + allowed-tools 정합성 |
+| `.hxsk/templates/MASTER-ISSUE.md` | 신규 |
+| `.hxsk/templates/WORK-ISSUE.md` | 신규 |
+| `scripts/issue-create.sh` | 업데이트: MASTER/WORK 스키마 호환 |
+| `scripts/issue-list.sh` | 업데이트: MASTER/WORK 문서 목록 표시 |
+| `.gitignore` | 수정: `.hxsk/issues/*.md` untracked 추가 |
+
+### 유지
+- Wave 기반 실행 모델
+- `Agent(isolation: "worktree")` 패턴
+- `scripts/merge-worktrees.sh` 재사용
+- 기존 파일 소유권 검증 로직 (side_effect_files로 강화)
+
+### 제거
+- 이슈 레지스트리 Lazy loading (L0→L1→L2) → WORK 문서로 단순화
+- 기존과 중복되는 상태 추적 방식
+
+### 역할 분리: 스크립트 vs AI 에이전트
+| 역할 | 담당 |
+|------|------|
+| MASTER/WORK 템플릿 생성 | 스크립트 (`issue-create.sh`) |
+| PLAN → Work 분할, 의존성 분석, 파일 배정 | AI 에이전트 (오케스트레이터) |
+| 위상 정렬, 순환 의존성 감지 | AI 에이전트 (오케스트레이터) |
+| 파일 소유권 검증 | 스크립트 (기존 로직 강화) |
+
+> `split-plan.sh`는 신규 생성하지 않는다. PLAN.md의 XML task 블록 파싱은
+> 순수 bash로 신뢰성이 낮으므로, AI 에이전트가 직접 분할하고
+> `issue-create.sh`로 문서를 생성하는 구조로 한다.
+
+## Research References
+
+| 프로젝트 | 참고 포인트 |
+|----------|------------|
+| [ccswarm](https://github.com/nwiizo/ccswarm) | 멀티 에이전트 오케스트레이션, 워크트리 격리 |
+| [parallel-worktrees](https://github.com/spillwavesolutions/parallel-worktrees) | Claude Code 스킬 기반 병렬 워크트리 |
+| [Backlog.md](https://github.com/MrLesk/Backlog.md) | 마크다운 기반 이슈 트래킹 |
+| [tick-md](https://purplehorizons.io/blog/tick-md-multi-agent-coordination-markdown) | 마크다운 기반 멀티 에이전트 조율 |
+| [Clash](https://github.com/clash-sh/clash) | 워크트리 간 머지 충돌 사전 감지 |
+
+## Design Decisions
+
+| 결정 | 선택 | 이유 |
+|------|------|------|
+| 이슈 문서 쓰기 주체 | 오케스트레이터 단독 | 머지 충돌 방지, 단일 진실 소스 |
+| 메인 루트 resolve | `git worktree list` | 범용적, 외부 종속성 없음 |
+| 실행 모델 | Wave 유지 + 의존성 문서화 | 검증된 패턴 + 추적성 |
+| 기존 dispatcher 관계 | in-place 개선 | 중복 기능/혼란 방지 |
+| 이슈 저장 위치 | `.hxsk/issues/` (git-untracked) | 워크트리 stale 복사본 방지, 절대경로 참조 |
+| Phase 3-5 구조 | Wave별 루프 | Wave N+1이 Wave N 결과 기반으로 동작 보장 |
+| 워크트리 보존 | Phase 6 검증 후 정리 | 검증 실패 시 롤백/디버깅 경로 확보 |
+| split-plan.sh | 생성하지 않음 | bash XML 파싱 비현실적, AI 에이전트 직접 분할 |
+| 의존성 해석 | 위상 정렬 + 순환 감지 | 다중 의존성, 다이아몬드 의존성 안전 처리 |
+| side_effect_files | WORK 문서에 명시 | lock 파일, barrel export 등 간접 충돌 방지 |

--- a/docs/plans/2026-03-26-dispatcher-v2-impl.md
+++ b/docs/plans/2026-03-26-dispatcher-v2-impl.md
@@ -1,0 +1,307 @@
+---
+phase: 1
+plan: 1
+wave: 1
+gap_closure: false
+---
+
+# Plan 1.1: Dispatcher v2 — 로컬 마크다운 이슈 트래킹 기반 병렬 오케스트레이션 구현
+
+## Objective
+
+기존 dispatcher 스킬을 확장하여 로컬 마크다운 이슈 트래킹(MASTER/WORK 문서)을 핵심으로 하는 6-Phase 오케스트레이션 라이프사이클을 구현한다. 설계 문서: `docs/plans/2026-03-26-dispatcher-v2-design.md`
+
+## Context
+Load these files for context:
+- docs/plans/2026-03-26-dispatcher-v2-design.md
+- .hxsk/skills/dispatcher/SKILL.md
+- .hxsk/agents/dispatcher.md
+- scripts/issue-create.sh
+- scripts/issue-list.sh
+- scripts/merge-worktrees.sh
+- .gitignore
+
+## Tasks
+
+### Wave 1: 기반 인프라 (템플릿 + 스크립트 + gitignore)
+
+<task type="auto">
+  <name>MASTER/WORK 이슈 템플릿 생성</name>
+  <files>
+    .hxsk/templates/MASTER-ISSUE.md
+    .hxsk/templates/WORK-ISSUE.md
+  </files>
+  <action>
+    설계 문서의 MASTER Document, WORK Document 스키마를 템플릿으로 작성.
+
+    Steps:
+    1. MASTER-ISSUE.md 템플릿 생성 (frontmatter: id, title, branch, status, works, wave_plan, created / body: Objective, Progress, Merge Log, Notes)
+    2. WORK-ISSUE.md 템플릿 생성 (frontmatter: id, master, title, status, wave, depends_on, files, side_effect_files, worktree, worktree_branch / body: Tasks, Result, Failure Log)
+
+    AVOID: 템플릿에 예시 값을 하드코딩하지 않음. 플레이스홀더 `{...}` 사용
+    USE: 기존 `.hxsk/templates/` 내 다른 템플릿의 포맷 컨벤션 참조
+  </action>
+  <verify>
+    # 파일 존재 확인
+    test -f .hxsk/templates/MASTER-ISSUE.md && test -f .hxsk/templates/WORK-ISSUE.md && echo "PASS"
+    # frontmatter 필수 필드 확인
+    grep -q "wave_plan:" .hxsk/templates/MASTER-ISSUE.md && grep -q "depends_on:" .hxsk/templates/WORK-ISSUE.md && echo "FIELDS OK"
+  </verify>
+  <done>
+    두 템플릿 파일이 존재하고, 설계 문서의 모든 frontmatter 필드와 body 섹션을 포함
+  </done>
+</task>
+
+<task type="auto">
+  <name>issue-create.sh MASTER/WORK 모드 추가</name>
+  <files>
+    scripts/issue-create.sh
+  </files>
+  <action>
+    기존 issue-create.sh를 확장하여 MASTER/WORK 문서 생성을 지원.
+
+    Steps:
+    1. 첫 번째 인자로 모드 분기: `master`, `work`, 또는 기존 모드 (하위 호환)
+    2. `master` 모드: `bash scripts/issue-create.sh master <title>` → MASTER-{id}.md 생성
+       - id: 기존 MASTER-*.md 중 최대 번호 + 1 (3자리 패딩)
+       - 파일명: MASTER-{id}.md
+       - 템플릿 기반으로 frontmatter 채우기
+    3. `work` 모드: `bash scripts/issue-create.sh work <master-id> <title> <wave> [depends_on] [files]`
+       - id: WORK-{master-id}-{seq}
+       - 파일명: WORK-{master-id}-{seq}.md
+       - seq: 해당 master의 기존 WORK 중 최대 seq + 1
+    4. 기존 인자 패턴(title, type, priority)은 레거시 모드로 유지
+
+    AVOID: 기존 기능 깨뜨리지 않음. 첫 인자가 master/work가 아니면 기존 로직 실행
+    USE: 기존 ISSUES_DIR 변수, 기존 타임스탬프 생성 패턴 재사용
+  </action>
+  <verify>
+    # MASTER 생성 테스트
+    bash scripts/issue-create.sh master "테스트 마스터플랜" 2>/dev/null
+    test -f .hxsk/issues/MASTER-001.md && echo "MASTER OK"
+    # WORK 생성 테스트
+    bash scripts/issue-create.sh work 001 "테스트 워크" 1 "" "src/test.ts" 2>/dev/null
+    test -f .hxsk/issues/WORK-001-1.md && echo "WORK OK"
+    # 레거시 모드 테스트
+    bash scripts/issue-create.sh "레거시 이슈" task P2 2>/dev/null | grep -q "CREATED" && echo "LEGACY OK"
+    # 정리
+    rm -f .hxsk/issues/MASTER-001.md .hxsk/issues/WORK-001-1.md .hxsk/issues/001-*.md
+  </verify>
+  <done>
+    master/work/legacy 3가지 모드 모두 정상 동작. 기존 스크립트 하위 호환 유지.
+  </done>
+</task>
+
+<task type="auto">
+  <name>issue-list.sh MASTER/WORK 출력 지원</name>
+  <files>
+    scripts/issue-list.sh
+  </files>
+  <action>
+    issue-list.sh를 확장하여 MASTER/WORK 문서를 구분 표시.
+
+    Steps:
+    1. MASTER-*.md와 WORK-*.md 파일을 별도로 감지
+    2. MASTER 문서: ID, STATUS, TITLE, WORKS 수, 현재 WAVE 표시
+    3. WORK 문서: ID, MASTER, STATUS, WAVE, DEPENDS_ON, TITLE 표시
+    4. 기존 형식(숫자-slug.md)은 레거시로 표시
+    5. 필터 옵션: `bash scripts/issue-list.sh [master|work|all] [status]`
+
+    AVOID: 기존 출력 형식을 완전히 깨뜨리지 않음
+    USE: 기존 frontmatter 파싱 로직 재사용
+  </action>
+  <verify>
+    # MASTER/WORK 생성 후 목록 확인
+    bash scripts/issue-create.sh master "테스트" 2>/dev/null
+    bash scripts/issue-create.sh work 001 "워크1" 1 2>/dev/null
+    bash scripts/issue-list.sh master | grep -q "MASTER" && echo "MASTER LIST OK"
+    bash scripts/issue-list.sh work | grep -q "WORK" && echo "WORK LIST OK"
+    rm -f .hxsk/issues/MASTER-001.md .hxsk/issues/WORK-001-1.md
+  </verify>
+  <done>
+    master/work/all 필터가 동작하고, 각 문서 타입에 맞는 컬럼 출력
+  </done>
+</task>
+
+<task type="auto">
+  <name>.gitignore 이슈 문서 untracked 정책 반영</name>
+  <files>
+    .gitignore
+  </files>
+  <action>
+    .hxsk/issues/ 내 MASTER/WORK 마크다운 파일을 git-untracked로 설정.
+
+    Steps:
+    1. 기존 `!.hxsk/issues/` 규칙 유지 (디렉토리 자체는 tracked)
+    2. `.hxsk/issues/MASTER-*.md` 와 `.hxsk/issues/WORK-*.md` 를 ignore 추가
+    3. `.hxsk/issues/archive/` 도 ignore 추가
+    4. `.hxsk/issues/.gitkeep`은 tracked 유지
+
+    AVOID: 기존 레거시 이슈 파일(숫자-slug.md)의 tracking 상태를 변경하지 않음
+    USE: 기존 gitignore 패턴 스타일과 일관된 주석 사용
+  </action>
+  <verify>
+    echo "test" > .hxsk/issues/MASTER-999.md
+    git check-ignore .hxsk/issues/MASTER-999.md && echo "IGNORED OK"
+    git check-ignore .hxsk/issues/.gitkeep || echo "GITKEEP TRACKED OK"
+    rm -f .hxsk/issues/MASTER-999.md
+  </verify>
+  <done>
+    MASTER-*.md, WORK-*.md는 git-ignored. .gitkeep은 tracked. 기존 규칙 미파괴.
+  </done>
+</task>
+
+### Wave 2: dispatcher 스킬 + 에이전트 업데이트
+
+<task type="auto">
+  <name>dispatcher SKILL.md 6-Phase 리라이트</name>
+  <files>
+    .hxsk/skills/dispatcher/SKILL.md
+  </files>
+  <action>
+    기존 4-Phase 구조를 설계 문서의 6-Phase Wave 루프 구조로 리라이트.
+
+    Steps:
+    1. frontmatter 업데이트:
+       - description 갱신 (MASTER/WORK 기반 명시)
+       - version 2.0.0으로 범프
+       - trigger에 "이슈 분할, work split, parallel issue, 마스터플랜" 추가
+       - allowed-tools에 Write 추가 (이슈 문서 생성/업데이트용)
+    2. Quick Reference 갱신:
+       - 입력: PLAN.md/SPEC.md → MASTER/WORK 문서
+       - 출력: 6-Phase 라이프사이클
+       - Main Root Resolve: `git worktree list | head -1 | awk '{print $1}'`
+    3. Dispatch Protocol 리라이트:
+       - Phase 1 (SPLIT): PLAN/SPEC → MASTER/WORK 분할, 위상 정렬, 파일 소유권 검증
+       - Phase 2 (BRANCH): 이슈 브랜치 생성
+       - Phase 3-5 Wave 루프: DISPATCH → TRACK → MERGE (설계 문서의 루프 다이어그램 포함)
+       - Phase 6 (VERIFY → CLOSE): 통합 테스트, 아카이브, 워크트리 정리
+    4. Subagent Interface 섹션 추가: 프롬프트 주입 템플릿, 서브에이전트 규약
+    5. Crash Recovery Protocol 섹션 추가
+    6. 기존 Issue Lazy Loading (L0/L1/L2) 섹션 제거
+    7. Dispatch Rules 유지 + side_effect_files 규칙 추가
+
+    AVOID: 기존 검증된 Wave 실행 패턴의 핵심 로직(Agent isolation, run_in_background)을 변경하지 않음
+    USE: 설계 문서의 정확한 Phase 설명 및 다이어그램 사용
+  </action>
+  <verify>
+    # 필수 섹션 존재 확인
+    grep -q "Phase 1: SPLIT" .hxsk/skills/dispatcher/SKILL.md && echo "P1 OK"
+    grep -q "Phase 2: BRANCH" .hxsk/skills/dispatcher/SKILL.md && echo "P2 OK"
+    grep -q "Phase 3: DISPATCH" .hxsk/skills/dispatcher/SKILL.md && echo "P3 OK"
+    grep -q "Phase 4: TRACK" .hxsk/skills/dispatcher/SKILL.md && echo "P4 OK"
+    grep -q "Phase 5: MERGE" .hxsk/skills/dispatcher/SKILL.md && echo "P5 OK"
+    grep -q "Phase 6: VERIFY" .hxsk/skills/dispatcher/SKILL.md && echo "P6 OK"
+    grep -q "Crash Recovery" .hxsk/skills/dispatcher/SKILL.md && echo "RECOVERY OK"
+    grep -q "version: 2.0.0" .hxsk/skills/dispatcher/SKILL.md && echo "VERSION OK"
+    # Lazy Loading 제거 확인
+    ! grep -q "L0.*L1.*L2" .hxsk/skills/dispatcher/SKILL.md && echo "LAZY REMOVED OK"
+  </verify>
+  <done>
+    6-Phase Wave 루프 구조로 전환 완료. Lazy Loading 제거. version 2.0.0.
+    설계 문서의 모든 Phase, Subagent Interface, Crash Recovery 반영.
+  </done>
+</task>
+
+<task type="auto">
+  <name>dispatcher.md 에이전트 정의 업데이트</name>
+  <files>
+    .hxsk/agents/dispatcher.md
+  </files>
+  <action>
+    에이전트 정의를 6-Phase에 맞춰 업데이트하고, tools 정합성 문제 해소.
+
+    Steps:
+    1. description 갱신: "MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이터"
+    2. tools에 Write 명시 (SKILL.md의 allowed-tools와 일치)
+    3. 오케스트레이션 단계를 6-Phase로 업데이트:
+       1. PLAN/SPEC에서 MASTER/WORK 문서 생성 (issue-create.sh 활용)
+       2. 이슈 브랜치 생성 및 파일 소유권 검증
+       3. Wave별 루프: DISPATCH → TRACK → MERGE
+       4. 통합 테스트, 아카이브, 사용자 승인 후 마스터 머지
+    4. Key constraints 업데이트:
+       - 오케스트레이터만 이슈 문서 쓰기
+       - side_effect_files 포함 소유권 검증
+       - 워크트리 보존 정책 (Phase 6 후 정리)
+
+    AVOID: model: opus 변경 없음 (복잡한 오케스트레이션이므로 유지)
+    USE: 기존 Agent Boundaries 섹션 유지
+  </action>
+  <verify>
+    grep -q "6-Phase" .hxsk/agents/dispatcher.md && echo "PHASE OK"
+    grep -q '"Write"' .hxsk/agents/dispatcher.md && echo "TOOLS OK"
+    grep -q "MASTER/WORK" .hxsk/agents/dispatcher.md && echo "SCHEMA OK"
+  </verify>
+  <done>
+    에이전트 정의가 SKILL.md와 일관된 6-Phase 구조. tools 목록 정합.
+  </done>
+</task>
+
+### Wave 3: 통합 검증
+
+<task type="auto">
+  <name>End-to-End 드라이런 검증</name>
+  <files>
+    .hxsk/issues/
+    scripts/issue-create.sh
+    scripts/issue-list.sh
+  </files>
+  <action>
+    실제 MASTER/WORK 문서 생성 → 목록 조회 → 정리까지 전체 흐름 검증.
+
+    Steps:
+    1. MASTER 생성: `bash scripts/issue-create.sh master "드라이런 테스트"`
+    2. WORK 3개 생성:
+       - Wave 1: WORK-001-1 (files: scripts/test1.sh), WORK-001-2 (files: scripts/test2.sh)
+       - Wave 2: WORK-001-3 (depends_on: WORK-001-1, files: scripts/test3.sh)
+    3. issue-list.sh로 목록 확인: master/work 필터 동작
+    4. gitignore 검증: `git check-ignore` 으로 MASTER/WORK 파일 ignored 확인
+    5. 메인 루트 resolve 검증: `git worktree list | head -1 | awk '{print $1}'` 정상 동작
+    6. 테스트 파일 정리
+
+    AVOID: 실제 워크트리 생성이나 브랜치 생성은 하지 않음 (드라이런)
+    USE: 스크립트의 실제 출력으로 검증
+  </action>
+  <verify>
+    # 정리 확인
+    ! ls .hxsk/issues/MASTER-001.md 2>/dev/null && echo "CLEANUP OK"
+  </verify>
+  <done>
+    MASTER/WORK 생성→조회→gitignore 검증→정리 전체 흐름 성공.
+    스크립트 간 데이터 일관성 확인 완료.
+  </done>
+</task>
+
+<task type="checkpoint:human-verify">
+  <name>SKILL.md + Agent 정의 리뷰</name>
+  <files>
+    .hxsk/skills/dispatcher/SKILL.md
+    .hxsk/agents/dispatcher.md
+  </files>
+  <action>
+    리라이트된 dispatcher SKILL.md와 agent 정의를 사용자가 리뷰.
+    설계 문서와의 일관성, 기존 기능과의 하위 호환성 확인.
+  </action>
+  <verify>
+    사용자 승인
+  </verify>
+  <done>
+    사용자가 SKILL.md와 agent 정의를 승인
+  </done>
+</task>
+
+## Must-Haves
+After all tasks complete, verify:
+- [ ] MASTER/WORK 템플릿이 설계 문서의 스키마와 100% 일치
+- [ ] issue-create.sh가 master/work/legacy 3모드 모두 정상 동작
+- [ ] issue-list.sh가 MASTER/WORK 문서를 구분 표시
+- [ ] .gitignore가 MASTER-*.md, WORK-*.md를 untracked 처리
+- [ ] dispatcher SKILL.md가 6-Phase Wave 루프 구조
+- [ ] dispatcher.md 에이전트의 tools가 SKILL.md allowed-tools와 일치
+- [ ] 기존 레거시 이슈 기능 하위 호환
+
+## Success Criteria
+- [ ] All tasks verified passing
+- [ ] Must-haves confirmed
+- [ ] 드라이런 E2E 통과
+- [ ] 사용자 리뷰 승인

--- a/scripts/issue-create.sh
+++ b/scripts/issue-create.sh
@@ -1,19 +1,139 @@
 #!/usr/bin/env bash
 # issue-create.sh — 이슈 생성 (파일 기반)
-# Usage: bash scripts/issue-create.sh <title> <type> <priority> [description]
+# Usage:
+#   bash scripts/issue-create.sh master <title>
+#   bash scripts/issue-create.sh work <master-id> <title> <wave> [depends_on] [files] [side_effect_files]
+#   bash scripts/issue-create.sh <title> <type> <priority> [description]  (레거시)
 set -euo pipefail
 
 ISSUES_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk/issues"
 mkdir -p "$ISSUES_DIR"
+mkdir -p "$ISSUES_DIR/archive"
 
-TITLE="${1:?Usage: issue-create.sh <title> <type> <priority> [description]}"
+MODE="${1:?Usage: issue-create.sh master|work|<title> ...}"
+TIMESTAMP=$(date '+%Y-%m-%d')
+
+# --- MASTER 모드 ---
+if [ "$MODE" = "master" ]; then
+    TITLE="${2:?Usage: issue-create.sh master <title>}"
+
+    # 다음 MASTER 번호
+    LAST_NUM=$(find "$ISSUES_DIR" -maxdepth 1 -name 'MASTER-*.md' 2>/dev/null \
+        | sed 's|.*/MASTER-||; s|\.md$||' | sort -n | tail -1)
+    NEXT_NUM=$(printf "%03d" $(( ${LAST_NUM:-0} + 1 )))
+
+    FILENAME="MASTER-${NEXT_NUM}.md"
+
+    cat > "$ISSUES_DIR/$FILENAME" << EOF
+---
+id: MASTER-${NEXT_NUM}
+title: "${TITLE}"
+branch: feat/master-${NEXT_NUM}
+status: draft
+works: []
+wave_plan:
+  wave-1: []
+created: ${TIMESTAMP}
+---
+
+## Objective
+${TITLE}
+
+## Progress
+- [ ] Wave 1 (0/0)
+
+## Merge Log
+
+## Notes
+EOF
+
+    echo "[CREATED] $ISSUES_DIR/$FILENAME"
+    exit 0
+fi
+
+# --- WORK 모드 ---
+if [ "$MODE" = "work" ]; then
+    MASTER_ID="${2:?Usage: issue-create.sh work <master-id> <title> <wave> [depends_on] [files] [side_effect_files]}"
+    TITLE="${3:?Usage: issue-create.sh work <master-id> <title> <wave> ...}"
+    WAVE="${4:-1}"
+    DEPENDS_ON="${5:-}"
+    FILES="${6:-}"
+    SIDE_EFFECT_FILES="${7:-}"
+
+    # MASTER 존재 확인
+    if [ ! -f "$ISSUES_DIR/MASTER-${MASTER_ID}.md" ]; then
+        echo "[FAIL] MASTER-${MASTER_ID}.md not found in $ISSUES_DIR"
+        exit 1
+    fi
+
+    # 다음 WORK seq 번호
+    LAST_SEQ=$(find "$ISSUES_DIR" -maxdepth 1 -name "WORK-${MASTER_ID}-*.md" 2>/dev/null \
+        | sed "s|.*/WORK-${MASTER_ID}-||; s|\.md$||" | sort -n | tail -1)
+    NEXT_SEQ=$(( ${LAST_SEQ:-0} + 1 ))
+
+    FILENAME="WORK-${MASTER_ID}-${NEXT_SEQ}.md"
+
+    # depends_on 포맷: 쉼표 구분 → YAML 배열
+    if [ -n "$DEPENDS_ON" ]; then
+        DEPENDS_YAML=$(echo "$DEPENDS_ON" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | awk '{printf "  - %s\n", $0}')
+        DEPENDS_BLOCK="depends_on:
+${DEPENDS_YAML}"
+    else
+        DEPENDS_BLOCK="depends_on: []"
+    fi
+
+    # files 포맷: 쉼표 구분 → YAML 배열
+    if [ -n "$FILES" ]; then
+        FILES_YAML=$(echo "$FILES" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | awk '{printf "  - %s\n", $0}')
+        FILES_BLOCK="files:
+${FILES_YAML}"
+    else
+        FILES_BLOCK="files: []"
+    fi
+
+    # side_effect_files 포맷
+    if [ -n "$SIDE_EFFECT_FILES" ]; then
+        SE_YAML=$(echo "$SIDE_EFFECT_FILES" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | awk '{printf "  - %s\n", $0}')
+        SE_BLOCK="side_effect_files:
+${SE_YAML}"
+    else
+        SE_BLOCK="side_effect_files: []"
+    fi
+
+    cat > "$ISSUES_DIR/$FILENAME" << EOF
+---
+id: WORK-${MASTER_ID}-${NEXT_SEQ}
+master: MASTER-${MASTER_ID}
+title: "${TITLE}"
+status: pending
+wave: ${WAVE}
+${DEPENDS_BLOCK}
+${FILES_BLOCK}
+${SE_BLOCK}
+worktree: ""
+worktree_branch: ""
+---
+
+## Tasks
+1. [ ] <!-- Task 1 -->
+
+## Result
+
+## Failure Log
+EOF
+
+    echo "[CREATED] $ISSUES_DIR/$FILENAME"
+    exit 0
+fi
+
+# --- 레거시 모드 ---
+TITLE="$MODE"
 TYPE="${2:-task}"
 PRIORITY="${3:-P2}"
 DESCRIPTION="${4:-}"
-TIMESTAMP=$(date '+%Y-%m-%d')
 
-# 다음 이슈 번호
-LAST_NUM=$(find "$ISSUES_DIR" -maxdepth 1 -name '*.md' 2>/dev/null \
+# 다음 이슈 번호 (레거시: MASTER/WORK 제외)
+LAST_NUM=$(find "$ISSUES_DIR" -maxdepth 1 -name '[0-9]*.md' 2>/dev/null \
     | sed 's|.*/||; s|-.*||' | sort -n | tail -1)
 NEXT_NUM=$(printf "%03d" $(( ${LAST_NUM:-0} + 1 )))
 

--- a/scripts/issue-list.sh
+++ b/scripts/issue-list.sh
@@ -1,39 +1,137 @@
 #!/usr/bin/env bash
-# issue-list.sh — 이슈 목록 (L0: frontmatter만)
-# Usage: bash scripts/issue-list.sh [status] [priority]
+# issue-list.sh — 이슈 목록 (MASTER/WORK/레거시 지원)
+# Usage: bash scripts/issue-list.sh [master|work|all] [status]
 set -euo pipefail
 
 ISSUES_DIR="${CLAUDE_PROJECT_DIR:-.}/.hxsk/issues"
-STATUS_FILTER="${1:-}"
-PRIORITY_FILTER="${2:-}"
+MODE="${1:-all}"
+STATUS_FILTER="${2:-}"
 
-if [ ! -d "$ISSUES_DIR" ] || [ -z "$(find "$ISSUES_DIR" -maxdepth 1 -name '*.md' 2>/dev/null)" ]; then
-    echo "No issues found."
+if [ ! -d "$ISSUES_DIR" ]; then
+    echo "No issues directory found."
     exit 0
 fi
 
-printf "%-5s %-8s %-4s %-8s %-6s %s\n" "ID" "TYPE" "PRI" "STATUS" "WAVE" "TITLE"
-printf "%-5s %-8s %-4s %-8s %-6s %s\n" "-----" "--------" "----" "--------" "------" "----------------------------"
+# --- MASTER 목록 ---
+list_master() {
+    local has_files=false
+    for f in "$ISSUES_DIR"/MASTER-*.md; do
+        [ -f "$f" ] || continue
+        has_files=true
+        break
+    done
+    if ! $has_files; then
+        [ "$MODE" = "master" ] && echo "No MASTER issues found."
+        return
+    fi
 
-for f in "$ISSUES_DIR"/*.md; do
-    [ -f "$f" ] || continue
-    [ "$(basename "$f")" = ".gitkeep" ] && continue
+    printf "\n%-12s %-12s %-6s %s\n" "ID" "STATUS" "WORKS" "TITLE"
+    printf "%-12s %-12s %-6s %s\n" "------------" "------------" "------" "----------------------------"
 
-    ID=""; TYPE=""; PRI=""; STATUS=""; WAVE=""; TITLE=""
+    for f in "$ISSUES_DIR"/MASTER-*.md; do
+        [ -f "$f" ] || continue
 
-    while IFS= read -r line; do
-        case "$line" in
-            id:*) ID=$(echo "$line" | sed 's/^id: *//') ;;
-            type:*) TYPE=$(echo "$line" | sed 's/^type: *//') ;;
-            priority:*) PRI=$(echo "$line" | sed 's/^priority: *//') ;;
-            status:*) STATUS=$(echo "$line" | sed 's/^status: *//') ;;
-            wave:*) WAVE=$(echo "$line" | sed 's/^wave: *//') ;;
-            title:*) TITLE=$(echo "$line" | sed 's/^title: *//; s/^"//; s/"$//') ;;
-        esac
-    done < <(awk 'NR==1 && /^---/{in_fm=1; next} in_fm && /^---/{exit} in_fm{print}' "$f")
+        ID=""; STATUS=""; TITLE=""; WORKS_COUNT=0
 
-    [ -n "$STATUS_FILTER" ] && [ "$STATUS" != "$STATUS_FILTER" ] && continue
-    [ -n "$PRIORITY_FILTER" ] && [ "$PRI" != "$PRIORITY_FILTER" ] && continue
+        while IFS= read -r line; do
+            case "$line" in
+                id:*) ID=$(echo "$line" | sed 's/^id: *//') ;;
+                status:*) STATUS=$(echo "$line" | sed 's/^status: *//') ;;
+                title:*) TITLE=$(echo "$line" | sed 's/^title: *//; s/^"//; s/"$//') ;;
+                "  - WORK-"*) WORKS_COUNT=$(( WORKS_COUNT + 1 )) ;;
+            esac
+        done < <(awk 'NR==1 && /^---/{in_fm=1; next} in_fm && /^---/{exit} in_fm{print}' "$f")
 
-    printf "%-5s %-8s %-4s %-8s %-6s %s\n" "$ID" "$TYPE" "$PRI" "$STATUS" "${WAVE:-—}" "$TITLE"
-done
+        [ -n "$STATUS_FILTER" ] && [ "$STATUS" != "$STATUS_FILTER" ] && continue
+
+        printf "%-12s %-12s %-6s %s\n" "$ID" "$STATUS" "$WORKS_COUNT" "$TITLE"
+    done
+}
+
+# --- WORK 목록 ---
+list_work() {
+    local has_files=false
+    for f in "$ISSUES_DIR"/WORK-*.md; do
+        [ -f "$f" ] || continue
+        has_files=true
+        break
+    done
+    if ! $has_files; then
+        [ "$MODE" = "work" ] && echo "No WORK issues found."
+        return
+    fi
+
+    printf "\n%-16s %-12s %-12s %-6s %-20s %s\n" "ID" "MASTER" "STATUS" "WAVE" "DEPENDS_ON" "TITLE"
+    printf "%-16s %-12s %-12s %-6s %-20s %s\n" "----------------" "------------" "------------" "------" "--------------------" "----------------------------"
+
+    for f in "$ISSUES_DIR"/WORK-*.md; do
+        [ -f "$f" ] || continue
+
+        ID=""; MASTER=""; STATUS=""; WAVE=""; TITLE=""; DEPENDS=""
+
+        while IFS= read -r line; do
+            case "$line" in
+                id:*) ID=$(echo "$line" | sed 's/^id: *//') ;;
+                master:*) MASTER=$(echo "$line" | sed 's/^master: *//') ;;
+                status:*) STATUS=$(echo "$line" | sed 's/^status: *//') ;;
+                wave:*) WAVE=$(echo "$line" | sed 's/^wave: *//') ;;
+                title:*) TITLE=$(echo "$line" | sed 's/^title: *//; s/^"//; s/"$//') ;;
+                "  - WORK-"*) DEPENDS="${DEPENDS:+$DEPENDS,}$(echo "$line" | sed 's/^  - //')" ;;
+            esac
+        done < <(awk 'NR==1 && /^---/{in_fm=1; next} in_fm && /^---/{exit} in_fm{print}' "$f")
+
+        [ -n "$STATUS_FILTER" ] && [ "$STATUS" != "$STATUS_FILTER" ] && continue
+
+        printf "%-16s %-12s %-12s %-6s %-20s %s\n" "$ID" "$MASTER" "$STATUS" "${WAVE:-—}" "${DEPENDS:-—}" "$TITLE"
+    done
+}
+
+# --- 레거시 목록 ---
+list_legacy() {
+    local has_files=false
+    for f in "$ISSUES_DIR"/[0-9]*.md; do
+        [ -f "$f" ] || continue
+        has_files=true
+        break
+    done
+    if ! $has_files; then
+        return
+    fi
+
+    printf "\n%-5s %-8s %-4s %-8s %-6s %s\n" "ID" "TYPE" "PRI" "STATUS" "WAVE" "TITLE"
+    printf "%-5s %-8s %-4s %-8s %-6s %s\n" "-----" "--------" "----" "--------" "------" "----------------------------"
+
+    for f in "$ISSUES_DIR"/[0-9]*.md; do
+        [ -f "$f" ] || continue
+
+        ID=""; TYPE=""; PRI=""; STATUS=""; WAVE=""; TITLE=""
+
+        while IFS= read -r line; do
+            case "$line" in
+                id:*) ID=$(echo "$line" | sed 's/^id: *//') ;;
+                type:*) TYPE=$(echo "$line" | sed 's/^type: *//') ;;
+                priority:*) PRI=$(echo "$line" | sed 's/^priority: *//') ;;
+                status:*) STATUS=$(echo "$line" | sed 's/^status: *//') ;;
+                wave:*) WAVE=$(echo "$line" | sed 's/^wave: *//') ;;
+                title:*) TITLE=$(echo "$line" | sed 's/^title: *//; s/^"//; s/"$//') ;;
+            esac
+        done < <(awk 'NR==1 && /^---/{in_fm=1; next} in_fm && /^---/{exit} in_fm{print}' "$f")
+
+        [ -n "$STATUS_FILTER" ] && [ "$STATUS" != "$STATUS_FILTER" ] && continue
+
+        printf "%-5s %-8s %-4s %-8s %-6s %s\n" "$ID" "$TYPE" "$PRI" "$STATUS" "${WAVE:-—}" "$TITLE"
+    done
+}
+
+# --- 실행 ---
+case "$MODE" in
+    master) list_master ;;
+    work)   list_work ;;
+    all)    list_master; list_work; list_legacy ;;
+    *)
+        # 하위 호환: 첫 인자가 status 필터일 수 있음 (기존 사용법)
+        STATUS_FILTER="$MODE"
+        MODE="all"
+        list_master; list_work; list_legacy
+        ;;
+esac


### PR DESCRIPTION
## Summary
- MASTER/WORK 로컬 마크다운 이슈 트래킹 시스템 도입 (GitHub Issues 대체)
- dispatcher 스킬 4-Phase → 6-Phase Wave 루프 구조 개선 (v2.0.0)
- arch-review 스킬에 설계 문서 논리 검토 단계 추가
- 에이전트 간결 프롬프트 컨벤션 설계 근거 README에 명시

## Changes
| 파일 | 변경 |
|------|------|
| `.hxsk/skills/dispatcher/SKILL.md` | 6-Phase Wave 루프, Crash Recovery, Subagent Interface |
| `.hxsk/agents/dispatcher.md` | 6-Phase 동기화 + tools 정합 |
| `.hxsk/templates/MASTER-ISSUE.md` | 신규: 마스터플랜 템플릿 |
| `.hxsk/templates/WORK-ISSUE.md` | 신규: Work 단위 템플릿 |
| `scripts/issue-create.sh` | master/work/legacy 3모드 |
| `scripts/issue-list.sh` | master/work/all 필터 |
| `.gitignore` | MASTER-*.md, WORK-*.md untracked |
| `.hxsk/skills/arch-review/SKILL.md` | Step 3 설계 문서 검토 추가 |
| `README.md` | 에이전트 프롬프트 컨벤션 근거 |
| `docs/plans/` | 설계 문서 + 구현 계획 |

## Test plan
- [x] issue-create.sh: master/work/legacy 3모드 E2E 검증
- [x] issue-list.sh: master/work/all 필터 검증
- [x] gitignore: MASTER/WORK 파일 ignored, .gitkeep tracked
- [x] Main Root resolve: 워크트리에서 메인 루트 접근 확인
- [x] depends_on 복수 의존성 파싱 검증
- [x] SKILL.md 6-Phase 구조 + Lazy Loading 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)