### PR TITLE
feat(setup): v2 — 멱등 수렴 엔진 + 2-hop 컨텍스트 + 범용 에이전트 지원

### DIFF
--- a/.hxsk/hooks/session-start.sh
+++ b/.hxsk/hooks/session-start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Hook: SessionStart — HXSK 상태 자동 로드
-# 세션 시작 시 .hxsk/STATE.md와 git status를 additionalContext로 주입
+# source 필드 기반 분기: startup(풀) / resume(최소) / compact(핵심)
+# source 미제공 시 .session-active 마커로 fallback 판별
 
 main() {
     set -uo pipefail
@@ -13,51 +14,113 @@ main() {
     # JSON 파싱 추상화 로드
     source "$HOOK_DIR/_json_parse.sh"
 
-    # 1. CURRENT.md 로드 (현재 세션 컨텍스트)
-    CURRENT_FILE="$HXSK_DIR/CURRENT.md"
-    if [ -f "$CURRENT_FILE" ]; then
-        CURRENT_CONTENT=$(head -15 "$CURRENT_FILE" 2>/dev/null || true)
-        if [ -n "$CURRENT_CONTENT" ] && ! grep -q "^<!-- Current task ID" "$CURRENT_FILE"; then
-            CONTEXT_PARTS+=("")
-            CONTEXT_PARTS+=("## Current Session Context (from .hxsk/CURRENT.md)")
-            CONTEXT_PARTS+=("$CURRENT_CONTENT")
+    # ─── Source 감지 ───
+    # stdin에서 JSON을 읽어 source 필드 파싱 시도
+    local INPUT=""
+    if [ -t 0 ]; then
+        INPUT="{}"
+    else
+        INPUT=$(cat 2>/dev/null || echo "{}")
+    fi
+
+    local SOURCE=""
+    SOURCE=$(echo "$INPUT" | json_get "source" 2>/dev/null || true)
+
+    # source가 없으면 .session-active 마커로 fallback
+    if [ -z "$SOURCE" ]; then
+        if [ -f "$HXSK_DIR/.session-active" ]; then
+            SOURCE="resume"
+        else
+            SOURCE="startup"
         fi
     fi
 
-    # 2. STATE.md 로드 (상위 30줄)
-    STATE_FILE="$HXSK_DIR/STATE.md"
-    if [ -f "$STATE_FILE" ]; then
-        STATE_CONTENT=$(head -30 "$STATE_FILE" 2>/dev/null || true)
-        if [ -n "$STATE_CONTENT" ]; then
-            CONTEXT_PARTS+=("")
-            CONTEXT_PARTS+=("## HXSK State (from .hxsk/STATE.md)")
-            CONTEXT_PARTS+=("$STATE_CONTENT")
+    # ─── startup: 풀 컨텍스트 로드 ───
+    if [ "$SOURCE" = "startup" ]; then
+        # .session-active 마커 생성
+        touch "$HXSK_DIR/.session-active" 2>/dev/null || true
+
+        # 1. CURRENT.md 로드
+        CURRENT_FILE="$HXSK_DIR/CURRENT.md"
+        if [ -f "$CURRENT_FILE" ]; then
+            CURRENT_CONTENT=$(head -15 "$CURRENT_FILE" 2>/dev/null || true)
+            if [ -n "$CURRENT_CONTENT" ] && ! grep -q "^<!-- Current task ID" "$CURRENT_FILE"; then
+                CONTEXT_PARTS+=("")
+                CONTEXT_PARTS+=("## Current Session Context (from .hxsk/CURRENT.md)")
+                CONTEXT_PARTS+=("$CURRENT_CONTENT")
+            fi
         fi
-    fi
 
-    # 3. Git 미커밋 변경사항 요약
-    GIT_STATUS=$(git -C "$PROJECT_DIR" status --short 2>/dev/null || true)
-    if [ -n "$GIT_STATUS" ]; then
-        FILE_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
-        CONTEXT_PARTS+=("")
-        CONTEXT_PARTS+=("## Uncommitted Changes ($FILE_COUNT files)")
-        CONTEXT_PARTS+=("$GIT_STATUS")
-    fi
+        # 2. STATE.md 로드 (상위 30줄)
+        STATE_FILE="$HXSK_DIR/STATE.md"
+        if [ -f "$STATE_FILE" ]; then
+            STATE_CONTENT=$(head -30 "$STATE_FILE" 2>/dev/null || true)
+            if [ -n "$STATE_CONTENT" ]; then
+                CONTEXT_PARTS+=("")
+                CONTEXT_PARTS+=("## HXSK State (from .hxsk/STATE.md)")
+                CONTEXT_PARTS+=("$STATE_CONTENT")
+            fi
+        fi
 
-    # 4. 최근 커밋 3개
-    RECENT_COMMITS=$(git -C "$PROJECT_DIR" log --oneline -3 2>/dev/null || true)
-    if [ -n "$RECENT_COMMITS" ]; then
-        CONTEXT_PARTS+=("")
-        CONTEXT_PARTS+=("## Recent Commits")
-        CONTEXT_PARTS+=("$RECENT_COMMITS")
-    fi
+        # 3. Git 미커밋 변경사항 요약
+        GIT_STATUS=$(git -C "$PROJECT_DIR" status --short 2>/dev/null || true)
+        if [ -n "$GIT_STATUS" ]; then
+            FILE_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
+            CONTEXT_PARTS+=("")
+            CONTEXT_PARTS+=("## Uncommitted Changes ($FILE_COUNT files)")
+            CONTEXT_PARTS+=("$GIT_STATUS")
+        fi
 
-    # 5. Memory Recall (파일 기반 메모리에서 최근 프로젝트 메모리)
-    MEMORY_OUTPUT=$("$HOOK_DIR/md-recall-memory.sh" "project context" "$PROJECT_DIR" 3 2>/dev/null || true)
-    if [ -n "$MEMORY_OUTPUT" ]; then
-        CONTEXT_PARTS+=("")
-        CONTEXT_PARTS+=("## Recent Memory Context")
-        CONTEXT_PARTS+=("$MEMORY_OUTPUT")
+        # 4. 최근 커밋 3개
+        RECENT_COMMITS=$(git -C "$PROJECT_DIR" log --oneline -3 2>/dev/null || true)
+        if [ -n "$RECENT_COMMITS" ]; then
+            CONTEXT_PARTS+=("")
+            CONTEXT_PARTS+=("## Recent Commits")
+            CONTEXT_PARTS+=("$RECENT_COMMITS")
+        fi
+
+        # 5. Memory Recall (2-hop)
+        MEMORY_OUTPUT=$("$HOOK_DIR/md-recall-memory.sh" "project context" "$PROJECT_DIR" 3 2>/dev/null || true)
+        if [ -n "$MEMORY_OUTPUT" ]; then
+            CONTEXT_PARTS+=("")
+            CONTEXT_PARTS+=("## Recent Memory Context")
+            CONTEXT_PARTS+=("$MEMORY_OUTPUT")
+        fi
+
+    # ─── resume: 최소 컨텍스트 ───
+    elif [ "$SOURCE" = "resume" ]; then
+        # CURRENT.md만
+        CURRENT_FILE="$HXSK_DIR/CURRENT.md"
+        if [ -f "$CURRENT_FILE" ]; then
+            CURRENT_CONTENT=$(head -15 "$CURRENT_FILE" 2>/dev/null || true)
+            if [ -n "$CURRENT_CONTENT" ] && ! grep -q "^<!-- Current task ID" "$CURRENT_FILE"; then
+                CONTEXT_PARTS+=("")
+                CONTEXT_PARTS+=("## Current Session Context (from .hxsk/CURRENT.md)")
+                CONTEXT_PARTS+=("$CURRENT_CONTENT")
+            fi
+        fi
+
+        # Git 미커밋만
+        GIT_STATUS=$(git -C "$PROJECT_DIR" status --short 2>/dev/null || true)
+        if [ -n "$GIT_STATUS" ]; then
+            FILE_COUNT=$(echo "$GIT_STATUS" | wc -l | tr -d ' ')
+            CONTEXT_PARTS+=("")
+            CONTEXT_PARTS+=("## Uncommitted Changes ($FILE_COUNT files)")
+            CONTEXT_PARTS+=("$GIT_STATUS")
+        fi
+
+    # ─── compact: 핵심 상태만 ───
+    elif [ "$SOURCE" = "compact" ]; then
+        # STATE.md 첫 15줄만
+        STATE_FILE="$HXSK_DIR/STATE.md"
+        if [ -f "$STATE_FILE" ]; then
+            STATE_CONTENT=$(head -15 "$STATE_FILE" 2>/dev/null || true)
+            if [ -n "$STATE_CONTENT" ]; then
+                CONTEXT_PARTS+=("")
+                CONTEXT_PARTS+=("## HXSK State (from .hxsk/STATE.md)")
+                CONTEXT_PARTS+=("$STATE_CONTENT")
+            fi
+        fi
     fi
 
     # 컨텍스트가 있으면 JSON으로 출력

--- a/.hxsk/skills/bootstrap/SKILL.md
+++ b/.hxsk/skills/bootstrap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bootstrap
-description: Complete initial project setup -- system verification, memory initialization, codebase analysis
-version: 4.0.0
+description: "Idempotent project setup — fresh install, update, or verify via convergence engine"
+version: 5.0.0
 allowed-tools:
   - Read
   - Write
@@ -9,48 +9,72 @@ allowed-tools:
   - Bash
   - Grep
   - Glob
-trigger: "프로젝트 초기화, 프로젝트 셋업, 처음 설정, project setup, initialize project, after cloning"
+trigger: "프로젝트 초기화, 프로젝트 셋업, 처음 설정, 업데이트, 갱신, project setup, initialize project, after cloning, update, refresh"
 ---
 
 ## Quick Reference
-- **시작**: `bash scripts/bootstrap.sh` (필수 도구 검증: git, bash)
-- **메모리**: `.hxsk/memories/` 14개 타입 디렉토리 + `_schema/` 확인
-- **Output**: BOOTSTRAP STATUS REPORT (READY / NEEDS ATTENTION)
+- **시작**: `bash scripts/bootstrap.sh` (멱등 — 반복 실행 안전)
+- **모드**: fresh(초기) / verify(검증) / update(갱신) — `.hxsk/.bootstrap-version`으로 자동 감지
+- **Output**: `[NEW]` `[UPDATED]` `[OK]` `[PASS]` `[FAIL]` `[WARN]` `[SKIP]` 태그
+- **2-hop**: `[NEW]`/`[UPDATED]` 항목에 관련 컴포넌트 자동 표시
 - **메모리 저장**: `md-store-memory.sh` 로 `.hxsk/memories/bootstrap/`에 기록
 
 ---
 
 # Skill: Bootstrap
 
-> **Goal**: Perform complete initial project setup — system verification, memory directory initialization, and codebase analysis.
-> **Scope**: 순수 bash 스크립트 기반. 외부 종속성 없음.
+> **Goal**: Idempotent project setup — detect state, converge to target, report delta.
+> **Scope**: 순수 bash 스크립트 기반. 외부 종속성 없음. 모든 에이전트에서 실행 가능.
 
 <role>
-You are a bootstrap orchestrator. Your job is to take a freshly cloned HExoskeleton and make it fully operational.
+You are a bootstrap orchestrator. Your job is to make an HExoskeleton project fully operational,
+whether it's a fresh clone or an existing installation being updated.
 
 **Core responsibilities:**
-- Verify system prerequisites (git, bash)
-- Initialize memory directory structure
-- Generate architecture documentation
+- Detect install mode (fresh / verify / update) via .hxsk/.bootstrap-version
+- Verify system prerequisites and project structure
+- Report changes with [NEW]/[UPDATED]/[OK] tags
+- Provide 2-hop context for new or changed components
 - Store bootstrap state in `.hxsk/memories/`
-- Report final status with actionable next steps
 </role>
 
 ---
 
 ## Procedure
 
+### Step 0: 모드 감지
+
+```bash
+test -f .hxsk/.bootstrap-version && echo "EXISTS" || echo "FRESH"
+```
+
+- **파일 없음** → 초기 설치 모드. Step 1~7 전체 실행.
+- **파일 있음** → `bash scripts/bootstrap.sh` 실행. 스크립트가 자동으로 verify/update 판별.
+  - 모든 항목 `[OK]` → 완료
+  - `[NEW]`/`[UPDATED]` 있음 → Step 6 (메모리 저장) + Step 7 (보고) 실행
+
+---
+
 ### Step 1: System Prerequisites Check
 
-Run the system dependency verification script:
+Run the idempotent convergence engine:
 
 ```bash
 bash scripts/bootstrap.sh
 ```
 
+**bootstrap.sh v5.0.0 출력 태그:**
+- `[NEW]` — 새로 생성된 컴포넌트 (↳ 관련: 2-hop 컨텍스트)
+- `[UPDATED]` — 변경 감지된 컴포넌트 (↳ 관련: 2-hop 컨텍스트)
+- `[OK]` — 변경 없음, 정상
+- `[PASS]` — 시스템 요구사항 충족
+- `[FAIL]` — 필수 요구사항 미충족
+- `[WARN]` — 선택 요구사항 미충족
+- `[SKIP]` — 해당 없음
+
 **If exit code 1:** STOP. Display the failing checks and provide installation instructions.
 
-**If exit code 0:** Record tool versions and continue.
+**If exit code 0:** Continue. `.hxsk/.bootstrap-version` 자동 생성/갱신됨.
 
 ---
 
@@ -67,6 +91,8 @@ else
 fi
 ```
 
+> bootstrap.sh가 이미 이 작업을 수행합니다. Step 1에서 `[NEW] .env`가 출력되었으면 건너뛰세요.
+
 ---
 
 ### Step 3: Memory Directory Verification
@@ -82,11 +108,7 @@ ls .hxsk/memories/ | wc -l  # 14 directories + _schema expected
 mkdir -p .hxsk/memories/{architecture-decision,root-cause,debug-eliminated,debug-blocked,health-event,session-handoff,execution-summary,deviation,pattern-discovery,bootstrap,session-summary,session-snapshot,security-finding,general,_schema}
 ```
 
-Verify schema files:
-```bash
-ls .hxsk/memories/_schema/
-# Expected: base.schema.json, type-relations.yaml, session-summary.schema.json, etc.
-```
+> bootstrap.sh가 이미 이 작업을 수행합니다. Step 1에서 `[NEW] .hxsk/memories/`가 출력되었으면 건너뛰세요.
 
 ---
 
@@ -99,15 +121,12 @@ Verify context management structure:
 ├── reports/           # Analysis reports (REPORT-*.md)
 ├── research/          # Research documents (RESEARCH-*.md)
 ├── archive/           # Monthly archives
+├── issues/archive/    # Completed issue archive
 ├── PATTERNS.md        # Core patterns (2KB limit)
 └── context-config.yaml # Cleanup rules
 ```
 
-**Verification:**
-```bash
-test -d .hxsk/reports && test -d .hxsk/research && test -d .hxsk/archive && echo "PASS" || echo "FAIL"
-test -f .hxsk/PATTERNS.md && echo "PASS" || echo "FAIL"
-```
+> bootstrap.sh가 자동 생성합니다.
 
 ---
 
@@ -122,7 +141,7 @@ Delegate to the `codebase-mapper` skill to analyze the project:
 
 ---
 
-### Step 6: Initial Memory
+### Step 6: Memory Storage
 
 Store the bootstrap record:
 
@@ -142,28 +161,21 @@ bash scripts/md-store-memory.sh \
 
 ### Step 7: Status Report
 
-Output the structured bootstrap status report:
+bootstrap.sh가 이미 구조화된 보고서를 출력합니다:
 
 ```
 ================================================================
- BOOTSTRAP STATUS REPORT
+ BOOTSTRAP v5.0.0
+ MODE: fresh | verify | update (vX.X.X → v5.0.0)
 ================================================================
-System Prerequisites:  {PASS|FAIL} (git, bash)
-Environment:           {PASS|FAIL} (.env configured)
-Memory Directory:      {PASS|FAIL} (.hxsk/memories/ — 14 types + _schema)
-Memory Schema:         {PASS|FAIL} (base.schema.json, type-relations.yaml)
-Context Structure:     {PASS|FAIL} (reports/, research/, archive/)
-Documentation:         {PASS|FAIL} (ARCHITECTURE.md, STACK.md)
-Memory Record:         {PASS|WARN} (bootstrap record stored)
-================================================================
- RESULT: READY / NEEDS ATTENTION
-================================================================
-Next: /plan | Start working on your project
+...
+ MODE: {mode}  |  PASS: N  FAIL: N  WARN: N  SKIP: N  NEW: N  UPDATED: N
+ RESULT: ALL REQUIRED CHECKS PASSED / FAILED
 ================================================================
 ```
 
-**READY** = All steps PASS (WARN is acceptable).
-**NEEDS ATTENTION** = Any step FAIL.
+**RESULT = PASSED** → 프로젝트 READY.
+**RESULT = FAILED** → NEEDS ATTENTION.
 
 ---
 
@@ -172,7 +184,7 @@ Next: /plan | Start working on your project
 | Error | Action |
 |-------|--------|
 | System prerequisite missing | STOP at Step 1. Print install commands |
-| Memory directory missing | Create directories automatically |
+| Memory directory missing | Auto-create (bootstrap.sh handles) |
 | Schema files missing | Copy from templates or create minimal versions |
 | codebase-mapper fails | FAIL the step, continue |
 | Memory store fails | WARN the step, continue |
@@ -181,5 +193,5 @@ Next: /plan | Start working on your project
 
 ## Scripts
 
-- `scripts/bootstrap.sh`: System dependency verification script (git, bash, memory structure)
+- `scripts/bootstrap.sh`: Idempotent convergence engine (fresh/verify/update 3-mode)
 - `scripts/detect-language.sh`: Language, package manager detection functions (optional)

--- a/.hxsk/templates/bootstrap-version.yaml
+++ b/.hxsk/templates/bootstrap-version.yaml
@@ -1,0 +1,15 @@
+# .hxsk/.bootstrap-version — bootstrap 상태 추적 파일
+# bootstrap.sh가 자동 생성/갱신합니다. 수동 편집하지 마세요.
+
+# 마지막으로 실행된 bootstrap 버전
+version: "{VERSION}"
+
+# 마지막 실행 날짜 (YYYY-MM-DD)
+last_run: "{DATE}"
+
+# 설치된 컴포넌트 수
+components:
+  skills: 0
+  agents: 0
+  hooks: 0
+  memories: 0

--- a/docs/plans/2026-03-26-setup-v2-design.md
+++ b/docs/plans/2026-03-26-setup-v2-design.md
@@ -1,0 +1,199 @@
+# Setup v2: 멱등 수렴 패턴 + 2-hop 컨텍스트 구성 + 범용 에이전트 지원
+
+> Date: 2026-03-26
+> Status: DRAFT
+> Scope: `scripts/bootstrap.sh`, `prompts/setup*.md`, `.hxsk/hooks/session-start.sh`, `.hxsk/skills/bootstrap/`
+
+## Background
+
+현재 setup은 단방향 초기 설치만 지원. "이미 설치됨 → 업데이트 필요" 상황 처리 없음. 또한 Claude Code 전용 기능(hooks)에 의존하면 범용성이 깨짐. 모든 에이전트가 공통으로 사용할 수 있는 멱등 setup 시스템이 필요.
+
+## Core Concept: 멱등 수렴 엔진
+
+`bootstrap.sh`를 "설치 스크립트"에서 **"상태 수렴 엔진"**으로 전환.
+
+```
+실행할 때마다:
+1. 현재 상태 스캔 (뭐가 있고 뭐가 없는지)
+2. 목표 상태와 비교 (버전 + 컴포넌트 목록)
+3. 차이만 적용
+4. 결과 보고: [NEW] / [UPDATED] / [OK]
+```
+
+### 버전 마커: `.hxsk/.bootstrap-version`
+
+```yaml
+version: 4.1.0
+last_run: 2026-03-26
+components:
+  - skills/19
+  - agents/17
+  - hooks/17
+  - memories/14
+```
+
+### 판별 로직
+
+| `.bootstrap-version` | 동작 | 보고 |
+|----------------------|------|------|
+| 파일 없음 | 전체 설치 | 모두 `[NEW]` |
+| 동일 버전 | 구조 검증만 | 모두 `[OK]` |
+| 구버전 | 변경분 적용 | 변경된 것만 `[UPDATED]`, 나머지 `[OK]` |
+
+**범용성**: 순수 bash + YAML frontmatter. 에이전트 무관. 어떤 에이전트든 `bash scripts/bootstrap.sh`를 실행하면 동작.
+
+## 2-hop 컨텍스트 구성
+
+새 컴포넌트 설치/업데이트 시 기존 설정과의 관계를 자동으로 설명.
+
+### 동작 흐름
+
+```
+[UPDATED] dispatcher v1.0.0 → v2.0.0
+  ↓ md-recall-memory.sh "dispatcher" 2-hop 검색
+  ↓ 관련 발견: planner, executor, merge-worktrees.sh
+  ↓
+  "dispatcher v2는 MASTER/WORK 이슈 문서를 사용합니다.
+   기존 planner(PLAN.md 생성)와 executor(PLAN 실행)의
+   출력을 입력으로 받아 병렬 분할합니다."
+```
+
+### 구현
+
+bootstrap.sh의 각 컴포넌트 체크 후 `[NEW]` 또는 `[UPDATED]`일 때만 2-hop 호출:
+
+```bash
+report_context() {
+    local component="$1" status="$2"
+    if [ "$status" = "NEW" ] || [ "$status" = "UPDATED" ]; then
+        local related
+        related=$(bash .hxsk/hooks/md-recall-memory.sh "$component" "." 3 compact 2 2>/dev/null)
+        [ -n "$related" ] && echo "  관련: $related"
+    fi
+}
+```
+
+**범용성**: `md-recall-memory.sh`는 순수 bash. 에이전트가 bootstrap.sh를 실행하면 자동으로 2-hop 컨텍스트가 출력에 포함.
+
+**제약**: 메모리가 비어있는 최초 설치 시에는 2-hop 결과 없음 → `[NEW]`만 표시. 이후 업데이트부터 관계 설명 제공.
+
+## setup.md 상태 인식형 가이드
+
+현재 7단계 선형 체크리스트를 **분기형 가이드**로 전환. 에이전트가 상태를 감지하고 스스로 초기/업데이트 경로를 선택.
+
+### 프롬프트 구조
+
+```markdown
+## Step 0: 상태 감지 (신규)
+1. `.hxsk/.bootstrap-version` 파일 확인
+2. 없으면 → "초기 설치" 경로 (Step 1부터 전체 실행)
+3. 있으면 → 버전 읽기 → "업데이트" 경로 (bootstrap.sh만 재실행)
+
+## 초기 설치 경로
+Step 1~7: 기존과 동일 (llms.txt 읽기 → 에이전트 지침 설치 → ... → 뱃지)
+마지막에 bootstrap.sh가 .bootstrap-version 생성
+
+## 업데이트 경로
+1. `bash scripts/bootstrap.sh` 실행
+2. [NEW/UPDATED/OK] 보고서 확인
+3. [UPDATED] 항목의 2-hop 관계 설명 읽기
+4. 필요 시 에이전트별 설정 갱신 (hook 등록 등)
+```
+
+**setup-claude.md도 동일 패턴** 적용. Claude Code 전용 부분(hook 등록, skills 경로)은 업데이트 경로에서 "설정 변경 있으면 갱신" 분기 추가.
+
+**범용성**: Step 0의 상태 감지는 파일 존재 확인(`[ -f ]`)이므로 어떤 에이전트든 수행 가능.
+
+## session-start.sh source 분기 (에이전트별 레이어)
+
+hook을 지원하는 에이전트에서 세션 시작 시 로드 범위를 자동 조절.
+
+### 분기 로직
+
+```bash
+# Claude Code / Gemini CLI: stdin JSON에서 source 파싱
+SOURCE=$(echo "$INPUT" | json_get "source" 2>/dev/null)
+
+# 타 에이전트 또는 source 미제공 시: 구조적 감지
+if [ -z "$SOURCE" ]; then
+    if [ -f ".hxsk/.session-active" ]; then
+        SOURCE="resume"
+    else
+        SOURCE="startup"
+    fi
+fi
+
+case "$SOURCE" in
+    startup)
+        # 풀 로드: STATE + memory 2-hop + git status + recent commits
+        touch .hxsk/.session-active
+        ;;
+    resume)
+        # 최소: uncommitted changes + CURRENT.md만
+        ;;
+    compact)
+        # 핵심만: STATE.md 첫 15줄 + 활성 PLAN 태스크
+        ;;
+esac
+```
+
+### 에이전트별 호환성
+
+| 에이전트 | source 감지 | fallback |
+|----------|------------|----------|
+| Claude Code | stdin JSON `source` 필드 | - |
+| Gemini CLI | stdin JSON `source` 필드 | - |
+| Cursor/Windsurf/Copilot | hook에서 셸 실행 가능 | `.session-active` 마커 |
+| Aider/기타 | hook 미지원 | setup.md에서 수동 실행 안내 |
+
+**SessionEnd**: `.session-active` 마커 삭제. hook 지원 에이전트는 SessionEnd hook에서 자동, 미지원은 수동.
+
+## 범용 에이전트 호환성 매트릭스
+
+| 기능 | 구현 위치 | 범용 (bash) | Claude Code | Gemini CLI | Cursor/WS/Copilot | Aider |
+|------|-----------|:-:|:-:|:-:|:-:|:-:|
+| 버전 마커 감지 | bootstrap.sh | O | O | O | O | O |
+| 멱등 수렴 | bootstrap.sh | O | O | O | O | O |
+| 2-hop 컨텍스트 | md-recall-memory.sh | O | O | O | O | O |
+| setup.md 분기 | 프롬프트 | O | O | O | O | O |
+| source 기반 세션 분기 | session-start.sh | - | O | O | fallback | - |
+| hook 자동 실행 | 에이전트별 설정 | - | O | O | O | - |
+
+## 변경 파일
+
+| 파일 | 유형 | 변경 내용 |
+|------|------|-----------|
+| `scripts/bootstrap.sh` | 수정 | 멱등 수렴 엔진 + 버전 마커 + `[NEW/UPDATED/OK]` + 2-hop 컨텍스트 |
+| `prompts/setup.md` | 수정 | Step 0 상태 감지 추가, 초기/업데이트 분기 |
+| `prompts/setup-claude.md` | 수정 | 동일 분기 + Claude 전용 hook 갱신 안내 |
+| `.hxsk/hooks/session-start.sh` | 수정 | source 분기 + .session-active fallback |
+| `.hxsk/skills/bootstrap/SKILL.md` | 수정 | 업데이트 시나리오 추가, 2-hop 보고 |
+| `.hxsk/templates/bootstrap-version.yaml` | 신규 | .bootstrap-version 템플릿 |
+
+### 유지
+
+- bootstrap.sh의 기존 체크 로직 (시스템 요구사항, 메모리 디렉토리 등)
+- setup.md의 7-step 구조 (초기 설치 경로에서 그대로 사용)
+- session-start.sh의 기존 컨텍스트 로드 로직 (startup에서 그대로 사용)
+
+## Design Decisions
+
+| 결정 | 선택 | 이유 |
+|------|------|------|
+| 설치/업데이트 구분 | 단일 멱등 경로 | 두 코드 경로보다 유지보수 용이 |
+| 2-hop 구성 | `[NEW/UPDATED]` 시에만 호출 | 매번 호출하면 느림, 필요할 때만 |
+| source 감지 fallback | `.session-active` 마커 | hook source 미제공 에이전트 호환 |
+| 범용/전용 분리 | bootstrap.sh(범용) + hook(전용) | AGENTS.md만 읽는 에이전트도 사용 가능 |
+| setup.md 분기 | 프롬프트 내 조건 지시 | 에이전트가 자율 판단, 사람 개입 불필요 |
+
+## Research References
+
+| 출처 | 참고 포인트 |
+|------|------------|
+| [Idempotent Bash Scripts](https://arslan.io/2019/07/03/how-to-write-idempotent-bash-scripts/) | 멱등 bash 패턴 (mkdir -p, [ -f ] \|\| cp) |
+| [Ansible Idempotent Playbooks](https://admantium.medium.com/ansible-idempotent-playbooks-a89bb0e012c9) | 단일 수렴 경로 > 분리된 install/update |
+| [Claude Code Hooks Reference](https://code.claude.com/docs/en/hooks) | SessionStart source 필드 |
+| [Gemini CLI Hooks](https://geminicli.com/docs/hooks/) | BeforeTool, SessionStart 등 10+ 이벤트 |
+| [AGENTS.md Standard](https://agents.md/) | 범용 에이전트 지침 표준 (60,000+ repos) |
+| [Self-Improving Bootstrap](https://gist.github.com/ChristopherA/fd2985551e765a86f4fbb24080263a2f) | 메타 규칙 기반 자기 개선 부트스트랩 |
+| [mem0 Graph Memory](https://mem0.ai/blog/graph-memory-solutions-ai-agents) | 2-hop 그래프 탐색으로 관계 기반 컨텍스트 구성 |

--- a/docs/plans/2026-03-26-setup-v2-impl.md
+++ b/docs/plans/2026-03-26-setup-v2-impl.md
@@ -1,0 +1,306 @@
+---
+phase: 1
+plan: 1
+wave: 1
+gap_closure: false
+---
+
+# Plan 1.1: Setup v2 — 멱등 수렴 패턴 + 2-hop 컨텍스트 + 범용 에이전트 지원
+
+## Objective
+
+bootstrap.sh를 멱등 수렴 엔진으로 전환하고, setup 프롬프트에 상태 인식 분기를 추가하며, session-start.sh에 source 기반 분기를 도입한다. 설계 문서: `docs/plans/2026-03-26-setup-v2-design.md`
+
+## Context
+Load these files for context:
+- docs/plans/2026-03-26-setup-v2-design.md
+- scripts/bootstrap.sh
+- prompts/setup.md
+- prompts/setup-claude.md
+- .hxsk/hooks/session-start.sh
+- .hxsk/skills/bootstrap/SKILL.md
+
+## Tasks
+
+### Wave 1: 기반 인프라 (버전 마커 + bootstrap.sh 멱등화)
+
+<task type="auto">
+  <name>bootstrap-version 템플릿 생성</name>
+  <files>
+    .hxsk/templates/bootstrap-version.yaml
+  </files>
+  <action>
+    .bootstrap-version 파일의 YAML 템플릿 작성.
+
+    Steps:
+    1. frontmatter 없이 순수 YAML 파일로 작성
+    2. 필드: version, last_run, components (skills/N, agents/N, hooks/N, memories/N)
+    3. 주석으로 각 필드 설명
+
+    AVOID: 복잡한 구조. 플랫한 YAML만 사용
+    USE: 기존 .hxsk/templates/ 컨벤션 참조
+  </action>
+  <verify>
+    test -f .hxsk/templates/bootstrap-version.yaml && echo "PASS"
+    grep -q "version:" .hxsk/templates/bootstrap-version.yaml && echo "FIELDS OK"
+  </verify>
+  <done>
+    템플릿 파일 존재, version/last_run/components 필드 포함
+  </done>
+</task>
+
+<task type="auto">
+  <name>bootstrap.sh 멱등 수렴 엔진 전환</name>
+  <files>
+    scripts/bootstrap.sh
+  </files>
+  <action>
+    기존 bootstrap.sh를 멱등 수렴 패턴으로 확장. 기존 체크 로직 유지.
+
+    Steps:
+    1. 스크립트 상단에 BOOTSTRAP_VERSION 상수 추가 (예: "5.0.0")
+    2. .hxsk/.bootstrap-version 읽기 로직 추가:
+       - 파일 없음 → MODE="fresh"
+       - 동일 버전 → MODE="verify"
+       - 구버전 → MODE="update", OLD_VERSION 기록
+    3. 기존 report_pass/fail/warn/skip에 report_new, report_updated 추가:
+       - report_new(): printf "  [NEW] ..."
+       - report_updated(): printf "  [UPDATED] ..."
+    4. report_context() 함수 추가:
+       - [NEW] 또는 [UPDATED] 시에만 md-recall-memory.sh 2-hop 호출
+       - 관련 컨텍스트가 있으면 "  관련: ..." 출력
+    5. 기존 각 체크 섹션에 모드별 분기 추가:
+       - fresh: 전체 실행, 모두 [NEW]
+       - verify: 구조 검증만, [OK] 또는 [FAIL]
+       - update: 변경분 감지, [UPDATED] 또는 [OK]
+    6. 스크립트 마지막에 .hxsk/.bootstrap-version 생성/갱신:
+       version: {BOOTSTRAP_VERSION}
+       last_run: $(date '+%Y-%m-%d')
+       components: skills/{count}, agents/{count}, hooks/{count}, memories/{count}
+    7. Summary에 모드 표시: "MODE: fresh | verify | update (from X.X.X)"
+
+    AVOID: 기존 체크 로직을 제거하지 않음. 래핑하여 확장
+    USE: 기존 report_* 헬퍼 패턴 유지, 새 헬퍼 추가
+  </action>
+  <verify>
+    # fresh 모드 테스트 (기존 .bootstrap-version 없는 상태)
+    rm -f .hxsk/.bootstrap-version
+    bash scripts/bootstrap.sh 2>&1 | grep -q "MODE:" && echo "MODE OK"
+    test -f .hxsk/.bootstrap-version && echo "VERSION FILE CREATED"
+    # verify 모드 테스트 (동일 버전)
+    bash scripts/bootstrap.sh 2>&1 | grep -q "verify" && echo "VERIFY MODE OK"
+    # update 모드 테스트 (구버전 시뮬)
+    sed -i '' 's/version: .*/version: 0.0.1/' .hxsk/.bootstrap-version
+    bash scripts/bootstrap.sh 2>&1 | grep -q "update" && echo "UPDATE MODE OK"
+  </verify>
+  <done>
+    fresh/verify/update 3모드 정상 동작. .bootstrap-version 자동 생성/갱신.
+    기존 PASS/FAIL/WARN/SKIP 출력 유지 + NEW/UPDATED 추가.
+  </done>
+</task>
+
+### Wave 2: 프롬프트 + 세션 훅 (Wave 1 의존)
+
+<task type="auto">
+  <name>setup.md 상태 인식형 분기 추가</name>
+  <files>
+    prompts/setup.md
+  </files>
+  <action>
+    기존 7-step 구조를 유지하면서 Step 0 상태 감지를 추가.
+
+    Steps:
+    1. 최상단에 "## Step 0: 상태 감지" 섹션 추가:
+       - `.hxsk/.bootstrap-version` 파일 확인
+       - 없으면 → "초기 설치" 경로 안내 (기존 Step 1~7)
+       - 있으면 → "업데이트" 경로 안내
+    2. 기존 Step 1~7은 "## 초기 설치" 하위로 감싸기
+    3. "## 업데이트" 섹션 추가:
+       - `bash scripts/bootstrap.sh` 실행
+       - [NEW/UPDATED/OK] 보고서 확인 안내
+       - 에이전트별 설정 갱신 분기
+    4. "다음 단계" 섹션도 초기/업데이트에 따라 분기
+
+    AVOID: 기존 Step 내용을 변경하지 않음. 구조만 감싸기
+    USE: 에이전트가 자율 판단할 수 있는 명확한 조건문 형태
+  </action>
+  <verify>
+    grep -q "Step 0" prompts/setup.md && echo "STEP0 OK"
+    grep -q "초기 설치" prompts/setup.md && echo "FRESH PATH OK"
+    grep -q "업데이트" prompts/setup.md && echo "UPDATE PATH OK"
+    grep -q "bootstrap-version" prompts/setup.md && echo "VERSION CHECK OK"
+  </verify>
+  <done>
+    Step 0 상태 감지 존재. 초기/업데이트 두 경로 존재. 기존 Step 1~7 내용 보존.
+  </done>
+</task>
+
+<task type="auto">
+  <name>setup-claude.md 상태 인식형 분기 추가</name>
+  <files>
+    prompts/setup-claude.md
+  </files>
+  <action>
+    setup.md와 동일한 상태 감지 + 분기 패턴 적용.
+
+    Steps:
+    1. 최상단에 상태 감지 섹션 추가 (.bootstrap-version 확인)
+    2. 기존 Quick Setup을 "초기 설치" 하위로
+    3. "업데이트" 섹션: bootstrap.sh 실행 + Claude Code 전용 갱신 안내
+       - hook 설정 변경 확인
+       - 새 스킬 설치 안내
+    4. "다음 단계" 분기
+
+    AVOID: 범용 setup.md와 중복되는 내용 최소화. Claude 전용 부분만
+    USE: 기존 구조 유지, 감싸기 패턴
+  </action>
+  <verify>
+    grep -q "bootstrap-version" prompts/setup-claude.md && echo "VERSION CHECK OK"
+    grep -q "업데이트" prompts/setup-claude.md && echo "UPDATE PATH OK"
+  </verify>
+  <done>
+    상태 감지 + 초기/업데이트 분기 존재. Claude 전용 hook 갱신 안내 포함.
+  </done>
+</task>
+
+<task type="auto">
+  <name>session-start.sh source 분기 추가</name>
+  <files>
+    .hxsk/hooks/session-start.sh
+  </files>
+  <action>
+    세션 시작 시 source 필드 기반으로 로드 범위를 조절.
+
+    Steps:
+    1. main() 함수 상단에서 stdin JSON의 source 필드 파싱 시도
+    2. source가 없으면 .hxsk/.session-active 파일로 fallback 판별:
+       - 파일 있음 → SOURCE="resume"
+       - 파일 없음 → SOURCE="startup"
+    3. case문으로 분기:
+       - startup: 기존 풀 로드 (5개 파트 전부) + .session-active 생성
+       - resume: CURRENT.md + uncommitted changes만
+       - compact: STATE.md 첫 15줄 + 활성 PLAN 정보만
+    4. 기존 로드 로직을 startup 케이스로 이동 (리팩터링)
+    5. resume/compact용 경량 로드 로직 추가
+
+    AVOID: 기존 startup 동작을 변경하지 않음. 새 분기만 추가
+    USE: 기존 json_get 함수로 source 파싱, _json_parse.sh 재사용
+  </action>
+  <verify>
+    # startup 시뮬 (stdin 없이 실행, .session-active 없음)
+    rm -f .hxsk/.session-active
+    echo '{}' | bash .hxsk/hooks/session-start.sh 2>/dev/null | grep -q "SessionStart" && echo "STARTUP OK"
+    test -f .hxsk/.session-active && echo "MARKER CREATED"
+    # resume 시뮬 (.session-active 존재)
+    echo '{}' | bash .hxsk/hooks/session-start.sh 2>/dev/null | grep -q "SessionStart" && echo "RESUME OK"
+    rm -f .hxsk/.session-active
+  </verify>
+  <done>
+    startup/resume/compact 3분기 동작. .session-active 마커 생성/감지.
+    기존 startup 동작 100% 보존.
+  </done>
+</task>
+
+### Wave 3: 스킬 업데이트 + 통합 검증
+
+<task type="auto">
+  <name>bootstrap SKILL.md 업데이트 시나리오 추가</name>
+  <files>
+    .hxsk/skills/bootstrap/SKILL.md
+  </files>
+  <action>
+    bootstrap 스킬에 업데이트 시나리오와 2-hop 보고를 추가.
+
+    Steps:
+    1. description에 "update, 업데이트, 갱신" 트리거 추가
+    2. version을 5.0.0으로 범프
+    3. Quick Reference에 업데이트 모드 설명 추가
+    4. Procedure에 "Step 0: 모드 감지" 추가:
+       - .bootstrap-version 확인 → fresh/update 분기
+       - update 시 bootstrap.sh만 재실행 + [NEW/UPDATED/OK] 보고
+    5. 기존 Step 1~7은 "초기 설치 시" 조건 명시
+    6. "업데이트 시" 절차 추가:
+       - bash scripts/bootstrap.sh 실행
+       - 2-hop 컨텍스트 보고 확인
+       - 변경사항 요약 출력
+
+    AVOID: 기존 7단계 절차 변경 없음. 감싸기 + 분기 추가
+    USE: 기존 SKILL.md 구조 패턴 유지
+  </action>
+  <verify>
+    grep -q "version: 5.0.0" .hxsk/skills/bootstrap/SKILL.md && echo "VERSION OK"
+    grep -q "업데이트" .hxsk/skills/bootstrap/SKILL.md && echo "UPDATE OK"
+    grep -q "모드 감지" .hxsk/skills/bootstrap/SKILL.md && echo "MODE DETECT OK"
+  </verify>
+  <done>
+    v5.0.0. 초기/업데이트 두 경로 존재. 2-hop 보고 언급.
+  </done>
+</task>
+
+<task type="auto">
+  <name>E2E 검증: fresh → verify → update 전체 사이클</name>
+  <files>
+    scripts/bootstrap.sh
+    .hxsk/hooks/session-start.sh
+    prompts/setup.md
+    prompts/setup-claude.md
+  </files>
+  <action>
+    전체 라이프사이클을 시뮬레이션하여 검증.
+
+    Steps:
+    1. fresh 모드: .bootstrap-version 삭제 → bootstrap.sh 실행 → [NEW] 태그 확인 → .bootstrap-version 생성 확인
+    2. verify 모드: 동일 버전으로 재실행 → [OK] 태그 확인 → .bootstrap-version 변경 없음
+    3. update 모드: .bootstrap-version의 version을 0.0.1로 수정 → 재실행 → [UPDATED] 태그 확인 → 2-hop 컨텍스트 출력 확인
+    4. session-start.sh: startup → .session-active 생성 확인 → resume 분기 확인
+    5. setup.md/setup-claude.md: .bootstrap-version 유무에 따른 분기 텍스트 존재 확인
+    6. 테스트 후 .bootstrap-version 정리
+
+    AVOID: 실제 프로젝트 상태를 변경하는 파괴적 테스트
+    USE: 임시 파일 조작 후 원복
+  </action>
+  <verify>
+    echo "ALL E2E TESTS PASSED" 이 출력되어야 함
+  </verify>
+  <done>
+    fresh/verify/update 3모드 + session-start 분기 + setup 프롬프트 분기 전체 정상 동작
+  </done>
+</task>
+
+<task type="checkpoint:human-verify">
+  <name>사용자 리뷰</name>
+  <files>
+    scripts/bootstrap.sh
+    .hxsk/hooks/session-start.sh
+    prompts/setup.md
+    prompts/setup-claude.md
+    .hxsk/skills/bootstrap/SKILL.md
+  </files>
+  <action>
+    전체 변경사항을 사용자가 리뷰.
+    설계 문서와의 일관성, 범용 에이전트 호환성 확인.
+  </action>
+  <verify>
+    사용자 승인
+  </verify>
+  <done>
+    사용자가 전체 변경사항을 승인
+  </done>
+</task>
+
+## Must-Haves
+After all tasks complete, verify:
+- [ ] bootstrap.sh가 fresh/verify/update 3모드 정상 동작
+- [ ] .bootstrap-version 파일 자동 생성/갱신
+- [ ] 2-hop 컨텍스트가 [NEW/UPDATED] 항목에서 출력
+- [ ] setup.md에 Step 0 상태 감지 + 초기/업데이트 분기
+- [ ] setup-claude.md에 동일 분기 + Claude 전용 갱신 안내
+- [ ] session-start.sh가 startup/resume/compact 분기
+- [ ] bootstrap SKILL.md v5.0.0 업데이트 시나리오 포함
+- [ ] 기존 기능 하위 호환 (fresh 모드 = 기존 동작과 동일)
+
+## Success Criteria
+- [ ] All tasks verified passing
+- [ ] Must-haves confirmed
+- [ ] E2E fresh → verify → update 사이클 통과
+- [ ] 사용자 리뷰 승인

--- a/prompts/setup-claude.md
+++ b/prompts/setup-claude.md
@@ -2,14 +2,27 @@
 
 Claude Code 전용 구성 가이드입니다. 범용 setup은 `prompts/setup.md`를 참조하세요.
 
-## Quick Setup
+## 상태 감지
+
+먼저 설치 상태를 확인하세요:
+
+```bash
+test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
+```
+
+- **FRESH** → 아래 "초기 설치"를 따르세요
+- **UPDATE** → 아래 "업데이트"를 따르세요
+
+---
+
+## 초기 설치
+
+### Quick Setup
 
 1. 이 레포의 `CLAUDE.md`를 프로젝트 루트에 저장
 2. `.hxsk/` 디렉토리 생성 및 working docs 초기화
 3. 필요한 스킬을 `.claude/skills/`에 배치
 4. `.claude/settings.json`에 훅 설정
-
-## 상세 구성
 
 ### 스킬 설치
 
@@ -55,13 +68,53 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact
 [![HExoskeleton](https://img.shields.io/badge/assisted%20with-HExoskeleton-blueviolet?style=flat-square)](https://github.com/SukbeomH/HExoskeleton)
 ```
 
