### PR TITLE
docs: 통합 setup 반영 — README + 내부문서 + workflow 최신화

### DIFF
--- a/.github/workflows/release-setup.yml
+++ b/.github/workflows/release-setup.yml
@@ -44,10 +44,9 @@ jobs:
           ## Quick Start
 
           에이전트에게 아래 프롬프트를 **복사하여 전달**하면 프로젝트에 HXSK를 자동 구성합니다.
+          모든 에이전트(Claude Code, Gemini, Copilot, Cursor, Windsurf)를 하나의 프롬프트로 지원합니다.
 
           ---
-
-          ### 범용 (Copilot, Cursor, Gemini, Windsurf 등)
 
           <details>
           <summary><strong>setup.md — 클릭하여 펼치고 복사</strong></summary>
@@ -56,23 +55,6 @@ jobs:
 
           echo '<pre><code>' >> /tmp/release-notes.md
           cat .hxsk/prompts/setup.md >> /tmp/release-notes.md
-          echo '</code></pre>' >> /tmp/release-notes.md
-
-          cat >> /tmp/release-notes.md << 'MID'
-
-          </details>
-
-          ---
-
-          ### Claude Code
-
-          <details>
-          <summary><strong>setup-claude.md — 클릭하여 펼치고 복사</strong></summary>
-
-          MID
-
-          echo '<pre><code>' >> /tmp/release-notes.md
-          cat .hxsk/prompts/setup-claude.md >> /tmp/release-notes.md
           echo '</code></pre>' >> /tmp/release-notes.md
 
           cat >> /tmp/release-notes.md << 'FOOTER'
@@ -85,8 +67,7 @@ jobs:
 
           | 파일 | 설명 |
           |------|------|
-          | `setup.md` | 범용 setup 프롬프트 |
-          | `setup-claude.md` | Claude Code setup 프롬프트 |
+          | `setup.md` | 통합 setup 프롬프트 (모든 에이전트 지원) |
           | `AGENTS.md` | 공통 에이전트 지침 |
           | `CLAUDE.md` | Claude Code 지침 |
           | `GEMINI.md` | Gemini CLI 지침 |
@@ -102,7 +83,6 @@ jobs:
             --title "Setup v${{ steps.version.outputs.version }}" \
             --notes-file /tmp/release-notes.md \
             .hxsk/prompts/setup.md \
-            .hxsk/prompts/setup-claude.md \
             AGENTS.md \
             CLAUDE.md \
             GEMINI.md \
@@ -117,7 +97,6 @@ jobs:
             --notes-file /tmp/release-notes.md
           gh release upload "${{ steps.version.outputs.tag }}" \
             .hxsk/prompts/setup.md \
-            .hxsk/prompts/setup-claude.md \
             AGENTS.md \
             CLAUDE.md \
             GEMINI.md \

--- a/.hxsk/ARCHITECTURE.md
+++ b/.hxsk/ARCHITECTURE.md
@@ -34,11 +34,12 @@ Source Components:
   ├── agents/  (17 agents)      └── *.md (11 docs)
   ├── hooks/   (17 hooks)
   ├── templates/ (27)           prompts/
-  ├── examples/ (4)             ├── setup.md
-  ├── issues/                   └── setup-claude.md
-  └── INDEX files
+  ├── examples/ (4)             prompts/
+  ├── issues/                   └── setup.md (통합)
+  ├── scripts/ (8)
 
-  scripts/ (10 utility scripts)
+  ├── docs/ (11+)
+  └── INDEX files
 ```
 
 ## Components
@@ -48,7 +49,7 @@ Source Components:
 - **Purpose:** 레포지토리 = 배포. 빌드 스크립트 없이 에이전트 도구가 직접 설정
 - **llms.txt:** 프로젝트 구조 인덱스. 에이전트가 시작점으로 사용
 - **AGENTS.md:** 에이전트 공통 지침 (Codex, Gemini, OpenCode 등 에이전트 불문)
-- **prompts/:** `setup.md` (범용), `setup-claude.md` (Claude Code 전용) — 에이전트에 Setup 절차 제공
+- **.hxsk/prompts/:** `setup.md` (통합 — 모든 에이전트 지원, Claude Code 전용 섹션 포함)
 - **CLAUDE.md:** Claude Code 전용 설정 (hooks, skills, compaction rules)
 
 ### 2. Agent-Skill System (`.hxsk/`)

--- a/.hxsk/docs/BUILD.md
+++ b/.hxsk/docs/BUILD.md
@@ -14,21 +14,20 @@
 | `AGENTS.md` | 범용 에이전트 지침 (Copilot, Cursor, Windsurf 등) |
 | `CLAUDE.md` | Claude Code 전용 설정 |
 | `GEMINI.md` | Gemini CLI 전용 설정 |
-| `prompts/setup.md` | 범용 setup 프롬프트 |
-| `prompts/setup-claude.md` | Claude Code 특화 프롬프트 |
+| `.hxsk/prompts/setup.md | 통합 setup 프롬프트 (모든 에이전트 지원) |
 
 ### 사용법
 
 사용자가 에이전트에게:
 1. 레포 URL 전달, 또는
-2. `prompts/setup.md` 내용 복붙
+2. `.hxsk/prompts/setup.md` 내용 복붙
 
 에이전트가 llms.txt를 따라가며 필요한 파일을 fetch하고 프로젝트에 배치합니다.
 
 ### 검증
 
 ```bash
-bash scripts/verify-self-configure.sh --all
+bash .hxsk/scripts/verify-self-configure.sh --all
 ```
 
 Layer 1 (정적 검증) + Layer 2 (시뮬레이션)을 실행합니다.

