### PR TITLE
docs(readme): Quick Start를 setup 프롬프트 소개로 변경 + GIF 하단 이동

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen?style=flat-square" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/stack-bash%20%2B%20markdown-blue?style=flat-square" alt="Bash + Markdown" />
-  <img src="https://img.shields.io/badge/agents-Claude%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Copilot%20%7C%20Windsurf-blueviolet?style=flat-square" alt="Multi-Agent" />
-  <img src="https://img.shields.io/badge/skills-19%20%7C%20agents%2017%20%7C%20hooks%2017-orange?style=flat-square" alt="Components" />
+  <img src="https://img.shields.io/badge/multi--agent-5%20platforms-blueviolet?style=flat-square" alt="Multi-Agent" />
+  <img src="https://img.shields.io/badge/19%20skills%20%C2%B7%2017%20agents%20%C2%B7%2017%20hooks-orange?style=flat-square" alt="Components" />
   <img src="https://img.shields.io/github/license/SukbeomH/HExoskeleton?style=flat-square" alt="License" />
 </p>
 
@@ -36,13 +36,7 @@ AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝�
 | [setup.md](prompts/setup.md) | 범용 | Copilot, Cursor, Gemini, Windsurf 등 |
 | [setup-claude.md](prompts/setup-claude.md) | Claude Code | 훅 + 스킬 + 메모리 전체 구성 |
 
-> 초기 설치와 업데이트를 자동 감지합니다. 에이전트가 `.hxsk/.bootstrap-version`을 확인하고 필요한 작업만 수행합니다.
-
-```
-SPEC → PLAN → EXECUTE → VERIFY
-```
-
-> **외부 종속성 없음** — Node.js, Python 환경, MCP 서버, 벡터 DB 불필요.
+> **외부 종속성 없음** — 초기 설치/업데이트 자동 감지. `SPEC → PLAN → EXECUTE → VERIFY`
 
 <details>
 <summary><strong>직접 코드를 받고 싶다면</strong></summary>
@@ -77,9 +71,9 @@ make setup
 | **메모리** | 파일 기반 2-Hop 그래프 검색 | 벡터 DB 유사도 검색 |
 | **감사(Audit)** | Git 추적 가능 (Markdown) | 블랙박스 |
 | **학습 곡선** | 낮음 (파일 수정 위주) | 높음 (SDK/API 학습 필요) |
-| **환경** | Claude Code 네이티브 최적화 | 범용, 별도 래퍼 필요 |
+| **환경** | 5개 에이전트 네이티브 지원 | 범용, 별도 래퍼 필요 |
 
-**핵심 원칙:** Claude Code의 네이티브 도구(`Grep`, `Glob`, `Read`)가 이미 강력한 검색 엔진입니다. 파일 시스템이 곧 데이터베이스입니다.
+**핵심 원칙:** 에이전트의 네이티브 도구(`Grep`, `Glob`, `Read`)가 이미 강력한 검색 엔진입니다. 파일 시스템이 곧 데이터베이스입니다.
 
 ---
 
@@ -92,7 +86,11 @@ make setup
 | **Hooks** | 17 | 이벤트 기반 자동화 (가드레일, 상태 저장) | [docs/HOOKS.md](docs/HOOKS.md) |
 | **Memory** | 14 types | A-Mem 확장 파일 기반 메모리 (2-hop) | [docs/MEMORY.md](docs/MEMORY.md) |
 
-**Skill**(How)과 **Agent**(When/With What)를 분리하여 유지보수성과 자율성을 동시에 확보합니다. Claude는 작업 성격을 인식하여 적절한 스킬을 자율 판단하고 호출합니다.
+**Skill**(How)과 **Agent**(When/With What)를 분리하여 유지보수성과 자율성을 동시에 확보합니다.
+
+<details>
+<summary><strong>상세 문서</strong></summary>
+<br>
 
 | 문서 | 설명 |
 |------|------|
@@ -102,6 +100,8 @@ make setup
 | [Linting](docs/LINTING.md) | 린팅 설정 |
 | [MCP](docs/MCP.md) | MCP 서버 통합 |
 | [Research](.hxsk/research/INDEX.md) | 리서치 문서 카탈로그 (30개, 6개 카테고리) |
+
+</details>
 
 ---
 
@@ -197,7 +197,9 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 
 ---
 
-## 디렉토리 구조
+<details>
+<summary><strong>디렉토리 구조</strong></summary>
+<br>
 
 ```
 .
@@ -221,9 +223,11 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 └── scripts/                   # 유틸리티 스크립트
 ```
 
