### PR TITLE
fix: bootstrap-version 비표준 포맷 호환 + setup 스킬 누락 수정

### DIFF
--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -52,7 +52,9 @@ test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
 - **Gemini CLI** → `.agent/skills/{name}/SKILL.md`
 - **기타** → 에이전트 문서에 따라 배치
 
-권장 필수 스킬: `planner`, `executor`, `verifier`, `memory-protocol`
+권장 필수 스킬: `bootstrap`, `planner`, `executor`, `verifier`, `memory-protocol`
+
+> **주의**: `.hxsk/.bootstrap-version` 파일을 직접 생성하지 마세요. `bootstrap.sh`가 자동 생성합니다.
 
 ### Step 5: 에이전트별 자동 로드 경로 연결
 

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -24,11 +24,19 @@ MODE="fresh"
 OLD_VERSION=""
 
 if [[ -f "$VERSION_FILE" ]]; then
+    # YAML format: "version: X.X.X" or plain version "X.X.X"
     OLD_VERSION=$(grep '^version:' "$VERSION_FILE" 2>/dev/null | sed 's/^version: *//' | tr -d '"')
+    if [[ -z "$OLD_VERSION" ]]; then
+        # Fallback: 파일 첫 줄이 버전 번호일 수 있음 (비표준 포맷)
+        OLD_VERSION=$(head -1 "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]"')
+    fi
     if [[ "$OLD_VERSION" = "$BOOTSTRAP_VERSION" ]]; then
         MODE="verify"
-    else
+    elif [[ -n "$OLD_VERSION" ]]; then
         MODE="update"
+    else
+        # 파싱 실패 — fresh로 취급
+        MODE="fresh"
     fi
 fi
 

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -24,11 +24,13 @@ MODE="fresh"
 OLD_VERSION=""
 
 if [[ -f "$VERSION_FILE" ]]; then
-    # YAML format: "version: X.X.X" or plain version "X.X.X"
-    OLD_VERSION=$(grep '^version:' "$VERSION_FILE" 2>/dev/null | sed 's/^version: *//' | tr -d '"')
+    # YAML format: "version: X.X.X" — grep || true로 errexit 방지
+    OLD_VERSION=$(grep '^version:' "$VERSION_FILE" 2>/dev/null | sed 's/^version: *//' || true)
+    # 정규화: quotes, whitespace, CR 모두 제거
+    OLD_VERSION=$(echo "$OLD_VERSION" | tr -d '"[:space:]')
     if [[ -z "$OLD_VERSION" ]]; then
         # Fallback: 파일 첫 줄이 버전 번호일 수 있음 (비표준 포맷)
-        OLD_VERSION=$(head -1 "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]"')
+        OLD_VERSION=$(head -1 "$VERSION_FILE" 2>/dev/null | tr -d '"[:space:]' || true)
     fi
     if [[ "$OLD_VERSION" = "$BOOTSTRAP_VERSION" ]]; then
         MODE="verify"


### PR DESCRIPTION
## Summary
실제 프로젝트 적용에서 발견된 2개 이슈 수정:

1. **`.bootstrap-version` 포맷 호환**: 에이전트가 `version: X.X.X` 대신 `X.X.X`만 작성하는 경우 파싱 실패 → fallback 추가
2. **setup.md 권장 스킬에 `bootstrap` 누락**: `/bootstrap` 명령어가 인식되지 않는 원인

## Test plan
- [x] `echo "1.0.0" > .hxsk/.bootstrap-version` → bootstrap.sh가 update 모드로 정상 동작
- [x] YAML 형식도 기존대로 동작
- [x] 파싱 불가 시 fresh 모드 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)