### PR TITLE
docs: README 전면 리라이트 — 설계 사상 + 핵심 개념 체계화

### DIFF
--- a/.hxsk/ARCHITECTURE.md
+++ b/.hxsk/ARCHITECTURE.md
@@ -166,10 +166,18 @@ Source Components:
 - [x] detect-language.sh 빌드 타겟 미포함 — 범용 유틸로 존속
 - [x] convert-hooks-to-plugins.py — 빌드 시스템과 함께 삭제
 
+**해소 완료 (2026-04-01, v5.1.1):**
+- [x] `$CLAUDE_PROJECT_DIR` 훅 경로 미확장 → 상대 경로 전환
+- [x] setup.md 훅 이벤트 5개 누락 → 전체 8개 반영
+- [x] setup.md 에이전트 복사 단계 누락 → Step 4에 추가
+- [x] bootstrap.sh `count_*` pipefail 충돌 → `mkdir -p` guard
+- [x] bootstrap.sh memories 빈 디렉토리 스킵 → 누락 타입 개별 보충
+- [x] .gitignore allowlist(23예외) → blocklist(10규칙) 전환
+
 **잔여:**
 - [ ] `bootstrap.sh:90` python3 버전 체크 — hooks에 필요한 python3 확인용, 기능상 문제 없음
 
 ---
 
 *Generated: 2026-03-24*
-*Updated: 2026-03-25 — Wave 4 통합 검증 완료. parallel-debt-and-infra 플랜 종결*
+*Updated: 2026-04-01 — v5.1.1 설치 완성도 개선 + 훅 경로 수정*

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 <h1 align="center">HExoskeleton</h1>
 
 <p align="center">
-  <strong>Get Shit Done</strong> — 추상화의 늪 없이, 실제 결과물을 내는 AI 에이전트 개발 프레임워크
+  <strong>Get Shit Done</strong> — AI 에이전트의 외골격. 추상화의 늪 없이, 실제 결과물을 내는 개발 방법론.
 </p>
 
 <p align="center">
+  <a href="#설계-사상">Design</a> &middot;
+  <a href="#아키텍처">Architecture</a> &middot;
+  <a href="#핵심-개념">Concepts</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#왜-hexoskeleton인가">Why</a> &middot;
-  <a href="#핵심-구성요소">Components</a> &middot;
-  <a href="#멀티-에이전트-하나의-프로젝트">Multi-Agent</a> &middot;
-  <a href="#메모리-시스템">Memory</a> &middot;
   <a href=".hxsk/docs/">Docs</a>
 </p>
 
@@ -21,155 +20,185 @@
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen?style=flat-square" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/stack-bash%20%2B%20markdown-blue?style=flat-square" alt="Bash + Markdown" />
   <img src="https://img.shields.io/badge/multi--agent-5%20platforms-blueviolet?style=flat-square" alt="Multi-Agent" />
-  <img src="https://img.shields.io/badge/19%20skills%20%C2%B7%2017%20agents%20%C2%B7%2017%20hooks-orange?style=flat-square" alt="Components" />
+  <img src="https://img.shields.io/badge/v5.1.1%20%C2%B7%2019%20skills%20%C2%B7%2017%20agents%20%C2%B7%2017%20hooks-orange?style=flat-square" alt="Components" />
   <img src="https://img.shields.io/github/license/SukbeomH/HExoskeleton?style=flat-square" alt="License" />
 </p>
 
 ---
 
-## Quick Start
+## 설계 사상
 
-AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝트에 HXSK를 구성합니다.
+HExoskeleton은 세 가지 관찰에서 출발합니다.
 
-**[setup.md](.hxsk/prompts/setup.md)** — 에이전트 유형별 분기 안내를 포함하여 Claude Code, Gemini, Copilot, Cursor, Windsurf 등에서 사용할 수 있습니다.
+**1. 에이전트의 네이티브 도구가 이미 강력한 검색 엔진이다.**
+`Grep`, `Glob`, `Read` — 코딩 에이전트가 기본 탑재한 도구만으로 파일 시스템을 완전히 탐색할 수 있습니다. 벡터 DB나 MCP 서버를 추가하는 건 복잡성 대비 이득이 적습니다.
 
