### PR TITLE
fix: 버전 5.1.1 수정 + CHANGELOG 현행화

### DIFF
--- a/.hxsk/.bootstrap-version
+++ b/.hxsk/.bootstrap-version
@@ -1,4 +1,4 @@
-version: 5.0.1
+version: 5.1.1
 last_run: 2026-03-31
 components:
   skills: 19

--- a/.hxsk/CHANGELOG.md
+++ b/.hxsk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ---
 
-### [2026-03-31] v5.0.1 — Hook 경로 수정
+### [2026-03-31] v5.1.1 — Hook 경로 수정 + gitignore 리팩토링
 
 **변경 파일**: 6개 | **Issue**: #001
 
@@ -17,7 +17,8 @@
 - `.hxsk/ARCHITECTURE.md` — Conventions 섹션 훅 경로 설명 수정
 - `.hxsk/prompts/setup.md` — Step 6 훅 설치 예시 상대 경로로 수정
 - `.hxsk/prompts/migrate-hook-paths.md` — 기존 프로젝트용 마이그레이션 프롬프트 신규
-- `.hxsk/.bootstrap-version` — 5.0.0 → 5.0.1
+- `.gitignore` — allowlist→blocklist 전환, 불필요 항목 정리
+- `.hxsk/.bootstrap-version` — 5.1.0 → 5.1.1
 
 ---
 

--- a/.hxsk/CURRENT.md
+++ b/.hxsk/CURRENT.md
@@ -1,34 +1,28 @@
 # Current Session Context
 
 ## Session Narrative
-> On 2026-03-31 13:38:46, the developer was working on the **fix/hook-paths-v5.0.1** branch, modifying 8 files across `.hxsk`. The recent work involved: refactor(gitignore): .hxsk allowlist → blocklist 전환 (#96).
+> On 2026-03-31 13:40:47, the developer was working on the **fix/hook-paths-v5.0.1** branch, modifying 1 files across `.hxsk`. The recent work involved: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반).
 
 ## Context Snapshot
-- **Active Task**: refactor(gitignore): .hxsk allowlist → blocklist 전환 (#96)
+- **Active Task**: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
 - **Branch**: fix/hook-paths-v5.0.1
-- **Files Changed**: 8
-- **Last Updated**: 2026-03-31 13:38:46
+- **Files Changed**: 1
+- **Last Updated**: 2026-03-31 13:40:47
 
 ## Working Files
 ```
-?? .hxsk/CURRENT.md
-?? .hxsk/DECISIONS.md
-?? .hxsk/JOURNAL.md
-?? .hxsk/ROADMAP.md
-?? .hxsk/SPEC.md
-?? .hxsk/STACK.md
-?? .hxsk/TODO.md
-?? .hxsk/VERIFICATION.md
+ M .hxsk/CURRENT.md
 ```
 
 ## Recent Commits
 ```
+f8dcd86 fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
+6aa702a chore: .hxsk 루트 working docs 8개 추적 시작 (#97)
 10ff9fd refactor(gitignore): .hxsk allowlist → blocklist 전환 (#96)
-f51fb35 refactor(gitignore): .hxsk 루트 파일 13개 예외 추가 + 불필요 항목 정리 (#95)
-ea7ba72 docs: v5.0.1 문서 최신화 — 훅 경로 상대경로 반영 + 마이그레이션 프롬프트 (#94)
 ```
 
 ## Diff Stats
 ```
-No diff available
+ .hxsk/CURRENT.md | 21 ++++++++-------------
+ 1 file changed, 8 insertions(+), 13 deletions(-)
 ```


### PR DESCRIPTION
## Summary
- 이전 PR(#93)에서 버전을 5.0.1로 잘못 설정 → 5.1.1로 수정 (기존 5.1.0 기반 패치)
- CHANGELOG v5.1.1 엔트리 반영

## Test plan
- [ ] `.hxsk/.bootstrap-version`이 `5.1.1`인지 확인
- [ ] CHANGELOG 엔트리가 v5.1.1로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)