### PR TITLE
fix: CI consistency check 오탐 해소 및 actions/checkout v6

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ jobs:
   consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run consistency check
         run: bash .hxsk/hooks/check-consistency.sh

--- a/.github/workflows/release-setup.yml
+++ b/.github/workflows/release-setup.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get version from bootstrap
         id: version

--- a/.hxsk/hooks/check-consistency.sh
+++ b/.hxsk/hooks/check-consistency.sh
@@ -383,13 +383,15 @@ REQUIRED_TYPES="architecture-decision root-cause debug-eliminated debug-blocked 
 MEM_MISSING=0
 for mtype in $REQUIRED_TYPES; do
     if [[ ! -d "$HXSK_DIR/memories/$mtype" ]]; then
-        fail "Memory type missing: $mtype"
+        warn "Memory type missing: $mtype (created at runtime)"
         ((MEM_MISSING++)) || true
     fi
 done
 
 if [[ "$MEM_MISSING" -eq 0 ]]; then
     pass "Memory types: all 14 present"
+else
+    warn "Memory dirs are gitignored — created at bootstrap, not in CI"
 fi
 
 # ─── 12. 데드 에이전트/스킬 탐지 ─────────────────


### PR DESCRIPTION
## Summary
- memory type 디렉토리 검증을 `fail` → `warn` 전환 (`.gitignore` 대상이라 CI에 존재하지 않아 항상 실패하던 문제)
- `actions/checkout` v4 → v6 업그레이드 (Node.js 20 deprecation, 2026-06-02 강제 전환 대응)

## Test plan
- [ ] PR Consistency Check 워크플로우가 memory type 항목에서 더 이상 FAIL하지 않는지 확인
- [ ] Release Setup Prompts 워크플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)