-> **외부 종속성 없음** — 초기 설치/업데이트 자동 감지. `SPEC → PLAN → EXECUTE → VERIFY`
+**2. 파일 시스템이 곧 데이터베이스다.**
+마크다운 파일은 사람이 읽을 수 있고, `git diff`로 변경을 추적할 수 있고, 어떤 에이전트든 `Read` 한 번이면 접근할 수 있습니다. 별도 인프라가 필요 없습니다.
 
-<details>
-<summary><strong>직접 코드를 받고 싶다면</strong></summary>
-<br>
+**3. 에이전트는 "어떻게(How)"보다 "언제, 무엇으로(When/With What)"가 중요하다.**
+절차는 스킬 문서에, 오케스트레이션은 에이전트 정의에 분리합니다. 에이전트 정의는 ~20-30줄로 유지하고, 상세 절차는 스킬에 위임합니다. 시스템 프롬프트가 짧을수록 에이전트는 정확해집니다.
 
-```bash
-git clone https://github.com/SukbeomH/HExoskeleton.git
-cd HExoskeleton
-make setup
+### 왜 순수 bash + 마크다운인가
+
+| 대안 | 채택하지 않은 이유 |
+|------|-------------------|
+| 벡터 DB (Qdrant, Weaviate) | 외부 서비스 의존, 설정 복잡도 증가 |
+| MCP 서버 | 추가 프로세스 필요, 네트워크 오버헤드 |
+| SQLite/JSON | 파일 수준 가독성 저하, Git diff 불가 |
+| Python/Node 런타임 | 환경 구성 필수, 에이전트 도구만으로 충분 |
+
+> **결론**: 외부 종속성 0. 빌드 스크립트 0. 레포지토리 자체가 배포 단위 (Self-Configure 모델).
+
+---
+
+## 아키텍처
+
+```
+                    ┌──────────────────────────┐
+                    │    GitHub Repository      │
+                    │    (= Distribution)       │
+                    └──────────┬───────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+        ┌─────▼─────┐   ┌─────▼─────┐   ┌─────▼──────┐
+        │  llms.txt  │   │ AGENTS.md │   │  prompts/  │
+        │  (진입점)  │   │  (공통)   │   │  (setup)   │
+        └─────┬──────┘   └───────────┘   └────────────┘
+              │
+    ┌─────────┼─────────┐
+    │         │         │
+┌───▼───┐ ┌──▼──┐ ┌───▼────┐
+│skills/│ │hooks│ │agents/ │
+│  19   │ │ 17  │ │  17    │
+└───────┘ └─────┘ └────────┘
 ```
 
-| 명령어 | 설명 |
-|--------|------|
-| `/bootstrap` | 프로젝트 분석 및 메모리 초기화 |
-| `/planner` | SPEC 기반 실행 계획 수립 |
-| `/executor` | 계획 실행 (atomic commits) |
-| `/verifier` | 경험적 증거 기반 결과 검증 |
+### Self-Configure 모델
 
-> `make help`로 전체 명령어를 확인할 수 있습니다.
+일반적인 프레임워크는 `npm install`, `pip install`, 빌드 스크립트를 요구합니다. HExoskeleton은 다릅니다:
 
-</details>
+1. 에이전트가 `llms.txt`를 읽어 프로젝트 구조를 파악
+2. `setup.md` 프롬프트를 따라 스킬/훅/에이전트를 프로젝트에 배치
+3. `bootstrap.sh`가 누락 컴포넌트를 수렴적(idempotent)으로 보충
+
+**빌드 없음, 설치 명령 없음.** 에이전트가 파일을 읽고 복사하는 것이 곧 설치입니다.
+
+### 멀티 에이전트 수렴
+
+하나의 프로젝트를 여러 AI 에이전트가 동시에 관리합니다. 에이전트 지침은 분리하되, 워킹 상태(`.hxsk/`)는 공유합니다.
+
+```
+┌───────────┐  ┌───────────┐  ┌───────────┐  ┌───────────┐  ┌───────────┐
+│ Claude    │  │ Gemini    │  │ Copilot   │  │ Cursor    │  │ Windsurf  │
+│ CLAUDE.md │  │ GEMINI.md │  │ symlink   │  │ symlink   │  │ symlink   │
+└─────┬─────┘  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘
+      └───────────────┼──────────────┼──────────────┼───────────────┘
+                      ▼              ▼              ▼
+                ┌──────────────────────────────────────┐
+                │           .hxsk/ (공유 상태)           │
+                │  STATE · SPEC · PATTERNS · memories   │
+                │  skills · agents · hooks              │
+                └──────────────────────────────────────┘
+```
+
+- **에이전트 간 인수인계** — Claude Code로 디버깅 → Cursor로 UI 작업. STATE.md와 메모리가 컨텍스트를 유지
+- **Lock-in 없음** — 순수 마크다운이므로 어떤 에이전트든 읽고 쓸 수 있음
+- **동시 사용** — 백엔드(Claude) + 프론트엔드(Cursor) 동시 작업 가능
 
 ---
 
-## 왜 HExoskeleton인가
+## 핵심 개념
 
-대부분의 AI 에이전트 프레임워크는 Python, Node.js, 벡터 DB, MCP 서버 등 복잡한 스택을 요구합니다. HExoskeleton은 반대 방향을 선택했습니다.
+### 1. Skill-Agent 분리 패턴
 
-| 구분 | HExoskeleton | 일반 AI 프레임워크 |
-|------|-----------------|-------------------|
-| **의존성** | 없음 (Bash + Markdown) | 높음 (Python, Node.js, DB) |
-| **메모리** | 파일 기반 2-Hop 그래프 검색 | 벡터 DB 유사도 검색 |
-| **감사(Audit)** | Git 추적 가능 (Markdown) | 블랙박스 |
-| **학습 곡선** | 낮음 (파일 수정 위주) | 높음 (SDK/API 학습 필요) |
-| **환경** | 5개 에이전트 네이티브 지원 | 범용, 별도 래퍼 필요 |
+**Skill = How** (재사용 가능한 절차), **Agent = When/With What** (오케스트레이션).
 
-**핵심 원칙:** 에이전트의 네이티브 도구(`Grep`, `Glob`, `Read`)가 이미 강력한 검색 엔진입니다. 파일 시스템이 곧 데이터베이스입니다.
+```
+┌─────────────────────────────────────────────┐
+│  Agent (~20줄)                               │
+│  "디버깅 시 systematic-debugging 스킬 사용"  │
+│  "도구: Bash, Read, Grep, Agent"             │
+└────────────────────┬────────────────────────┘
+                     │ 위임
+                     ▼
+┌─────────────────────────────────────────────┐
+│  Skill (~100-300줄)                          │
+│  "1. 에러 메시지 수집"                        │
+│  "2. 가설 3개 수립"                           │
+│  "3. 가설별 검증..."                          │
+└─────────────────────────────────────────────┘
+```
 
----
+에이전트 정의가 간결할수록 에이전트는 정확하게 동작합니다.
 
-## 핵심 구성요소
-
-| 구성요소 | 개수 | 설명 | 상세 |
-|----------|------|------|------|
-| **Skills** | 19 | Claude가 자율 호출하는 기능 단위 (How) | [docs/SKILLS.md](.hxsk/docs/SKILLS.md) |
-| **Agents** | 17 | 스킬을 조합하는 서브에이전트 (When/With What) | [docs/AGENTS.md](.hxsk/docs/AGENTS.md) |
-| **Hooks** | 17 | 이벤트 기반 자동화 (가드레일, 상태 저장) | [docs/HOOKS.md](.hxsk/docs/HOOKS.md) |
-| **Memory** | 14 types | A-Mem 확장 파일 기반 메모리 (2-hop) | [docs/MEMORY.md](.hxsk/docs/MEMORY.md) |
-
-**Skill**(How)과 **Agent**(When/With What)를 분리하여 유지보수성과 자율성을 동시에 확보합니다.
-
-<details>
-<summary><strong>상세 문서</strong></summary>
-<br>
-
-| 문서 | 설명 |
+| 근거 | 출처 |
 |------|------|
-| [Build](.hxsk/docs/BUILD.md) | Self-Configure 배포 가이드 |
-| [Workflows](.hxsk/docs/WORKFLOWS.md) | 워크플로우 상세 |
-| [Conventions](.hxsk/docs/CONVENTIONS.md) | 개발 컨벤션 (Issue, Branch, Commit, PR) |
-| [Linting](.hxsk/docs/LINTING.md) | 린팅 설정 |
-| [MCP](.hxsk/docs/MCP.md) | MCP 서버 통합 |
-| [Research](.hxsk/research/INDEX.md) | 리서치 문서 카탈로그 (30개, 6개 카테고리) |
+| 시스템 프롬프트 ~1,800 토큰이 최적 구간 | Anthropic 내부 테스트 |
+| 2,500 토큰 초과 시 환각 34% 증가 | Microsoft/Stanford 연구 |
+| "가장 작은 고신호 토큰 집합" | [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) |
 
-</details>
+| 구성요소 | 개수 | 위치 | 상세 |
+|----------|------|------|------|
+| **Skills** | 19 | `.hxsk/skills/` | [docs/SKILLS.md](.hxsk/docs/SKILLS.md) |
+| **Agents** | 17 | `.hxsk/agents/` | [docs/AGENTS.md](.hxsk/docs/AGENTS.md) |
 
----
+### 2. 8-Event Hook 생명주기
 
-## 멀티 에이전트, 하나의 프로젝트
-
-HExoskeleton은 **하나의 프로젝트를 여러 AI 에이전트가 동시에 관리**할 수 있도록 설계되었습니다. 에이전트 지침은 분리하되, 워킹 상태(`.hxsk/`)는 공유합니다.
+Claude Code의 훅 시스템으로 에이전트 행동을 자동화합니다. 7개 이벤트, 17개 스크립트.
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                    프로젝트                           │
-│                                                     │
-│  ┌───────────┐  ┌───────────┐  ┌───────────┐       │
-│  │ Claude    │  │ Gemini    │  │ Cursor    │       │
-│  │ CLAUDE.md │  │ GEMINI.md │  │ AGENTS.md │       │
-│  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘       │
-│        └───────────────┼───────────────┘             │
-│                        ▼                             │
-│              ┌──────────────────┐                    │
-│              │     .hxsk/       │                    │
-│              │  STATE · SPEC    │                    │
-│              │  memories        │                    │
-│              │  skills · hooks  │                    │
-│              └──────────────────┘                    │
-└─────────────────────────────────────────────────────┘
+SessionStart ──→ [작업 수행] ──→ SessionEnd
+     │               │                │
+     ▼               ▼                ▼
+ STATE.md 로드    PreToolUse        대화 내역 저장
+ 메모리 로드      (보안 검사)       세션 변경 추적
+                  PostToolUse
+                  (포맷, 추적)
+                  Stop
+                  (검증, 메모리 저장)
+                  PreCompact
+                  (스냅샷)
+                  SubagentStop
+                  (결과 요약)
 ```
 