-## 다음 단계
+### 초기 설치 후 다음 단계
 
-설정이 완료되면 사용자에게 다음 메시지를 보내도록 안내하세요:
+```
+/bootstrap    # 프로젝트 분석 및 메모리 초기화 (← .bootstrap-version 자동 생성)
+/planner      # SPEC 기반 실행 계획 수립
+```
 
-> **"HXSK 초기 설정이 완료되었습니다. 아래 명령어로 워크플로우를 시작하세요."**
->
-> ```
-> /bootstrap    # 프로젝트 분석 및 메모리 초기화
-> /planner      # SPEC 기반 실행 계획 수립
-> ```
+---
+
+## 업데이트
+
+이전 설치가 감지되었습니다.
+
+### Step 1: bootstrap 실행
+
+```bash
+bash scripts/bootstrap.sh
+```
+
+`[NEW]`/`[UPDATED]` 태그와 `↳ 관련:` 2-hop 컨텍스트를 확인하세요.
+
+### Step 2: Claude Code 전용 갱신
+
+`[NEW]` 또는 `[UPDATED]`가 있는 경우:
+
+**스킬 갱신이 필요하면:**
+```bash
+# 새 스킬 또는 변경된 스킬을 .claude/skills/에 복사
+cp .hxsk/skills/{name}/SKILL.md .claude/skills/{name}/SKILL.md
+```
+
+**훅 갱신이 필요하면:**
+- `.hxsk/hooks/` 내 변경된 훅 확인
+- `.claude/settings.json`에 새 훅 이벤트 등록 필요 여부 확인
+
+**CLAUDE.md 갱신이 필요하면:**
+- HExoskeleton 레포의 최신 `CLAUDE.md`와 프로젝트의 `CLAUDE.md` 비교
+- 변경 사항 반영
+
+### Step 3: 확인
+
+```bash
+bash scripts/bootstrap.sh
+```
+
+모든 항목이 `[OK]`이면 업데이트 완료.
+
+### 업데이트 후 다음 단계
+
+> **업데이트가 완료되었습니다. `[UPDATED]` 항목의 관련 컴포넌트를 확인하고 작업을 이어가세요.**

