### PR TITLE
docs: 문서 현행화 — dispatcher v2 반영 + 실전 테스트

### DIFF
--- a/.hxsk/STATE.md
+++ b/.hxsk/STATE.md
@@ -2,19 +2,20 @@
 
 ## Current Position
 
-**Milestone:** Self-Configure 전환 완료 + 안정화
-**Phase:** Complete
-**Status:** idle
+**Milestone:** Dispatcher v2 + 안정화
+**Phase:** Testing
+**Status:** active
 **Branch:** master
 
 ## Last Action
 
-E2E 검증 통과 (93/93 PASS). README 재구성, 워크트리 전수 정리, gitignore 빌드 산출물 추가, STATE.md 동기화.
+Dispatcher v2 구현 완료 (#75). MASTER/WORK 마크다운 이슈 트래킹, 6-Phase Wave 루프 오케스트레이션, arch-review 설계 문서 검토 단계 추가, 에이전트 간결 프롬프트 컨벤션 근거 README 명시.
 
 ## Next Steps
 
-1. `parallel-debt-and-infra` 플랜 실행 상태 확인 및 잔여 태스크 처리
-2. 새 작업 정의 시 SPEC.md 작성
+1. Dispatcher v2 실전 테스트 (MASTER → WORK 분할 → 워크트리 병렬 실행 → 머지 full cycle)
+2. 실전 테스트 피드백 반영
+3. 새 작업 정의 시 SPEC.md 작성
 
 ## Active Decisions
 
@@ -25,6 +26,10 @@ E2E 검증 통과 (93/93 PASS). README 재구성, 워크트리 전수 정리, gi
 | Agent 구조 | Skill(How) + Agent(When/With What) 래핑 | 2026-02-02 | .hxsk/ 전체 |
 | 외부 종속성 | 없음 (MCP, Python 환경 제거) | 2026-02-05 | 전체 시스템 |
 | 배포 모델 | Self-Configure (레포 = 배포, 빌드 없음) | 2026-03-24 | 전체 시스템 |
+| Dispatcher v2 | MASTER/WORK 이슈 트래킹 + 6-Phase Wave 루프 | 2026-03-26 | .hxsk/skills/dispatcher, .hxsk/agents/dispatcher, scripts/issue-*.sh |
+| 에이전트 프롬프트 컨벤션 | 간결 유지 (~20-30줄), 상세는 SKILL.md 위임 | 2026-03-26 | .hxsk/agents/ 전체 |
+| 이슈 문서 쓰기 주체 | 오케스트레이터 단독 (서브에이전트 읽기 전용) | 2026-03-26 | dispatcher 워크플로우 |
+| 이슈 문서 저장 | .hxsk/issues/ (git-untracked, 절대경로 참조) | 2026-03-26 | .gitignore, dispatcher |
 
 ## Blockers
 
@@ -34,10 +39,11 @@ None
 
 None
 
-## Session Context
-
-Self-Configure 전환 완료 및 E2E 검증 통과. 워크트리 전수 정리, README 재구성 (구조 재배치 + 시각 개선), gitignore 보강.
+## Recent Commits
+eb3cb4f feat(dispatcher): v2 — MASTER/WORK 마크다운 이슈 트래킹 기반 6-Phase 오케스트레이션 (#75)
+50b60cc feat: setup 프롬프트에 'assisted with HExoskeleton' 뱃지 안내 추가 (#74)
+263e21a docs: README 가독성 개선 + setup 프롬프트에 다음 단계 안내 추가 (#73)
 
 ---
 
-*Last updated: 2026-03-25*
+*Last updated: 2026-03-26*

--- a/.hxsk/agents/INDEX.md
+++ b/.hxsk/agents/INDEX.md
@@ -12,7 +12,7 @@
 | context-health-monitor | Monitors context complexity and triggers state dumps before quality degrades | haiku | `agents/context-health-monitor.md` |
 | create-pr | Analyzes changes, creates branch, splits commits logically, pushes and creates PR via gh CLI | haiku | `agents/create-pr.md` |
 | debugger | Systematic debugging with persistent state and fresh context advantages | opus | `agents/debugger.md` |
-| dispatcher | Wave-based parallel issue dispatch orchestrator | opus | `agents/dispatcher.md` |
+| dispatcher | MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이터 (v2) | opus | `agents/dispatcher.md` |
 | executor | Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols | sonnet | `agents/executor.md` |
 | handoff | Session handoff workflow -- git status, test, commit+push, memory store, summary | haiku | `agents/handoff.md` |
 | impact-analysis | Analyzes change impact before code modifications to prevent regression | opus | `agents/impact-analysis.md` |

--- a/.hxsk/skills/INDEX.md
+++ b/.hxsk/skills/INDEX.md
@@ -12,7 +12,7 @@
 | context-health-monitor | Monitors context complexity and triggers state dumps before quality degrades | `skills/context-health-monitor/SKILL.md` |
 | create-pr | Analyzes changes, creates branch, splits commits logically, pushes and creates pull request via gh CLI | `skills/create-pr/SKILL.md` |
 | debugger | Systematic debugging with persistent state and fresh context advantages | `skills/debugger/SKILL.md` |
-| dispatcher | Wave 기반 병렬 이슈 디스패치 -- 이슈 → worktree subagent 배정 | `skills/dispatcher/SKILL.md` |
+| dispatcher | MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이션 (v2.0.0) | `skills/dispatcher/SKILL.md` |
 | empirical-validation | Requires proof before marking work complete -- no "trust me, it works" | `skills/empirical-validation/SKILL.md` |
 | executor | Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols, and state management | `skills/executor/SKILL.md` |
 | handoff | Session handoff workflow -- status check, test, commit, memory store, summary output | `skills/handoff/SKILL.md` |


### PR DESCRIPTION
## Summary
- STATE.md: dispatcher v2 (#75) 완료 반영, Active Decisions 추가
- Skills/Agents INDEX.md: dispatcher v2.0.0 description 갱신

## Dispatcher v2 실전 테스트 결과
MASTER-001 → WORK-001-1, WORK-001-2 (Wave 1 병렬) → 커밋 → TRACK → 아카이브까지 6-Phase full cycle 정상 동작 확인.

## Test plan
- [x] MASTER/WORK 문서 생성 (issue-create.sh)
- [x] 파일 소유권 겹침 없음 검증
- [x] Work별 atomic commit (WORK ID 포함)
- [x] WORK status tracking (pending → in-progress → done)
- [x] MASTER progress 갱신 + Merge Log 기록
- [x] 아카이브 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)