----
+</details>
 
-## 참고 문서
+<details>
+<summary><strong>참고 문서</strong></summary>
+<br>
 
 | 구분 | 링크 | 설명 |
 |------|------|------|
@@ -232,6 +236,8 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 | Claude Code | [Sub-agents](https://code.claude.com/docs/en/sub-agents.md) | 에이전트 frontmatter |
 | Community | [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | Claude Code 리소스 큐레이션 |
 | Community | [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | MCP 서버 목록 |
+
+</details>
 
 ---
 
@@ -281,10 +287,6 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 <p align="center">
   <img src="logo.gif" alt="HExoskeleton 워크플로우 데모" width="480" />
   <br><sub>SPEC → PLAN → EXECUTE → VERIFY 워크플로우</sub>
-</p>
-
----
-
-<p align="center">
+  <br><br>
   MIT License
 </p>

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ SPEC → PLAN → EXECUTE → VERIFY
 
 <details>
 <summary><strong>직접 코드를 받고 싶다면</strong></summary>
+<br>
 
 ```bash
 git clone https://github.com/SukbeomH/HExoskeleton.git
@@ -52,14 +53,14 @@ cd HExoskeleton
 make setup
 ```
 
-```
-/bootstrap    # 프로젝트 분석 및 메모리 초기화
-/planner      # SPEC 기반 실행 계획 수립
-/executor     # 계획 실행 (atomic commits)
-/verifier     # 경험적 증거 기반 결과 검증
-```
+| 명령어 | 설명 |
+|--------|------|
+| `/bootstrap` | 프로젝트 분석 및 메모리 초기화 |
+| `/planner` | SPEC 기반 실행 계획 수립 |
+| `/executor` | 계획 실행 (atomic commits) |
+| `/verifier` | 경험적 증거 기반 결과 검증 |
 
-`make help`로 전체 명령어를 확인할 수 있습니다.
+> `make help`로 전체 명령어를 확인할 수 있습니다.
 
 </details>
 
@@ -170,23 +171,24 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 
 <details>
 <summary><strong>메모리 타입 (14개)</strong></summary>
+<br>
 
-| 타입 | 용도 |
-|------|------|
-| `architecture-decision` | 아키텍처 결정 사항 |
-| `root-cause` | 디버깅 근본 원인 |
-| `debug-eliminated` | 배제된 가설 |
-| `debug-blocked` | 3-strike 차단 |
-| `pattern-discovery` | 발견된 패턴/학습 |
-| `deviation` | 계획 대비 이탈 |
-| `execution-summary` | 실행 결과 요약 |
-| `session-summary` | 세션 종료 요약 (자동) |
-| `session-snapshot` | Pre-compact 스냅샷 |
-| `session-handoff` | 세션 인수인계 |
-| `health-event` | 컨텍스트 건강 이벤트 |
-| `bootstrap` | 프로젝트 초기 설정 |
-| `security-finding` | 보안 발견 사항 |
-| `general` | 기타 |
+| 카테고리 | 타입 | 용도 |
+|----------|------|------|
+| **디버깅** | `root-cause` | 근본 원인 분석 |
+| | `debug-eliminated` | 배제된 가설 |
+| | `debug-blocked` | 3-strike 차단 |
+| **아키텍처** | `architecture-decision` | 아키텍처 결정 사항 |
+| | `pattern-discovery` | 발견된 패턴/학습 |
+| **실행** | `execution-summary` | 실행 결과 요약 |
+| | `deviation` | 계획 대비 이탈 |
+| **세션** | `session-summary` | 세션 종료 요약 (자동) |
+| | `session-snapshot` | Pre-compact 스냅샷 |
+| | `session-handoff` | 세션 인수인계 |
+| **시스템** | `health-event` | 컨텍스트 건강 이벤트 |
+| | `bootstrap` | 프로젝트 초기 설정 |
+| | `security-finding` | 보안 발견 사항 |
+| | `general` | 기타 |
 
 </details>
 
@@ -234,45 +236,42 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 
 <details>
 <summary><strong>설계 배경 (Design Rationale)</strong></summary>
+<br>
 
 현재 아키텍처는 최신 에이전트 메모리 및 추론 최적화 연구들을 분석하고 선택적으로 적용한 결과입니다.
 
-### 왜 순수 bash + 마크다운인가?
+#### 왜 순수 bash + 마크다운인가?
 
-| 대안 | 장점 | 채택하지 않은 이유 |
-|------|------|-------------------|
-| 벡터 DB (Qdrant, Weaviate) | 의미적 유사도 검색 | 외부 서비스 의존, 설정 복잡도 증가 |
-| MCP 서버 | 표준화된 인터페이스 | 추가 프로세스 필요, 네트워크 오버헤드 |
-| SQLite/JSON | 구조화된 쿼리 | 파일 수준 가독성 저하, Git diff 불가 |
+| 대안 | 채택하지 않은 이유 |
+|------|-------------------|
+| 벡터 DB (Qdrant, Weaviate) | 외부 서비스 의존, 설정 복잡도 증가 |
+| MCP 서버 | 추가 프로세스 필요, 네트워크 오버헤드 |
+| SQLite/JSON | 파일 수준 가독성 저하, Git diff 불가 |
 
-### 연구 기반
+#### 연구 기반
 
-| 출처 | 채택한 것 | 적용 |
-|------|----------|------|
-| [A-Mem](https://arxiv.org/html/2502.12110v11) | 7-속성 노트, Link Generation, 그래프 탐색, 토큰 절감 | frontmatter 필드, `related`, 2-hop 검색, compact 모드 |
-| [Nemori](https://arxiv.org/html/2508.03341v3) | Episodic+Semantic 이중 메모리, 중복 제거, 서사화 | 타입 분리, `[SKIP:DUPLICATE]`, contextual_description |
-| [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | 계획-실행 분리 (5x 효율) | SPEC → PLAN → EXECUTE 분리 |
-| [RLM](https://arxiv.org/html/2512.24601v2) | Root/Sub-LLM 분리, 재귀적 분할 | Agent-Skill 래핑, Phase → Plan → Task |
+| 출처 | 적용 |
+|------|------|
+| [A-Mem](https://arxiv.org/html/2502.12110v11) | frontmatter 필드, `related`, 2-hop 검색, compact 모드 |
+| [Nemori](https://arxiv.org/html/2508.03341v3) | 타입 분리, `[SKIP:DUPLICATE]`, contextual_description |
+| [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | SPEC → PLAN → EXECUTE 분리 |
+| [RLM](https://arxiv.org/html/2512.24601v2) | Agent-Skill 래핑, Phase → Plan → Task |
 
-### 왜 에이전트 정의는 간결하게?
+#### 왜 에이전트 정의는 간결하게?
 
-에이전트 정의(`.hxsk/agents/*.md`)는 ~20-30줄로 유지하고, 절차적 상세는 스킬(`.hxsk/skills/*/SKILL.md`)에 위임합니다.
+에이전트 정의(`.hxsk/agents/*.md`)는 ~20-30줄로 유지하고, 절차적 상세는 스킬에 위임합니다.
 
 | 근거 | 출처 |
 |------|------|
-| 시스템 프롬프트 ~1,800 토큰이 최적 구간, 이후 100토큰당 ~2.3% 성능 저하 | Anthropic 내부 테스트 (2차 출처) |
+| 시스템 프롬프트 ~1,800 토큰이 최적 구간 | Anthropic 내부 테스트 (2차 출처) |
 | 2,500 토큰 초과 시 환각 34% 증가 | Microsoft/Stanford 연구 |
-| "가능한 가장 작은 고신호 토큰 집합" 권장 | [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) |
-| 에이전트 트리거 정확도는 description 품질 > 길이 | [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents) |
-| 외부 파일 위임 패턴이 컨텍스트 오버플로 방지에 효과적 | Deep Agents 연구 |
+| "가장 작은 고신호 토큰 집합" 권장 | [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) |
+| description 품질 > 길이 | [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents) |
+| 외부 파일 위임 패턴 | Deep Agents 연구 |
 
-**채택하지 않은 것:**
-- Memory Evolution (A-Mem) — write-once로 감사 추적성 유지
-- Predict-Calibrate (Nemori) — LLM 추가 호출 비용 대비 효용 불확실
-- Persistent REPL (RLM) — 현재 사용 사례에서 필요성 낮음
-- 상세 에이전트 프롬프트 (100+줄) — 컨텍스트 예산 비효율, 스킬 위임으로 동등 성능 달성
+**채택하지 않은 것:** Memory Evolution (A-Mem), Predict-Calibrate (Nemori), Persistent REPL (RLM), 상세 에이전트 프롬프트 (100+줄)
 
-> 상세 리서치 문서: [.hxsk/research/INDEX.md](.hxsk/research/INDEX.md)
+> 상세: [.hxsk/research/INDEX.md](.hxsk/research/INDEX.md)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,28 @@
 
 ## Quick Start
 
+AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝트에 HXSK를 구성합니다.
+
+| 프롬프트 | 대상 | 설명 |
+|----------|------|------|
+| [setup.md](prompts/setup.md) | 범용 | Copilot, Cursor, Gemini, Windsurf 등 |
+| [setup-claude.md](prompts/setup-claude.md) | Claude Code | 훅 + 스킬 + 메모리 전체 구성 |
+
+> 초기 설치와 업데이트를 자동 감지합니다. 에이전트가 `.hxsk/.bootstrap-version`을 확인하고 필요한 작업만 수행합니다.
+
+```
+SPEC → PLAN → EXECUTE → VERIFY
+```
+
+> **외부 종속성 없음** — Node.js, Python 환경, MCP 서버, 벡터 DB 불필요.
+
+<details>
+<summary><strong>직접 코드를 받고 싶다면</strong></summary>
+
 ```bash
 git clone https://github.com/SukbeomH/HExoskeleton.git
 cd HExoskeleton
 make setup
-```
-
-```
-SPEC → PLAN → EXECUTE → VERIFY
 ```
 
 ```
@@ -45,13 +59,9 @@ SPEC → PLAN → EXECUTE → VERIFY
 /verifier     # 경험적 증거 기반 결과 검증
 ```
 
-> **외부 종속성 없음** — Node.js, Python 환경, MCP 서버, 벡터 DB 불필요.
-> `make help`로 전체 명령어를 확인할 수 있습니다.
+`make help`로 전체 명령어를 확인할 수 있습니다.
 
-<p align="center">
-  <img src="logo.gif" alt="HExoskeleton 워크플로우 데모" width="480" />
-  <br><sub>SPEC → PLAN → EXECUTE → VERIFY 워크플로우</sub>
-</p>
+</details>
 
 ---
 
@@ -134,12 +144,7 @@ HExoskeleton은 **하나의 프로젝트를 여러 AI 에이전트가 동시에 
 
 ### 새 프로젝트에 적용
 
-| 프롬프트 | 대상 | 설명 |
-|----------|------|------|
-| [setup-claude.md](prompts/setup-claude.md) | Claude Code | 훅 + 스킬 + 메모리 전체 구성 |
-| [setup.md](prompts/setup.md) | 범용 | Copilot, Cursor, Gemini 등 |
-
-> 두 프롬프트를 **동시에 적용**할 수 있습니다. Claude Code 전용 훅은 `.claude/settings.json`에만 등록되므로 다른 에이전트에 영향을 주지 않습니다.
+상단 [Quick Start](#quick-start)의 setup 프롬프트를 에이전트에게 전달하세요. 두 프롬프트를 **동시에 적용**할 수 있습니다. Claude Code 전용 훅은 `.claude/settings.json`에만 등록되므로 다른 에이전트에 영향을 주지 않습니다.
 
 ---
 
@@ -270,6 +275,13 @@ bash scripts/md-recall-memory.sh "검색어" "." 5 compact 2
 > 상세 리서치 문서: [.hxsk/research/INDEX.md](.hxsk/research/INDEX.md)
 
 </details>
+
+---
+
+<p align="center">
+  <img src="logo.gif" alt="HExoskeleton 워크플로우 데모" width="480" />
+  <br><sub>SPEC → PLAN → EXECUTE → VERIFY 워크플로우</sub>
+</p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen?style=flat-square" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/stack-bash%20%2B%20markdown-blue?style=flat-square" alt="Bash + Markdown" />
-  <img src="https://img.shields.io/badge/optimized%20for-Claude%20Code-blueviolet?style=flat-square" alt="Claude Code" />
+  <img src="https://img.shields.io/badge/agents-Claude%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Copilot%20%7C%20Windsurf-blueviolet?style=flat-square" alt="Multi-Agent" />
+  <img src="https://img.shields.io/badge/skills-19%20%7C%20agents%2017%20%7C%20hooks%2017-orange?style=flat-square" alt="Components" />
   <img src="https://img.shields.io/github/license/SukbeomH/HExoskeleton?style=flat-square" alt="License" />
 </p>
 


### PR DESCRIPTION
## Summary
- Quick Start: setup 프롬프트 테이블로 전환 (에이전트가 자율 설정)
- 기존 `git clone` + `make setup` 내용은 접기(details)로 이동
- logo.gif를 문서 최하단으로 이동
- "새 프로젝트에 적용" 중복 setup 링크 제거

## Test plan
- [x] Quick Start에 setup.md/setup-claude.md 링크 존재
- [x] "직접 코드를 받고 싶다면" details 블록 존재
- [x] logo.gif가 MIT License 직전에 위치
- [x] 기존 내용 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)