--- a/prompts/setup.md
+++ b/prompts/setup.md
@@ -2,18 +2,33 @@
 
 아래 지침에 따라 현재 프로젝트에 HExoskeleton(HXSK) 개발 방법론을 구성하세요.
 
-## Step 1: 진입점 읽기
+## Step 0: 상태 감지
+
+먼저 설치 상태를 확인하세요:
+
+```bash
+test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
+```
+
+- **FRESH** (파일 없음) → 아래 "초기 설치" 경로를 따르세요 (Step 1~7)
+- **UPDATE** (파일 있음) → 아래 "업데이트" 경로를 따르세요
+
+---
+
+## 초기 설치
+
+### Step 1: 진입점 읽기
 
 이 레포의 `llms.txt`를 읽어 사용 가능한 리소스 목록을 파악하세요.
 
-## Step 2: 에이전트 지침 설정
+### Step 2: 에이전트 지침 설정
 
 당신의 에이전트 유형에 맞는 지침 파일을 가져오세요:
 - **Claude Code** → `CLAUDE.md`를 프로젝트 루트에 저장
 - **Gemini CLI** → `GEMINI.md`를 프로젝트 루트에 저장
 - **기타** (Copilot, Cursor, Windsurf 등) → `AGENTS.md`를 프로젝트 루트에 저장
 
