### PR TITLE
fix(setup): 설치 완성도 개선 — 훅 전체 이벤트 + 에이전트 복사 + 메모리 보충

### DIFF
--- a/.hxsk/CURRENT.md
+++ b/.hxsk/CURRENT.md
@@ -1,28 +1,29 @@
 # Current Session Context
 
 ## Session Narrative
-> On 2026-03-31 13:40:47, the developer was working on the **fix/hook-paths-v5.0.1** branch, modifying 1 files across `.hxsk`. The recent work involved: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반).
+> On 2026-03-31 13:44:42, the developer was working on the **master** branch, modifying 0
+0 files across `the project`. The recent work involved: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94).
 
 ## Context Snapshot
-- **Active Task**: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
-- **Branch**: fix/hook-paths-v5.0.1
-- **Files Changed**: 1
-- **Last Updated**: 2026-03-31 13:40:47
+- **Active Task**: fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94)
+- **Branch**: master
+- **Files Changed**: 0
+0
+- **Last Updated**: 2026-03-31 13:44:42
 
 ## Working Files
 ```
- M .hxsk/CURRENT.md
+No changes detected
 ```
 
 ## Recent Commits
 ```
-f8dcd86 fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반)
-6aa702a chore: .hxsk 루트 working docs 8개 추적 시작 (#97)
-10ff9fd refactor(gitignore): .hxsk allowlist → blocklist 전환 (#96)
+c3b540a fix: 버전 5.0.1 → 5.1.1 수정 (기존 5.1.0 기반) (#98) (#94)
+cb4237c fix(hooks): v5.0.1 — 훅 경로 상대경로 전환 + 마이그레이션 프롬프트 (#93)
+6174e6d fix(setup): 완료 확인 체크리스트 스킬 항목을 필수로 변경 (#92)
 ```
 
 ## Diff Stats
 ```
- .hxsk/CURRENT.md | 21 ++++++++-------------
- 1 file changed, 8 insertions(+), 13 deletions(-)
+No diff available
 ```

--- a/.hxsk/docs/HOOKS.md
+++ b/.hxsk/docs/HOOKS.md
@@ -120,6 +120,16 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
             "timeout": 2
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".hxsk/hooks/track-modifications.sh",
+            "timeout": 2
+          }
+        ]
       }
     ],
     "PreCompact": [
@@ -155,7 +165,7 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Subagent task completed. If significant findings..."
+            "prompt": "## SubagentStop\n- 핵심 결과 2-3문장 요약\n- 코드 변경 시: `touch .hxsk/.modified-this-session`\n- 재사용 패턴 발견 시: PATTERNS.md에 추가 검토\n- 스킬 본문을 결과에 복제하지 말 것"
           }
         ]
       }

--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -43,9 +43,9 @@ test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
 └── examples/     ← 사용 예시
 ```
 
-### Step 4: 스킬 설치
+### Step 4: 스킬 및 에이전트 설치
 
-`.hxsk/skills/INDEX.md`를 참조하여 스킬을 가져오세요.
+`.hxsk/skills/INDEX.md`를 참조하여 스킬을, `.hxsk/agents/INDEX.md`를 참조하여 에이전트를 가져오세요.
 
 **필수 스킬** (반드시 설치):
 
@@ -59,14 +59,21 @@ test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
 
 **Claude Code 설치 방법:**
 ```bash
-# .hxsk/skills/ 에서 .claude/skills/ 로 복사
+# 스킬: .hxsk/skills/ → .claude/skills/
 for skill in bootstrap planner executor verifier memory-protocol; do
     mkdir -p .claude/skills/$skill
     cp .hxsk/skills/$skill/SKILL.md .claude/skills/$skill/SKILL.md
 done
