### PR TITLE
fix: hooks INDEX 카운트 + pre-pr-check pipefail 수정

### DIFF
--- a/.hxsk/hooks/INDEX.md
+++ b/.hxsk/hooks/INDEX.md
@@ -1,6 +1,6 @@
 # Hooks Index
 
-> 17 hook scripts. Claude Code only -- other agents use AGENTS.md rules instead.
+> 19 hook scripts. Claude Code only -- other agents use AGENTS.md rules instead.
 
 | Hook | Event | Purpose | File |
 |------|-------|---------|------|
@@ -20,4 +20,6 @@
 | md-recall-memory.sh | (utility) | Recall memory (2-hop) | `hooks/md-recall-memory.sh` |
 | scaffold-hxsk.sh | (utility) | Scaffold HXSK documents | `hooks/scaffold-hxsk.sh` |
 | scaffold-infra.sh | (utility) | Compare infra files | `hooks/scaffold-infra.sh` |
+| check-consistency.sh | (utility) | Code/doc/skill/agent consistency check (14 points) | `hooks/check-consistency.sh` |
+| pre-pr-check.sh | (utility) | Pre-PR validation + version recommendation | `hooks/pre-pr-check.sh` |
 | _json_parse.sh | (library) | JSON parse abstraction | `hooks/_json_parse.sh` |

--- a/.hxsk/hooks/pre-pr-check.sh
+++ b/.hxsk/hooks/pre-pr-check.sh
@@ -81,7 +81,8 @@ fi
 echo ""
 echo "=== Git status ==="
 
-UNCOMMITTED=$(git -C "$PROJECT_DIR" status --short 2>/dev/null | grep -v '^??' | wc -l | tr -d ' ')
+UNCOMMITTED=$(git -C "$PROJECT_DIR" status --short 2>/dev/null | grep -v '^??' || true)
+UNCOMMITTED=$(echo "$UNCOMMITTED" | grep -c . 2>/dev/null || echo "0")
 if [[ "$UNCOMMITTED" -eq 0 ]]; then
     pass "No uncommitted changes"
 else


### PR DESCRIPTION
## Summary
- hooks INDEX.md 카운트 17→19, check-consistency.sh + pre-pr-check.sh 등록
- pre-pr-check.sh git status에서 pipefail로 hang하는 버그 수정

## pre-pr-check 결과
```
PRE-PR CHECK  |  PASS: 11  FAIL: 0  WARN: 2
RESULT: READY FOR PR

Version recommendation:
  Commits: 1 (feat:0 fix:1 other:0)
  [WARN] Version bump recommended: 5.2.0 -> 5.2.1 (patch)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)