### PR TITLE
fix: 부트스트랩 시 훅 파일 실행 권한 자동 부여 (#106)

### DIFF
--- a/.hxsk/.bootstrap-version
+++ b/.hxsk/.bootstrap-version
@@ -1,5 +1,5 @@
 version: 5.2.0
-last_run: 2026-04-02
+last_run: 2026-04-06
 components:
   skills: 19
   agents: 17

--- a/.hxsk/CURRENT.md
+++ b/.hxsk/CURRENT.md
@@ -1,29 +1,34 @@
 # Current Session Context
 
 ## Session Narrative
-> On 2026-04-02 13:21:41, the developer was working on the **master** branch, modifying 0
-0 files across `the project`. The recent work involved: chore: CURRENT.md 세션 상태 업데이트 (#103).
+> On 2026-04-06 08:46:25, the developer was working on the **master** branch, modifying 4 files across `.hxsk,.hxsk/hooks,.hxsk/scripts`. The recent work involved: chore: CURRENT.md 최신 상태 반영 (#104).
 
 ## Context Snapshot
-- **Active Task**: chore: CURRENT.md 세션 상태 업데이트 (#103)
+- **Active Task**: chore: CURRENT.md 최신 상태 반영 (#104)
 - **Branch**: master
-- **Files Changed**: 0
-0
-- **Last Updated**: 2026-04-02 13:21:41
+- **Files Changed**: 4
+- **Last Updated**: 2026-04-06 08:46:25
 
 ## Working Files
 ```
-No changes detected
+ M .hxsk/.bootstrap-version
+ M .hxsk/CURRENT.md
+ M .hxsk/hooks/check-consistency.sh
+ M .hxsk/scripts/bootstrap.sh
 ```
 
 ## Recent Commits
 ```
+91ecb07 chore: CURRENT.md 최신 상태 반영 (#104)
 b124d6d chore: CURRENT.md 세션 상태 업데이트 (#103)
 88c075a fix: hooks INDEX.md 카운트 17→19 + 신규 훅 2개 등록 (#102)
-44f82da feat(pre-pr): Conventional Commits 기반 버전업 자동 추천 (#105) (#101)
 ```
 
 ## Diff Stats
 ```
-No diff available
+ .hxsk/.bootstrap-version         |  2 +-
+ .hxsk/CURRENT.md                 | 17 ++++++++---------
+ .hxsk/hooks/check-consistency.sh | 14 +++++++++++---
+ .hxsk/scripts/bootstrap.sh       | 21 +++++++++++++++++++++
+ 4 files changed, 41 insertions(+), 13 deletions(-)
 ```

--- a/.hxsk/hooks/check-consistency.sh
+++ b/.hxsk/hooks/check-consistency.sh
@@ -11,6 +11,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+FIX_MODE=false
+[[ "${1:-}" == "--fix" ]] && FIX_MODE=true
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 HXSK_DIR="$PROJECT_DIR/.hxsk"
 FAIL=0
@@ -288,10 +291,15 @@ PERM_FAIL=0
 while IFS= read -r hook_file; do
     [[ -z "$hook_file" ]] && continue
     bn=$(basename "$hook_file")
-    # 실행 권한 확인
+    # 실행 권한 확인 + --fix 시 자동 수정
     if [[ ! -x "$hook_file" ]]; then
-        fail "$bn: not executable (chmod +x needed)"
-        ((PERM_FAIL++)) || true
+        if $FIX_MODE; then
+            chmod +x "$hook_file"
+            pass "$bn: chmod +x applied (auto-fixed)"
+        else
+            fail "$bn: not executable (chmod +x needed — use --fix to auto-repair)"
+            ((PERM_FAIL++)) || true
+        fi
     fi
     # shebang 확인
     FIRST_LINE=$(head -1 "$hook_file")

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -311,6 +311,27 @@ else
 fi
 
 # ─────────────────────────────────────────────────────
+# Hook Permissions (Auto-fix)
+# ─────────────────────────────────────────────────────
+
+echo ""
+echo "--- Hook Permissions ---"
+
+PERM_FIXED=0
+while IFS= read -r hook_file; do
+    [[ -z "$hook_file" ]] && continue
+    if [[ ! -x "$hook_file" ]]; then
+        chmod +x "$hook_file"
+        report_updated "$(basename "$hook_file")" "chmod +x applied"
+        ((PERM_FIXED++)) || true
+    fi
+done < <(find "$HOOK_DIR" \( -name "*.sh" -o -name "*.py" \) 2>/dev/null)
+
+if [[ "$PERM_FIXED" -eq 0 ]]; then
+    report_ok "Hook permissions" "all executable"
+fi
+
+# ─────────────────────────────────────────────────────
 # Prompt Patch (Optional)
 # ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `bootstrap.sh`에 **Hook Permissions** 단계 추가 — `.sh`/`.py` 훅 파일에 `chmod +x` 자동 적용
- `check-consistency.sh`에 `--fix` 옵션 구현 — 실행 권한 누락 시 자동 수정 가능
- 원인: `.py` 훅 파일이 실행 권한 없이 복사되어 다른 프로젝트에서 PreToolUse hook error 발생

## Test plan
- [x] `bash .hxsk/scripts/bootstrap.sh` 실행 → Hook Permissions 섹션 `[OK]` 확인
- [ ] 새 프로젝트에서 부트스트랩 후 `.py` 훅 파일 실행 권한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)