### PR TITLE
fix(bootstrap): count_* 함수 mkdir -p guard 추가

### DIFF
--- a/.hxsk/CURRENT.md
+++ b/.hxsk/CURRENT.md
@@ -1,28 +1,29 @@
 # Current Session Context
 
 ## Session Narrative
-> On 2026-03-31 13:40:47, the developer was working on the **fix/hook-paths-v5.0.1** branch, modifying 1 files across `.hxsk`. The recent work involved: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반).
+> On 2026-03-31 13:44:42, the developer was working on the **master** branch, modifying 0
+0 files across `the project`. The recent work involved: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94).
 
 ## Context Snapshot
-- **Active Task**: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
-- **Branch**: fix/hook-paths-v5.0.1
-- **Files Changed**: 1
-- **Last Updated**: 2026-03-31 13:40:47
+- **Active Task**: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94)
+- **Branch**: master
+- **Files Changed**: 0
+0
+- **Last Updated**: 2026-03-31 13:44:42
 
 ## Working Files
 ```
- M .hxsk/CURRENT.md
+No changes detected
 ```
 
 ## Recent Commits
 ```
-f8dcd86 fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
-6aa702a chore: .hxsk 루트 working docs 8개 추적 시작 (#97)
-10ff9fd refactor(gitignore): .hxsk allowlist → blocklist 전환 (#96)
+c3b540a fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94)
+cb4237c fix(hooks): v5.0.1 — 훅 경로 상대경로 전환 + 마이그레이션 프롬프트 (#93)
+6174e6d fix(setup): 완료 확인 체크리스트 스킬 항목을 필수로 변경 (#92)
 ```
 
 ## Diff Stats
 ```
- .hxsk/CURRENT.md | 21 ++++++++-------------
- 1 file changed, 8 insertions(+), 13 deletions(-)
+No diff available
 ```

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -17,7 +17,7 @@ set -o pipefail
 # Version & Mode Detection
 # ─────────────────────────────────────────────────────
 
-BOOTSTRAP_VERSION="5.1.0"
+BOOTSTRAP_VERSION="5.1.1"
 VERSION_FILE=".hxsk/.bootstrap-version"
 HOOK_DIR=".hxsk/hooks"
 MODE="fresh"
@@ -108,11 +108,11 @@ report_context() {
     fi
 }
 
-# 컴포넌트 수 세기
-count_skills() { find .hxsk/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '; }
-count_agents() { find .hxsk/agents -name "*.md" -not -name "INDEX.md" 2>/dev/null | wc -l | tr -d ' '; }
-count_hooks()  { find .hxsk/hooks -name "*.sh" -o -name "*.py" 2>/dev/null | wc -l | tr -d ' '; }
-count_memories() { find .hxsk/memories -mindepth 1 -maxdepth 1 -type d -not -name "_schema" 2>/dev/null | wc -l | tr -d ' '; }
+# 컴포넌트 수 세기 (mkdir -p guard: 디렉토리 부재 시 pipefail 방지)
+count_skills()   { mkdir -p .hxsk/skills;   find .hxsk/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_agents()   { mkdir -p .hxsk/agents;   find .hxsk/agents -name "*.md" -not -name "INDEX.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_hooks()    { mkdir -p .hxsk/hooks;    find .hxsk/hooks -name "*.sh" -o -name "*.py" 2>/dev/null | wc -l | tr -d ' '; }
+count_memories() { mkdir -p .hxsk/memories; find .hxsk/memories -mindepth 1 -maxdepth 1 -type d -not -name "_schema" 2>/dev/null | wc -l | tr -d ' '; }
 
 # ─────────────────────────────────────────────────────
 # Header


### PR DESCRIPTION
## Summary
- `count_skills/agents/hooks/memories` 함수에 `mkdir -p` guard 추가
- 디렉토리 부재 시 `find`가 `pipefail`과 충돌하여 스크립트 중단되는 버그 수정
- `BOOTSTRAP_VERSION` 5.1.0 → 5.1.1 동기화

## Test plan
- [x] `bash .hxsk/scripts/bootstrap.sh` — ALL REQUIRED CHECKS PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)