-## Step 3: HXSK 문서 구조 생성
+### Step 3: HXSK 문서 구조 생성
 
 프로젝트에 `.hxsk/` 디렉토리를 만들고 working docs를 생성하세요:
 
@@ -29,7 +44,7 @@
 
 `templates/INDEX.md`를 참조하여 필요한 템플릿만 선택적으로 가져오세요.
 
-## Step 4: 스킬 설치 (선택)
+### Step 4: 스킬 설치 (선택)
 
 `skills/INDEX.md`를 참조하여 필요한 스킬만 가져오세요:
 - **Claude Code** → `.claude/skills/{name}/SKILL.md`에 배치
@@ -38,7 +53,7 @@
 
 권장 필수 스킬: `planner`, `executor`, `verifier`, `memory-protocol`
 
-## Step 5: 에이전트별 자동 로드 경로 연결
+### Step 5: 에이전트별 자동 로드 경로 연결
 
 `AGENTS.md`를 각 에이전트의 자동 로드 경로에 심볼릭 링크로 연결하세요:
 
@@ -56,21 +71,13 @@ ln -sf AGENTS.md .windsurfrules
 
 이렇게 하면 별도 옵션 없이 에이전트를 실행해도 HXSK 지침이 자동 로드됩니다.
 
-## Step 6: 훅 설치 (Claude Code만, 선택)
+### Step 6: 훅 설치 (Claude Code만, 선택)
 
 훅은 Claude Code에서만 동작합니다. 다른 에이전트는 AGENTS.md의 Agent Boundaries 규칙으로 대체됩니다.
 
 `hooks/INDEX.md`를 참조하여 필요한 훅을 가져오고 `.claude/settings.json`에 등록하세요.
 