+
+# 에이전트: .hxsk/agents/*.md → .claude/agents/ (INDEX.md 제외)
+mkdir -p .claude/agents
+for agent in .hxsk/agents/*.md; do
+    [[ "$(basename "$agent")" == "INDEX.md" ]] && continue
+    cp "$agent" .claude/agents/
+done
 ```
 
-**Gemini CLI** → `.agent/skills/{name}/SKILL.md`에 배치
+**Gemini CLI** → `.agent/skills/{name}/SKILL.md`, `.agent/agents/{name}.md`에 배치
 **기타** → 에이전트 문서에 따라 배치
 
 > **주의**: `.hxsk/.bootstrap-version` 파일을 직접 생성하지 마세요. `bootstrap.sh`가 자동 생성합니다.
@@ -96,10 +103,37 @@ ln -sf AGENTS.md .windsurfrules
 ```json
 {
   "hooks": {
-    "SessionStart": [{"matcher": "startup|resume", "hooks": [{"type": "command", "command": ".hxsk/hooks/session-start.sh", "timeout": 10}]}],
+    "SessionStart": [
+      {"matcher": "startup|resume", "hooks": [{"type": "command", "command": ".hxsk/hooks/session-start.sh", "timeout": 10}]}
+    ],
     "PreToolUse": [
       {"matcher": "Edit|Write|Read", "hooks": [{"type": "command", "command": ".hxsk/hooks/file-protect.py", "timeout": 5}]},
       {"matcher": "Bash", "hooks": [{"type": "command", "command": ".hxsk/hooks/bash-guard.py", "timeout": 5}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Edit|Write", "hooks": [
+        {"type": "command", "command": ".hxsk/hooks/auto-format.sh", "timeout": 30},
+        {"type": "command", "command": ".hxsk/hooks/track-modifications.sh", "timeout": 2}
+      ]},
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": ".hxsk/hooks/track-modifications.sh", "timeout": 2}]}
+    ],
+    "PreCompact": [
+      {"matcher": "auto|manual", "hooks": [{"type": "command", "command": ".hxsk/hooks/pre-compact-save.sh", "timeout": 10}]}
+    ],
+    "Stop": [
+      {"hooks": [
+        {"type": "command", "command": ".hxsk/hooks/post-turn-verify.sh", "timeout": 15},
+        {"type": "command", "command": ".hxsk/hooks/stop-context-save.sh", "timeout": 10}
+      ]}
+    ],
+    "SubagentStop": [
+      {"hooks": [{"type": "prompt", "prompt": "## SubagentStop\n- 핵심 결과 2-3문장 요약\n- 코드 변경 시: `touch .hxsk/.modified-this-session`\n- 재사용 패턴 발견 시: PATTERNS.md에 추가 검토\n- 스킬 본문을 결과에 복제하지 말 것"}]}
+    ],
+    "SessionEnd": [
+      {"hooks": [
+        {"type": "command", "command": ".hxsk/hooks/save-transcript.sh", "timeout": 10},
+        {"type": "command", "command": ".hxsk/hooks/save-session-changes.sh", "timeout": 10}
+      ]}
     ]
   }
 }
@@ -127,9 +161,11 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact
 
 - [ ] 에이전트 지침 파일이 프로젝트 루트에 존재
 - [ ] `.hxsk/` 디렉토리에 SPEC.md, STATE.md, PATTERNS.md 존재
+- [ ] SPEC.md에 프로젝트 실제 내용 반영 (플레이스홀더 `{...}` 가 남아있으면 안 됨)
 - [ ] 필수 스킬 5개가 에이전트 설정 디렉토리에 배치됨 (bootstrap, planner, executor, verifier, memory-protocol)
+- [ ] 에이전트 정의 파일이 에이전트 설정 디렉토리에 배치됨
 - [ ] (선택) 에이전트별 심볼릭 링크 생성됨
-- [ ] (Claude Code) 훅이 `.claude/settings.json`에 등록됨
+- [ ] (Claude Code) 훅 **8개 이벤트** 모두 `.claude/settings.json`에 등록됨 (SessionStart, PreToolUse, PostToolUse, PreCompact, Stop, SubagentStop, SessionEnd)
 - [ ] (Claude Code) 메모리 명령어 동작 확인
 
 ### 초기 설치 후 다음 단계

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -17,7 +17,7 @@ set -o pipefail
 # Version & Mode Detection
 # ─────────────────────────────────────────────────────
 
-BOOTSTRAP_VERSION="5.1.0"
+BOOTSTRAP_VERSION="5.1.1"
 VERSION_FILE=".hxsk/.bootstrap-version"
 HOOK_DIR=".hxsk/hooks"
 MODE="fresh"
@@ -108,11 +108,11 @@ report_context() {
     fi
 }
 
-# 컴포넌트 수 세기
-count_skills() { find .hxsk/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '; }
-count_agents() { find .hxsk/agents -name "*.md" -not -name "INDEX.md" 2>/dev/null | wc -l | tr -d ' '; }
-count_hooks()  { find .hxsk/hooks -name "*.sh" -o -name "*.py" 2>/dev/null | wc -l | tr -d ' '; }
-count_memories() { find .hxsk/memories -mindepth 1 -maxdepth 1 -type d -not -name "_schema" 2>/dev/null | wc -l | tr -d ' '; }
+# 컴포넌트 수 세기 (mkdir -p guard: 디렉토리 부재 시 pipefail 방지)
+count_skills()   { mkdir -p .hxsk/skills;   find .hxsk/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_agents()   { mkdir -p .hxsk/agents;   find .hxsk/agents -name "*.md" -not -name "INDEX.md" 2>/dev/null | wc -l | tr -d ' '; }
+count_hooks()    { mkdir -p .hxsk/hooks;    find .hxsk/hooks -name "*.sh" -o -name "*.py" 2>/dev/null | wc -l | tr -d ' '; }
+count_memories() { mkdir -p .hxsk/memories; find .hxsk/memories -mindepth 1 -maxdepth 1 -type d -not -name "_schema" 2>/dev/null | wc -l | tr -d ' '; }
 
 # ─────────────────────────────────────────────────────
 # Header

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -223,17 +223,22 @@ fi
 echo ""
 echo "--- HXSK Structure ---"
 
-# Memory directories
-if [[ -d ".hxsk/memories" ]]; then
-    MEM_COUNT=$(count_memories)
-    if [[ "$MODE" = "fresh" ]]; then
-        report_new ".hxsk/memories/" "${MEM_COUNT} type directories"
-    else
-        report_ok ".hxsk/memories/" "${MEM_COUNT} type directories"
+# Memory directories — 존재 여부와 무관하게 누락 타입 보충
+MEMORY_TYPES=(architecture-decision root-cause debug-eliminated debug-blocked health-event session-handoff execution-summary deviation pattern-discovery bootstrap session-summary session-snapshot security-finding general _schema)
+CREATED_MEM=0
+for mtype in "${MEMORY_TYPES[@]}"; do
+    if [[ ! -d ".hxsk/memories/$mtype" ]]; then
+        mkdir -p ".hxsk/memories/$mtype"
+        ((CREATED_MEM++)) || true
     fi
+done
+MEM_COUNT=$(count_memories)
+if [[ "$CREATED_MEM" -gt 0 ]]; then
+    report_new ".hxsk/memories/" "created ${CREATED_MEM} missing types (total: ${MEM_COUNT})"
+elif [[ "$MODE" = "fresh" ]]; then
+    report_new ".hxsk/memories/" "${MEM_COUNT} type directories"
 else
-    mkdir -p .hxsk/memories/{architecture-decision,root-cause,debug-eliminated,debug-blocked,health-event,session-handoff,execution-summary,deviation,pattern-discovery,bootstrap,session-summary,session-snapshot,security-finding,general,_schema}
-    report_new ".hxsk/memories/" "created (14 types + _schema)"
+    report_ok ".hxsk/memories/" "${MEM_COUNT} type directories"
 fi
 
 # Context directories


### PR DESCRIPTION
## Summary
- `setup.md`의 settings.json 예시에 **누락된 5개 훅 이벤트** 추가 (PostToolUse, PreCompact, Stop, SubagentStop, SessionEnd)
- Step 4에 **에이전트 정의 파일 복사** 단계 추가 (기존에는 스킬만 안내)
- `bootstrap.sh`의 memories 로직 개선: 디렉토리 존재 여부와 무관하게 **누락 타입 보충**
- `HOOKS.md` PostToolUse Bash matcher + SubagentStop prompt 동기화

## 근본 원인
Wiki-multiagents 프로젝트에 실제 적용 결과, 설치 완성도 60% — settings.json 3/8 이벤트, memories 2/14, agents 0개.
setup.md 예시가 불완전했고, bootstrap.sh가 빈 디렉토리를 "존재"로 판단해 스킵하는 로직이었음.

## Test plan
- [x] HExoskeleton 본체 `bootstrap.sh` — ALL PASSED
- [x] Wiki-multiagents 적용 후 `bootstrap.sh` — ALL PASSED (Skills 5, Agents 17, Hooks 17, Memories 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)