--- a/.hxsk/scripts/generate-llms-txt.sh
+++ b/.hxsk/scripts/generate-llms-txt.sh
@@ -28,8 +28,7 @@ cat > "$OUTPUT" << EOF
 > Last Updated: ${TODAY} · Format: llms.txt v1.0
 
 ## Setup
-- [Setup Prompt (범용)](.hxsk/prompts/setup.md): 어떤 에이전트든 이 프롬프트를 실행하면 HXSK 구성 완료
-- [Setup Prompt (Claude Code)](.hxsk/prompts/setup-claude.md): Claude Code 특화 구성
+- [Setup Prompt](.hxsk/prompts/setup.md): 어떤 에이전트든 이 프롬프트를 실행하면 HXSK 구성 완료 (Claude Code 포함)
 
 ## Agent Instructions
 - [AGENTS.md](AGENTS.md): 범용 에이전트 지침 (Copilot, Cursor, Windsurf, Devin 등)

--- a/.hxsk/scripts/verify-self-configure.sh
+++ b/.hxsk/scripts/verify-self-configure.sh
@@ -28,7 +28,7 @@ layer1() {
 
     # 1.1 Core files existence
     echo "--- 1.1 Core Files ---"
-    for f in llms.txt AGENTS.md GEMINI.md CLAUDE.md prompts/setup.md prompts/setup-claude.md; do
+    for f in llms.txt AGENTS.md GEMINI.md CLAUDE.md .hxsk/prompts/setup.md; do
         if [ -f "$REPO_ROOT/$f" ]; then
             pass "$f exists"
         else

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="#핵심-구성요소">Components</a> &middot;
   <a href="#멀티-에이전트-하나의-프로젝트">Multi-Agent</a> &middot;
   <a href="#메모리-시스템">Memory</a> &middot;
-  <a href="docs/">Docs</a>
+  <a href=".hxsk/docs/">Docs</a>
 </p>
 
 <p align="center">
@@ -143,7 +143,7 @@ HExoskeleton은 **하나의 프로젝트를 여러 AI 에이전트가 동시에 
 
 ### 새 프로젝트에 적용
 
-상단 [Quick Start](#quick-start)의 setup 프롬프트를 에이전트에게 전달하세요. 두 프롬프트를 **동시에 적용**할 수 있습니다. Claude Code 전용 훅은 `.claude/settings.json`에만 등록되므로 다른 에이전트에 영향을 주지 않습니다.
+상단 [Quick Start](#quick-start)의 setup 프롬프트를 에이전트에게 전달하세요. 하나의 프롬프트로 모든 에이전트를 지원하며, Claude Code 전용 훅은 `.claude/settings.json`에만 등록되므로 다른 에이전트에 영향을 주지 않습니다.
 
 ---
 
@@ -207,17 +207,18 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 ├── .windsurfrules → AGENTS.md # Windsurf symlink
 ├── llms.txt                   # LLM 진입점
 ├── .claude/settings.json      # 훅 설정
-├── .hxsk/                     # HXSK 핵심 (Single Source of Truth)
-│   ├── skills/                # 스킬 정의 (19)
-│   ├── agents/                # 서브에이전트 정의 (17)
-│   ├── hooks/                 # 훅 스크립트 (17)
-│   ├── memories/              # 파일 기반 메모리 (14 타입)
-│   ├── research/              # 리서치 문서 (30개, 6 카테고리)
-│   ├── STATE.md               # 현재 작업 상태
-│   └── PATTERNS.md            # 핵심 패턴/학습
-│   ├── prompts/              # Setup 프롬프트
-│   ├── docs/                 # 상세 문서
-│   └── scripts/              # 유틸리티 스크립트
+└── .hxsk/                     # HXSK 핵심 (Single Source of Truth)
+    ├── skills/                # 스킬 정의 (19)
+    ├── agents/                # 서브에이전트 정의 (17)
+    ├── hooks/                 # 훅 스크립트 (17)
+    ├── scripts/               # 유틸리티 스크립트
+    ├── docs/                  # 상세 문서
+    ├── prompts/               # Setup 프롬프트 (통합)
+    ├── templates/             # 문서 템플릿
+    ├── memories/              # 파일 기반 메모리 (14 타입)
+    ├── research/              # 리서치 문서 (30개)
+    ├── STATE.md               # 현재 작업 상태
+    └── PATTERNS.md            # 핵심 패턴/학습
 ```
 
 </details>


### PR DESCRIPTION
## Summary
#87 (setup 프롬프트 통합) 머지 후 남아있던 내부 문서 참조 일괄 최신화.

**6파일:**
- README.md: 네비 링크, 디렉토리 트리, "두 프롬프트" → "하나"
- ARCHITECTURE.md: prompts/ 구조 + Self-Configure 설명
- BUILD.md: setup-claude.md → setup.md, 경로 .hxsk/
- generate-llms-txt.sh: 단일 setup 링크
- verify-self-configure.sh: 검증 대상
- release-setup.yml: 단일 setup.md 구조

## Test plan
- [x] setup-claude.md 참조 0건 (plans/ 히스토리 제외)
- [x] README 디렉토리 트리 정상
- [x] workflow에서 setup-claude.md 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)