-## 완료 확인
-
-- [ ] 에이전트 지침 파일이 프로젝트 루트에 존재
-- [ ] `.hxsk/` 디렉토리에 SPEC.md, STATE.md, PATTERNS.md 존재
-- [ ] (선택) 스킬이 에이전트 설정 디렉토리에 배치됨
-- [ ] (선택) 에이전트별 심볼릭 링크 생성됨 (.cursorrules, .windsurfrules 등)
-- [ ] (선택, Claude Code) 훅이 설치되고 settings.json에 등록됨
-
-## Step 7: README에 뱃지 추가 (선택)
+### Step 7: README에 뱃지 추가 (선택)
 
 프로젝트 README에 HExoskeleton 뱃지를 추가하세요:
 
@@ -78,13 +85,54 @@ ln -sf AGENTS.md .windsurfrules
 [![HExoskeleton](https://img.shields.io/badge/assisted%20with-HExoskeleton-blueviolet?style=flat-square)](https://github.com/SukbeomH/HExoskeleton)
 ```
 
-## 다음 단계
+### 완료 확인
 
-설정이 완료되면 사용자에게 다음 메시지를 보내도록 안내하세요:
+- [ ] 에이전트 지침 파일이 프로젝트 루트에 존재
+- [ ] `.hxsk/` 디렉토리에 SPEC.md, STATE.md, PATTERNS.md 존재
+- [ ] (선택) 스킬이 에이전트 설정 디렉토리에 배치됨
+- [ ] (선택) 에이전트별 심볼릭 링크 생성됨 (.cursorrules, .windsurfrules 등)
+- [ ] (선택, Claude Code) 훅이 설치되고 settings.json에 등록됨
 
-> **"HXSK 초기 설정이 완료되었습니다. 아래 명령어로 워크플로우를 시작하세요."**
->
-> ```
-> /bootstrap    # 프로젝트 분석 및 메모리 초기화
-> /planner      # SPEC 기반 실행 계획 수립
-> ```
+### 초기 설치 후 다음 단계
+
+```
+/bootstrap    # 프로젝트 분석 및 메모리 초기화 (← .bootstrap-version 자동 생성)
+/planner      # SPEC 기반 실행 계획 수립
+```
+
+---
+
+## 업데이트
+
+이전 설치가 감지되었습니다. 아래 절차로 업데이트하세요.
+
+### Step 1: bootstrap 실행
+
+```bash
+bash scripts/bootstrap.sh
+```
+
+출력에서 다음 태그를 확인하세요:
+- `[OK]` — 변경 없음, 정상
+- `[NEW]` — 새로 추가된 컴포넌트
+- `[UPDATED]` — 변경된 컴포넌트 (이전 → 현재 수치 표시)
+- `[UPDATED]` 항목에는 `↳ 관련:` 으로 연관 컴포넌트가 2-hop 검색으로 표시됩니다
+
+### Step 2: 에이전트별 설정 갱신
+
+`[NEW]` 또는 `[UPDATED]`가 있는 경우:
+- 스킬이 추가/변경되었으면 → 에이전트 스킬 디렉토리 갱신
+- 훅이 추가/변경되었으면 → `.claude/settings.json` 갱신 (Claude Code만)
+- 에이전트 지침이 변경되었으면 → CLAUDE.md/GEMINI.md/AGENTS.md 갱신
+
+### Step 3: 확인
+
+```bash
+bash scripts/bootstrap.sh
+```
+
+모든 항목이 `[OK]`이면 업데이트 완료.
+
+### 업데이트 후 다음 단계
+
+> **업데이트가 완료되었습니다. `[UPDATED]` 항목의 관련 컴포넌트를 확인하고 작업을 이어가세요.**

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-# Verify system prerequisites for the boilerplate project.
-# Checks required tools, MCP dependencies, environment files, and optional extras.
+# Idempotent bootstrap convergence engine for HExoskeleton.
+# Detects fresh install / verify / update mode via .hxsk/.bootstrap-version.
+# Checks required tools, environment, context structure, and reports delta.
+#
 # Usage: bash scripts/bootstrap.sh
 #
 # Exit 0: All required checks pass
@@ -12,6 +14,25 @@ set -o nounset
 set -o pipefail
 
 # ─────────────────────────────────────────────────────
+# Version & Mode Detection
+# ─────────────────────────────────────────────────────
+
+BOOTSTRAP_VERSION="5.0.0"
+VERSION_FILE=".hxsk/.bootstrap-version"
+HOOK_DIR=".hxsk/hooks"
+MODE="fresh"
+OLD_VERSION=""
+
+if [[ -f "$VERSION_FILE" ]]; then
+    OLD_VERSION=$(grep '^version:' "$VERSION_FILE" 2>/dev/null | sed 's/^version: *//' | tr -d '"')
+    if [[ "$OLD_VERSION" = "$BOOTSTRAP_VERSION" ]]; then
+        MODE="verify"
+    else
+        MODE="update"
+    fi
+fi
+
+# ─────────────────────────────────────────────────────
 # Counters
 # ─────────────────────────────────────────────────────
 
@@ -19,6 +40,8 @@ PASS_COUNT=0
 FAIL_COUNT=0
 WARN_COUNT=0
 SKIP_COUNT=0
+NEW_COUNT=0
+UPDATED_COUNT=0
 REQUIRED_FAIL=0
 
 # ─────────────────────────────────────────────────────
@@ -26,35 +49,80 @@ REQUIRED_FAIL=0
 # ─────────────────────────────────────────────────────
 
 report_pass() {
-    printf "  [PASS] %-20s %s\n" "$1" "$2"
+    printf "  [PASS]    %-20s %s\n" "$1" "$2"
     ((PASS_COUNT++)) || true
 }
 
 report_fail() {
-    printf "  [FAIL] %-20s %s\n" "$1" "$2"
+    printf "  [FAIL]    %-20s %s\n" "$1" "$2"
     ((FAIL_COUNT++)) || true
     ((REQUIRED_FAIL++)) || true
 }
 
 report_warn() {
-    printf "  [WARN] %-20s %s\n" "$1" "$2"
+    printf "  [WARN]    %-20s %s\n" "$1" "$2"
     ((WARN_COUNT++)) || true
 }
 
 report_skip() {
-    printf "  [SKIP] %-20s %s\n" "$1" "$2"
+    printf "  [SKIP]    %-20s %s\n" "$1" "$2"
     ((SKIP_COUNT++)) || true
 }
+
+report_new() {
+    printf "  [NEW]     %-20s %s\n" "$1" "$2"
+    ((NEW_COUNT++)) || true
+    report_context "$1"
+}
+
+report_updated() {
+    printf "  [UPDATED] %-20s %s\n" "$1" "$2"
+    ((UPDATED_COUNT++)) || true
+    report_context "$1"
+}
+
+report_ok() {
+    printf "  [OK]      %-20s %s\n" "$1" "$2"
+    ((PASS_COUNT++)) || true
+}
+
+# 2-hop 컨텍스트: [NEW] 또는 [UPDATED] 항목에 관련 컴포넌트 표시
+report_context() {
+    local component="$1"
+    if [[ -x "$HOOK_DIR/md-recall-memory.sh" ]]; then
+        local related
+        related=$("$HOOK_DIR/md-recall-memory.sh" "$component" "." 3 compact 2 2>/dev/null || true)
+        if [[ -n "$related" ]]; then
+            printf "            %-20s %s\n" "" "↳ 관련: $(echo "$related" | head -3 | tr '\n' ' ')"
+        fi
+    fi
+}
+
+# 컴포넌트 수 세기
+count_skills() { find .hxsk/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_agents() { find .hxsk/agents -name "*.md" -not -name "INDEX.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_hooks()  { find .hxsk/hooks -name "*.sh" -o -name "*.py" 2>/dev/null | wc -l | tr -d ' '; }
+count_memories() { find .hxsk/memories -mindepth 1 -maxdepth 1 -type d -not -name "_schema" 2>/dev/null | wc -l | tr -d ' '; }
+
+# ─────────────────────────────────────────────────────
+# Header
+# ─────────────────────────────────────────────────────
+
+echo "================================================================"
+echo " BOOTSTRAP v${BOOTSTRAP_VERSION}"
+case "$MODE" in
+    fresh)  echo " MODE: fresh (초기 설치)" ;;
+    verify) echo " MODE: verify (v${OLD_VERSION} — 구조 검증)" ;;
+    update) echo " MODE: update (v${OLD_VERSION} → v${BOOTSTRAP_VERSION})" ;;
+esac
+echo "================================================================"
 
 # ─────────────────────────────────────────────────────
 # System Prerequisites (Required)
 # ─────────────────────────────────────────────────────
 
-echo "================================================================"
-echo " BOOTSTRAP: System Prerequisites Check"
-echo "================================================================"
 echo ""
-echo "--- Required ---"
+echo "--- System Prerequisites ---"
 
 # Node.js >= 18
 if command -v node &>/dev/null; then
@@ -77,7 +145,7 @@ else
     report_fail "npm" "not found — https://nodejs.org/"
 fi
 
-# uv (optional — Python 프로젝트에서만 필요)
+# uv (optional)
 if command -v uv &>/dev/null; then
     UV_VER=$(uv --version 2>/dev/null | awk '{print $2}')
     report_pass "uv" "${UV_VER}"
@@ -85,7 +153,7 @@ else
     report_skip "uv" "not found — only needed for Python projects"
 fi
 
-# Python 3 (보안 훅에서 사용 — 선택적)
+# Python 3
 if command -v python3 &>/dev/null; then
     PY_VER=$(python3 --version | awk '{print $2}')
     PY_MINOR=$(echo "$PY_VER" | cut -d. -f2)
@@ -95,7 +163,7 @@ if command -v python3 &>/dev/null; then
         report_warn "Python" "${PY_VER} (>= 3.11 recommended)"
     fi
 else
-    report_warn "Python" "not found — security hooks (file-protect, bash-guard) unavailable"
+    report_warn "Python" "not found — security hooks unavailable"
 fi
 
 # qlty CLI
@@ -103,19 +171,19 @@ if command -v qlty &>/dev/null; then
     QLTY_VER=$(qlty --version 2>/dev/null || echo "installed")
     report_pass "qlty" "${QLTY_VER}"
 else
-    report_warn "qlty" "not found — optional for code quality checks"
+    report_warn "qlty" "not found — optional"
 fi
 
-# .hxsk/memories/ directory
-if [[ -d ".hxsk/memories" ]]; then
-    MEM_COUNT=$(ls .hxsk/memories/ 2>/dev/null | wc -l | tr -d ' ')
-    report_pass ".hxsk/memories/" "${MEM_COUNT} type directories"
+# gh CLI
+if command -v gh &>/dev/null; then
+    GH_VER=$(gh --version 2>/dev/null | head -1 | awk '{print $3}')
+    report_pass "gh CLI" "v${GH_VER}"
 else
-    report_warn ".hxsk/memories/" "missing — will be created by bootstrap"
+    report_skip "gh CLI" "not found — brew install gh"
 fi
 
 # ─────────────────────────────────────────────────────
-# Environment (Warn)
+# Environment
 # ─────────────────────────────────────────────────────
 
 echo ""
@@ -124,54 +192,107 @@ echo "--- Environment ---"
 if [[ -f .env ]]; then
     report_pass ".env" "exists"
 else
-    report_warn ".env" "missing — will be created from .env.example"
+    if [[ -f .env.example ]]; then
+        cp .env.example .env
+        report_new ".env" "created from .env.example"
+    else
+        report_warn ".env" "missing — no .env.example found"
+    fi
 fi
 
 if [[ -d .venv ]]; then
     report_pass ".venv" "exists"
 else
-    report_warn ".venv" "missing — will be created by uv sync"
+    report_skip ".venv" "missing — create with uv sync if needed"
 fi
 
 # ─────────────────────────────────────────────────────
-# Context Structure (Auto-create)
+# HXSK Structure
 # ─────────────────────────────────────────────────────
 
 echo ""
-echo "--- Context Structure ---"
+echo "--- HXSK Structure ---"
 
-# Required .hxsk folders
-for dir in reports research archive; do
+# Memory directories
+if [[ -d ".hxsk/memories" ]]; then
+    MEM_COUNT=$(count_memories)
+    if [[ "$MODE" = "fresh" ]]; then
+        report_new ".hxsk/memories/" "${MEM_COUNT} type directories"
+    else
+        report_ok ".hxsk/memories/" "${MEM_COUNT} type directories"
+    fi
+else
+    mkdir -p .hxsk/memories/{architecture-decision,root-cause,debug-eliminated,debug-blocked,health-event,session-handoff,execution-summary,deviation,pattern-discovery,bootstrap,session-summary,session-snapshot,security-finding,general,_schema}
+    report_new ".hxsk/memories/" "created (14 types + _schema)"
+fi
+
+# Context directories
+for dir in reports research archive issues/archive; do
     if [[ -d ".hxsk/$dir" ]]; then
-        report_pass ".hxsk/$dir/" "exists"
+        report_ok ".hxsk/$dir/" "exists"
     else
         mkdir -p ".hxsk/$dir"
-        report_pass ".hxsk/$dir/" "created"
+        report_new ".hxsk/$dir/" "created"
     fi
 done
 
-# Context management files
+# Context files
 if [[ -f ".hxsk/PATTERNS.md" ]]; then
     PATTERNS_SIZE=$(wc -c < ".hxsk/PATTERNS.md" | tr -d ' ')
-    report_pass "PATTERNS.md" "${PATTERNS_SIZE}B"
+    report_ok "PATTERNS.md" "${PATTERNS_SIZE}B"
 else
     if [[ -f ".hxsk/templates/patterns.md" ]]; then
         cp ".hxsk/templates/patterns.md" ".hxsk/PATTERNS.md"
-        report_pass "PATTERNS.md" "initialized from template"
+        report_new "PATTERNS.md" "initialized from template"
     else
         report_warn "PATTERNS.md" "missing — no template found"
     fi
 fi
 
 if [[ -f ".hxsk/context-config.yaml" ]]; then
-    report_pass "context-config.yaml" "exists"
+    report_ok "context-config.yaml" "exists"
 else
     if [[ -f ".hxsk/templates/context-config.yaml" ]]; then
         cp ".hxsk/templates/context-config.yaml" ".hxsk/context-config.yaml"
-        report_pass "context-config.yaml" "initialized from template"
+        report_new "context-config.yaml" "initialized from template"
     else
         report_warn "context-config.yaml" "missing — no template found"
     fi
+fi
+
+# ─────────────────────────────────────────────────────
+# Components
+# ─────────────────────────────────────────────────────
+
+echo ""
+echo "--- Components ---"
+
+SKILL_COUNT=$(count_skills)
+AGENT_COUNT=$(count_agents)
+HOOK_COUNT=$(count_hooks)
+MEM_TYPE_COUNT=$(count_memories)
+
+if [[ "$MODE" = "fresh" ]]; then
+    report_new "Skills" "${SKILL_COUNT} installed"
+    report_new "Agents" "${AGENT_COUNT} installed"
+    report_new "Hooks" "${HOOK_COUNT} installed"
+    report_new "Memory Types" "${MEM_TYPE_COUNT} directories"
+elif [[ "$MODE" = "update" ]]; then
+    # 구버전의 컴포넌트 수와 비교
+    OLD_SKILLS=$(grep 'skills:' "$VERSION_FILE" 2>/dev/null | sed 's/.*skills: *//' | tr -d ' ')
+    OLD_AGENTS=$(grep 'agents:' "$VERSION_FILE" 2>/dev/null | sed 's/.*agents: *//' | tr -d ' ')
+    OLD_HOOKS=$(grep 'hooks:' "$VERSION_FILE" 2>/dev/null | sed 's/.*hooks: *//' | tr -d ' ')
+    OLD_MEMS=$(grep 'memories:' "$VERSION_FILE" 2>/dev/null | sed 's/.*memories: *//' | tr -d ' ')
+
+    [[ "$SKILL_COUNT" != "${OLD_SKILLS:-0}" ]] && report_updated "Skills" "${OLD_SKILLS:-0} → ${SKILL_COUNT}" || report_ok "Skills" "${SKILL_COUNT}"
+    [[ "$AGENT_COUNT" != "${OLD_AGENTS:-0}" ]] && report_updated "Agents" "${OLD_AGENTS:-0} → ${AGENT_COUNT}" || report_ok "Agents" "${AGENT_COUNT}"
+    [[ "$HOOK_COUNT" != "${OLD_HOOKS:-0}" ]]   && report_updated "Hooks" "${OLD_HOOKS:-0} → ${HOOK_COUNT}"   || report_ok "Hooks" "${HOOK_COUNT}"
+    [[ "$MEM_TYPE_COUNT" != "${OLD_MEMS:-0}" ]] && report_updated "Memory Types" "${OLD_MEMS:-0} → ${MEM_TYPE_COUNT}" || report_ok "Memory Types" "${MEM_TYPE_COUNT}"
+else
+    report_ok "Skills" "${SKILL_COUNT}"
+    report_ok "Agents" "${AGENT_COUNT}"
+    report_ok "Hooks" "${HOOK_COUNT}"
+    report_ok "Memory Types" "${MEM_TYPE_COUNT}"
 fi
 
 # ─────────────────────────────────────────────────────
@@ -200,18 +321,19 @@ else
 fi
 
 # ─────────────────────────────────────────────────────
-# Optional
+# Write Version File
 # ─────────────────────────────────────────────────────
 
-echo ""
-echo "--- Optional ---"
-
-if command -v gh &>/dev/null; then
-    GH_VER=$(gh --version 2>/dev/null | head -1 | awk '{print $3}')
-    report_pass "gh CLI" "v${GH_VER}"
-else
-    report_skip "gh CLI" "not found — brew install gh"
-fi
+mkdir -p "$(dirname "$VERSION_FILE")"
+cat > "$VERSION_FILE" << EOF
+version: ${BOOTSTRAP_VERSION}
+last_run: $(date '+%Y-%m-%d')
+components:
+  skills: ${SKILL_COUNT}
+  agents: ${AGENT_COUNT}
+  hooks: ${HOOK_COUNT}
+  memories: ${MEM_TYPE_COUNT}
+EOF
 
 # ─────────────────────────────────────────────────────
 # Summary
@@ -219,8 +341,13 @@ fi
 
 echo ""
 echo "================================================================"
-printf " PASS: %d  |  FAIL: %d  |  WARN: %d  |  SKIP: %d\n" \
-    "$PASS_COUNT" "$FAIL_COUNT" "$WARN_COUNT" "$SKIP_COUNT"
+case "$MODE" in
+    fresh)  printf " MODE: fresh  |  " ;;
+    verify) printf " MODE: verify |  " ;;
+    update) printf " MODE: update (v%s → v%s)  |  " "$OLD_VERSION" "$BOOTSTRAP_VERSION" ;;
+esac
+printf "PASS: %d  FAIL: %d  WARN: %d  SKIP: %d  NEW: %d  UPDATED: %d\n" \
+    "$PASS_COUNT" "$FAIL_COUNT" "$WARN_COUNT" "$SKIP_COUNT" "$NEW_COUNT" "$UPDATED_COUNT"
 
 if [[ "$REQUIRED_FAIL" -gt 0 ]]; then
     echo " RESULT: FAILED — ${REQUIRED_FAIL} required check(s) failed"


### PR DESCRIPTION
## Summary
- bootstrap.sh를 멱등 수렴 엔진으로 전환 (fresh/verify/update 3모드)
- `[NEW/UPDATED/OK]` 태깅 + 2-hop 메모리 컨텍스트 자동 표시
- setup.md/setup-claude.md에 상태 감지 분기 (에이전트가 자율 판단)
- session-start.sh에 source 기반 분기 (startup/resume/compact)
- 범용 에이전트 호환: 순수 bash, `.session-active` 마커 fallback

## Changes
| 파일 | 변경 |
|------|------|
| `scripts/bootstrap.sh` | 멱등 수렴 + 버전 마커 + 2-hop + [NEW/UPDATED/OK] |
| `prompts/setup.md` | Step 0 상태 감지 + 초기/업데이트 분기 |
| `prompts/setup-claude.md` | 동일 분기 + Claude 전용 갱신 안내 |
| `.hxsk/hooks/session-start.sh` | source 분기 + .session-active fallback |
| `.hxsk/skills/bootstrap/SKILL.md` | v5.0.0, 업데이트 시나리오 |
| `.hxsk/templates/bootstrap-version.yaml` | 신규 템플릿 |

## Test plan
- [x] fresh 모드: NEW 태그 + .bootstrap-version 생성
- [x] verify 모드: OK 태그 + 변경 없음
- [x] update 모드: UPDATED 감지 (Skills 18→19)
- [x] session-start startup: 풀 로드 + .session-active 생성
- [x] session-start resume: 최소 로드 (memory/commits 미포함)
- [x] setup.md Step 0 존재
- [x] setup-claude.md 분기 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)