-- **에이전트 간 인수인계** — Claude Code로 디버깅 → Cursor로 UI 작업. `.hxsk/STATE.md`와 메모리가 컨텍스트 유지.
-- **Lock-in 없음** — 순수 마크다운이므로 어떤 에이전트든 읽고 쓸 수 있음.
-- **동시 사용** — 백엔드(Claude Code) + 프론트엔드(Cursor) 동시 작업 가능.
+| 이벤트 | 훅 | 역할 |
+|--------|-----|------|
+| **SessionStart** | `session-start.sh` | STATE.md + git status 컨텍스트 주입 |
+| **PreToolUse** | `file-protect.py`, `bash-guard.py` | .env/시크릿 보호, 파괴적 명령 차단 |
+| **PostToolUse** | `auto-format.sh`, `track-modifications.sh` | 자동 포맷, 변경 파일 추적 |
+| **PreCompact** | `pre-compact-save.sh` | 컨텍스트 압축 전 스냅샷 |
+| **Stop** | `post-turn-verify.sh`, `stop-context-save.sh` | 작업 검증, 세션 컨텍스트 저장 |
+| **SubagentStop** | (prompt) | 서브에이전트 결과 요약 |
+| **SessionEnd** | `save-transcript.sh`, `save-session-changes.sh` | 대화 내역 + 변경사항 저장 |
 
