### PR TITLE
fix(setup): 스킬 설치 안내 구체화 — 필수 테이블 + 복사 명령어

### DIFF
--- a/.hxsk/PATTERNS.md
+++ b/.hxsk/PATTERNS.md
@@ -12,8 +12,8 @@
 - **Self-Configure 배포**: llms.txt + AGENTS.md + setup 프롬프트. 빌드 스크립트 없음, 레포 = 배포
 
 ## Memory System
-- **저장**: `bash scripts/md-store-memory.sh <title> <content> [tags] [type]` (→ `.hxsk/hooks/` canonical로 위임)
-- **검색**: `bash scripts/md-recall-memory.sh <query> [path] [limit] [mode]` (→ `.hxsk/hooks/` canonical로 위임)
+- **저장**: `bash .hxsk/hooks/md-store-memory.sh <title> <content> [tags] [type]`
+- **검색**: `bash .hxsk/hooks/md-recall-memory.sh <query> [path] [limit] [mode]`
 - **A-Mem 필드**: `keywords`, `contextual_description`, `related` (2-hop 검색용)
 - **중복 방지**: 동일 title → `[SKIP:DUPLICATE]` 반환
 - **스키마**: `.hxsk/memories/_schema/` (JSON Schema + type-relations.yaml)

--- a/.hxsk/hooks/save-session-changes.sh
+++ b/.hxsk/hooks/save-session-changes.sh
@@ -17,6 +17,9 @@ main() {
     CHANGELOG="$PROJECT_DIR/.hxsk/CHANGELOG.md"
     HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+    # 세션 활성 마커 정리 (session-start.sh가 생성)
+    rm -f "$PROJECT_DIR/.hxsk/.session-active"
+
     # JSON 파싱 추상화 로드
     source "$HOOK_DIR/_json_parse.sh"
 

--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -43,16 +43,31 @@ test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
 └── examples/     ← 사용 예시
 ```
 
-### Step 4: 스킬 설치 (선택)
+### Step 4: 스킬 설치
 
-`.hxsk/skills/INDEX.md`를 참조하여 필요한 스킬을 가져오세요.
+`.hxsk/skills/INDEX.md`를 참조하여 스킬을 가져오세요.
 
-**배치 경로** (에이전트별):
-- **Claude Code** → `.claude/skills/{name}/SKILL.md`
-- **Gemini CLI** → `.agent/skills/{name}/SKILL.md`
-- **기타** → 에이전트 문서에 따라 배치
+**필수 스킬** (반드시 설치):
 
-권장 필수 스킬: `bootstrap`, `planner`, `executor`, `verifier`, `memory-protocol`
+| 스킬 | 용도 |
+|------|------|
+| `bootstrap` | 프로젝트 초기화 + 업데이트 감지 |
+| `planner` | SPEC 기반 실행 계획 수립 |
+| `executor` | 계획 실행 (atomic commits) |
+| `verifier` | 경험적 증거 기반 검증 |
+| `memory-protocol` | 메모리 저장/검색 프로토콜 |
+
+**Claude Code 설치 방법:**
+```bash
+# .hxsk/skills/ 에서 .claude/skills/ 로 복사
+for skill in bootstrap planner executor verifier memory-protocol; do
+    mkdir -p .claude/skills/$skill
+    cp .hxsk/skills/$skill/SKILL.md .claude/skills/$skill/SKILL.md
+done
+```
+
+**Gemini CLI** → `.agent/skills/{name}/SKILL.md`에 배치
+**기타** → 에이전트 문서에 따라 배치
 
 > **주의**: `.hxsk/.bootstrap-version` 파일을 직접 생성하지 마세요. `bootstrap.sh`가 자동 생성합니다.
 

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -4,7 +4,7 @@
 # Detects fresh install / verify / update mode via .hxsk/.bootstrap-version.
 # Checks required tools, environment, context structure, and reports delta.
 #
-# Usage: bash scripts/bootstrap.sh
+# Usage: bash .hxsk/scripts/bootstrap.sh
 #
 # Exit 0: All required checks pass
 # Exit 1: One or more required checks failed

--- a/.hxsk/scripts/verify-self-configure.sh
+++ b/.hxsk/scripts/verify-self-configure.sh
@@ -8,7 +8,7 @@
 #
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 PASS=0
 FAIL=0
 WARN=0

--- a/.hxsk/skills/bootstrap/SKILL.md
+++ b/.hxsk/skills/bootstrap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bootstrap
 description: "Idempotent project setup — fresh install, update, or verify via convergence engine"
-version: 5.0.0
+version: 5.1.0
 allowed-tools:
   - Read
   - Write
@@ -63,7 +63,7 @@ Run the idempotent convergence engine:
 bash .hxsk/scripts/bootstrap.sh
 ```
 
-**bootstrap.sh v5.0.0 출력 태그:**
+**bootstrap.sh v5.1.0 출력 태그:**
 - `[NEW]` — 새로 생성된 컴포넌트 (↳ 관련: 2-hop 컨텍스트)
 - `[UPDATED]` — 변경 감지된 컴포넌트 (↳ 관련: 2-hop 컨텍스트)
 - `[OK]` — 변경 없음, 정상
@@ -165,8 +165,8 @@ bootstrap.sh가 이미 구조화된 보고서를 출력합니다:
 
 ```
 ================================================================
- BOOTSTRAP v5.0.0
- MODE: fresh | verify | update (vX.X.X → v5.0.0)
+ BOOTSTRAP v5.1.0
+ MODE: fresh | verify | update (vX.X.X → v5.1.0)
 ================================================================
 ...
  MODE: {mode}  |  PASS: N  FAIL: N  WARN: N  SKIP: N  NEW: N  UPDATED: N

--- a/.hxsk/skills/bootstrap/SKILL.md
+++ b/.hxsk/skills/bootstrap/SKILL.md
@@ -146,7 +146,7 @@ Delegate to the `codebase-mapper` skill to analyze the project:
 Store the bootstrap record:
 
 ```bash
-bash .hxsk/scripts/md-store-memory.sh \
+bash .hxsk/hooks/md-store-memory.sh \
   "Project Bootstrap" \
   "Bootstrap completed. System prerequisites verified. Memory initialized." \
   "bootstrap,init,setup" \
@@ -193,5 +193,5 @@ bootstrap.sh가 이미 구조화된 보고서를 출력합니다:
 
 ## Scripts
 
-- `scripts/bootstrap.sh`: Idempotent convergence engine (fresh/verify/update 3-mode)
-- `scripts/detect-language.sh`: Language, package manager detection functions (optional)
+- `.hxsk/scripts/bootstrap.sh`: Idempotent convergence engine (fresh/verify/update 3-mode)
+- `.hxsk/scripts/detect-language.sh`: Language, package manager detection functions (optional)

--- a/.hxsk/skills/dispatcher/SKILL.md
+++ b/.hxsk/skills/dispatcher/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
 - **출력**: 6-Phase 라이프사이클 (SPLIT → BRANCH → Wave Loop[DISPATCH → TRACK → MERGE] → VERIFY)
 - **Main Root**: `git worktree list | head -1 | awk '{print $1}'`
 - **규칙**: 같은 Wave 내 files + side_effect_files 겹침 금지
-- **Merge**: `scripts/merge-worktrees.sh` 사용
+- **Merge**: `.hxsk/scripts/merge-worktrees.sh` 사용
 
 # Dispatcher Skill v2
 


### PR DESCRIPTION
## Summary
적용 프로젝트에서 `/bootstrap` 등 스킬이 인식되지 않는 문제 해결.

**원인:** setup.md Step 4가 "선택"으로 표기, 스킬 이름만 나열 → 에이전트가 일부 누락
**수정:** 필수 스킬 테이블 + Claude Code용 for-loop 복사 명령어 명시

## Test plan
- [x] setup.md에 5개 필수 스킬 테이블 존재
- [x] `for skill in bootstrap planner...` 복사 명령어 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)