-### 에이전트별 자동 로드
+> 상세: [docs/HOOKS.md](.hxsk/docs/HOOKS.md)
 
-`AGENTS.md`를 각 에이전트의 자동 로드 경로에 심볼릭 링크로 연결합니다.
+### 3. 파일 기반 메모리 시스템
 
-| 에이전트 | 자동 로드 경로 | 방식 |
-|----------|--------------|------|
-| Claude Code | `CLAUDE.md` | 루트 자동 로드 |
-| Gemini CLI | `GEMINI.md` | 루트 자동 로드 |
-| GitHub Copilot | `.github/copilot-instructions.md` | → `AGENTS.md` symlink |
-| Cursor | `.cursorrules` | → `AGENTS.md` symlink |
-| Windsurf | `.windsurfrules` | → `AGENTS.md` symlink |
+[A-Mem](https://arxiv.org/html/2502.12110v11), [Nemori](https://arxiv.org/html/2508.03341v3) 논문의 핵심 개념을 파일 시스템 위에 구현했습니다.
 
-### 새 프로젝트에 적용
-
-상단 [Quick Start](#quick-start)의 setup 프롬프트를 에이전트에게 전달하세요. 하나의 프롬프트로 모든 에이전트를 지원하며, Claude Code 전용 훅은 `.claude/settings.json`에만 등록되므로 다른 에이전트에 영향을 주지 않습니다.
-
----
-
-## 메모리 시스템
-
-순수 bash + 마크다운 파일 기반 에이전트 메모리. [A-Mem](https://arxiv.org/html/2502.12110v11), [Nemori](https://arxiv.org/html/2508.03341v3), ReWOO 논문의 핵심 개념을 파일 시스템 위에 구현했습니다.
-
-- **2-Hop 그래프 검색** — `related` 필드로 메모리 간 연결, 관련 메모리까지 자동 추적
-- **중복 방지** — 동일 제목 저장 시 자동 스킵 (`[SKIP:DUPLICATE]`)
-- **토큰 최적화** — `compact` 모드로 제목 + 1줄 요약만 반환
-- **완전한 감사 추적** — 모든 메모리가 Markdown 파일, Git diff 가능
+| 개념 | 출처 | HXSK 구현 |
+|------|------|-----------|
+| Frontmatter 메타데이터 | A-Mem | YAML frontmatter (`title`, `tags`, `keywords`, `related`) |
+| 2-Hop 그래프 검색 | A-Mem | `related` 필드 → 관련 메모리까지 자동 추적 |
+| Compact 모드 | A-Mem | 제목 + 1줄 요약만 반환 (토큰 최적화) |
+| 타입별 분리 | Nemori | 14개 디렉토리 (root-cause, architecture-decision 등) |
+| 중복 방지 | Nemori | 동일 제목 저장 시 `[SKIP:DUPLICATE]` |
+| Contextual description | Nemori | 검색 시 압축 요약 자동 생성 |
 
 ```bash
 # 저장
 bash .hxsk/hooks/md-store-memory.sh "제목" "내용" "태그1,태그2" "타입"
 
-# 검색 (compact)
-bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact
-
-# 2-hop 검색
+# 검색 (compact, 2-hop)
 bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 ```
 
 <details>
-<summary><strong>메모리 타입 (14개)</strong></summary>
-<br>
+<summary><strong>14개 메모리 타입</strong></summary>
 
 | 카테고리 | 타입 | 용도 |
 |----------|------|------|
@@ -192,93 +221,143 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 
 > 상세: [docs/MEMORY.md](.hxsk/docs/MEMORY.md)
 
+### 4. SPEC → PLAN → EXECUTE → VERIFY 워크플로우
+
+[ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) 연구의 "계획과 실행의 분리" 개념을 적용합니다.
+
+```
+SPEC.md          PLAN.md           실행              검증
+(무엇을)    →    (어떻게)     →    (코드 작성)   →   (경험적 증거)
+ 목표 정의       태스크 분해       atomic commit      실제 실행 결과로
+ 성공 기준       의존성 정리       PR 단위           성공/실패 판단
+ 제약 조건       파일 소유권
+```
+
+**순차 실행**: SPEC → PLAN → 태스크 순서대로 실행 → VERIFY
+
+**병렬 실행** (Dispatcher): 대규모 작업 시 Wave 기반 병렬 처리
+
+```
+Discovery → Issue 생성 (.hxsk/issues/)
+├── Wave 할당 (파일 소유권 검증 — 같은 wave 내 동일 파일 수정 금지)
+├── Wave 1: Agent(isolation: "worktree") × N개 병렬
+├── merge → 통합 검증
+├── Wave 2: Agent(isolation: "worktree") × M개 병렬
+├── merge → 통합 검증
+└── 완료
+```
+
+### 5. Lazy Loading 문서 계층
+
+에이전트가 필요한 만큼만 읽도록 3단계로 구조화합니다.
+
+| 레벨 | 내용 | 토큰 | 예시 |
+|------|------|------|------|
+| **L0** | YAML frontmatter만 | ~50 | 이슈 목록 스캔 |
+| **L1** | 본문 (Quick Reference 포함) | ~200-500 | 스킬 개요 파악 |
+| **L2** | 관련 SKILL/PLAN/연구 문서 | ~1000+ | 상세 절차 실행 |
+
+`CLAUDE.md`(L1) → `skills/SKILL.md`(L2) → `.hxsk/research/`(L3) 순으로 깊어집니다.
+
+### 6. 수렴적 Bootstrap
+
+`bootstrap.sh`는 멱등(idempotent) 수렴 엔진입니다. 몇 번을 실행해도 동일한 최종 상태에 도달합니다.
+
+```
+fresh   → 모든 컴포넌트 생성, 카운트 기록
+update  → 기존 카운트와 비교, 변경분만 [NEW]/[UPDATED] 표시
+verify  → 구조 검증, 누락 타입 자동 보충
+```
+
 ---
 
+## Quick Start
+
+AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝트에 HXSK를 구성합니다.
+
+**[setup.md](.hxsk/prompts/setup.md)** — Claude Code, Gemini, Copilot, Cursor, Windsurf 모두 지원.
+
+> 초기 설치/업데이트를 자동 감지합니다. 빌드 명령 없음.
+
 <details>
-<summary><strong>디렉토리 구조</strong></summary>
+<summary><strong>직접 코드를 받고 싶다면</strong></summary>
 <br>
+
+```bash
+git clone https://github.com/SukbeomH/HExoskeleton.git
+cd HExoskeleton
+make setup
+```
+
+| 명령어 | 설명 |
+|--------|------|
+| `/bootstrap` | 프로젝트 분석 및 메모리 초기화 |
+| `/planner` | SPEC 기반 실행 계획 수립 |
+| `/executor` | 계획 실행 (atomic commits) |
+| `/verifier` | 경험적 증거 기반 결과 검증 |
+
+</details>
+
+---
+
+## 디렉토리 구조
 
 ```
 .
-├── CLAUDE.md                  # Claude Code 지침
+├── CLAUDE.md                  # Claude Code 지침 (L1)
 ├── AGENTS.md                  # 공통 에이전트 지침
 ├── GEMINI.md                  # Gemini 지침
 ├── .cursorrules → AGENTS.md   # Cursor symlink
 ├── .windsurfrules → AGENTS.md # Windsurf symlink
-├── llms.txt                   # LLM 진입점
-├── .claude/settings.json      # 훅 설정
-└── .hxsk/                     # HXSK 핵심 (Single Source of Truth)
-    ├── skills/                # 스킬 정의 (19)
-    ├── agents/                # 서브에이전트 정의 (17)
-    ├── hooks/                 # 훅 스크립트 (17)
-    ├── scripts/               # 유틸리티 스크립트
-    ├── docs/                  # 상세 문서
-    ├── prompts/               # Setup 프롬프트 (통합)
-    ├── templates/             # 문서 템플릿
+├── llms.txt                   # LLM 진입점 (Self-Configure 시작)
+├── .claude/settings.json      # 훅 설정 (8개 이벤트)
+└── .hxsk/                     # Single Source of Truth
+    ├── skills/                # 스킬 정의 (19) — How
+    ├── agents/                # 에이전트 정의 (17) — When/With What
+    ├── hooks/                 # 훅 스크립트 (17) — 자동화
+    ├── scripts/               # 유틸리티 (bootstrap, issue, merge)
+    ├── docs/                  # 상세 문서 (11)
+    ├── prompts/               # Setup + 마이그레이션 프롬프트
+    ├── templates/             # 문서 템플릿 (27)
     ├── memories/              # 파일 기반 메모리 (14 타입)
-    ├── research/              # 리서치 문서 (30개)
+    ├── research/              # 연구 문서 (30개, 7개 카테고리)
+    ├── issues/                # 파일 기반 이슈 레지스트리
     ├── STATE.md               # 현재 작업 상태
-    └── PATTERNS.md            # 핵심 패턴/학습
+    ├── SPEC.md                # 프로젝트 명세
+    ├── PATTERNS.md            # 학습된 패턴
+    └── DECISIONS.md           # 아키텍처 결정 기록
 ```
-
-</details>
-
-<details>
-<summary><strong>참고 문서</strong></summary>
-<br>
-
-| 구분 | 링크 | 설명 |
-|------|------|------|
-| Claude Code | [Hooks](https://code.claude.com/docs/en/hooks.md) | 이벤트 훅 설정 |
-| Claude Code | [Skills](https://code.claude.com/docs/en/skills.md) | 스킬 정의 및 활용 |
-| Claude Code | [Sub-agents](https://code.claude.com/docs/en/sub-agents.md) | 에이전트 frontmatter |
-| Community | [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) | Claude Code 리소스 큐레이션 |
-| Community | [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) | MCP 서버 목록 |
-
-</details>
 
 ---
 
-<details>
-<summary><strong>설계 배경 (Design Rationale)</strong></summary>
-<br>
+## 연구 기반
 
-현재 아키텍처는 최신 에이전트 메모리 및 추론 최적화 연구들을 분석하고 선택적으로 적용한 결과입니다.
+현재 아키텍처는 최신 에이전트 메모리 및 추론 최적화 연구를 분석하고 선택적으로 적용한 결과입니다.
 
-#### 왜 순수 bash + 마크다운인가?
-
-| 대안 | 채택하지 않은 이유 |
-|------|-------------------|
-| 벡터 DB (Qdrant, Weaviate) | 외부 서비스 의존, 설정 복잡도 증가 |
-| MCP 서버 | 추가 프로세스 필요, 네트워크 오버헤드 |
-| SQLite/JSON | 파일 수준 가독성 저하, Git diff 불가 |
-
-#### 연구 기반
-
-| 출처 | 적용 |
-|------|------|
-| [A-Mem](https://arxiv.org/html/2502.12110v11) | frontmatter 필드, `related`, 2-hop 검색, compact 모드 |
-| [Nemori](https://arxiv.org/html/2508.03341v3) | 타입 분리, `[SKIP:DUPLICATE]`, contextual_description |
-| [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | SPEC → PLAN → EXECUTE 분리 |
-| [RLM](https://arxiv.org/html/2512.24601v2) | Agent-Skill 래핑, Phase → Plan → Task |
-
-#### 왜 에이전트 정의는 간결하게?
-
-에이전트 정의(`.hxsk/agents/*.md`)는 ~20-30줄로 유지하고, 절차적 상세는 스킬에 위임합니다.
-
-| 근거 | 출처 |
-|------|------|
-| 시스템 프롬프트 ~1,800 토큰이 최적 구간 | Anthropic 내부 테스트 (2차 출처) |
-| 2,500 토큰 초과 시 환각 34% 증가 | Microsoft/Stanford 연구 |
-| "가장 작은 고신호 토큰 집합" 권장 | [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) |
-| description 품질 > 길이 | [Claude Code Sub-agents Docs](https://code.claude.com/docs/en/sub-agents) |
-| 외부 파일 위임 패턴 | Deep Agents 연구 |
-
-**채택하지 않은 것:** Memory Evolution (A-Mem), Predict-Calibrate (Nemori), Persistent REPL (RLM), 상세 에이전트 프롬프트 (100+줄)
+| 출처 | 적용한 것 | 적용하지 않은 것 |
+|------|-----------|-----------------|
+| [A-Mem](https://arxiv.org/html/2502.12110v11) | frontmatter, `related`, 2-hop, compact | Memory Evolution (자동 진화) |
+| [Nemori](https://arxiv.org/html/2508.03341v3) | 타입 분리, `[SKIP:DUPLICATE]`, contextual_description | Predict-Calibrate (확률 보정) |
+| [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | SPEC → PLAN → EXECUTE 분리 | 전체 프레임워크 |
+| [RLM](https://arxiv.org/html/2512.24601v2) | Agent-Skill 래핑, Phase → Plan → Task | Persistent REPL |
+| [Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | 간결한 에이전트 정의, 외부 파일 위임 | — |
 
 > 상세: [.hxsk/research/INDEX.md](.hxsk/research/INDEX.md)
 
-</details>
+---
+
+## 상세 문서
+
+| 문서 | 설명 |
+|------|------|
+| [Skills](.hxsk/docs/SKILLS.md) | 19개 스킬 상세 |
+| [Agents](.hxsk/docs/AGENTS.md) | 17개 에이전트 상세 |
+| [Hooks](.hxsk/docs/HOOKS.md) | 훅 시스템 + settings.json 전체 예시 |
+| [Memory](.hxsk/docs/MEMORY.md) | 파일 기반 메모리 시스템 |
+| [Workflows](.hxsk/docs/WORKFLOWS.md) | SPEC→PLAN→EXECUTE→VERIFY |
+| [Conventions](.hxsk/docs/CONVENTIONS.md) | 개발 컨벤션 (Issue, Branch, Commit, PR) |
+| [Build](.hxsk/docs/BUILD.md) | Self-Configure 배포 가이드 |
+| [Research](.hxsk/research/INDEX.md) | 30개 연구 문서 카탈로그 |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > AI 에이전트 기반 개발 방법론. 순수 bash + 마크다운 기반, 외부 종속성 없음.
 > 어떤 코딩 에이전트든 이 문서를 읽고 프로젝트에 HXSK를 구성할 수 있습니다.
-> Last Updated: 2026-03-26 · Format: llms.txt v1.0
+> Last Updated: 2026-04-01 · Format: llms.txt v1.0 · HXSK v5.1.1
 
 ## Setup
 - [Setup Prompt](.hxsk/prompts/setup.md): 어떤 에이전트든 이 프롬프트를 실행하면 HXSK 구성 완료 (Claude Code 포함)


### PR DESCRIPTION
## Summary
- README를 기능 나열 → **설계 사상 + 핵심 개념 중심**으로 전면 리라이트
- 핵심 개념 6개 섹션 체계화: Skill-Agent 분리, 8-Event Hook 생명주기, 파일 기반 메모리, SPEC→PLAN→EXECUTE→VERIFY 워크플로우, Lazy Loading 문서 계층, 수렴적 Bootstrap
- Self-Configure 모델, Dispatcher 병렬 실행 등 기존에 숨겨진 설계 결정을 전면에 배치
- ARCHITECTURE.md v5.1.1 기술 부채 해소 항목 추가

## Test plan
- [ ] README 렌더링 확인 (다이어그램, 테이블, 링크)
- [ ] 상세 문서 링크 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)