### PR TITLE
fix: bootstrap-version 5.2.0 → 5.2.1 동기화

### DIFF
--- a/.hxsk/.bootstrap-version
+++ b/.hxsk/.bootstrap-version
@@ -1,4 +1,4 @@
-version: 5.2.0
+version: 5.2.1
 last_run: 2026-04-06
 components:
   skills: 19


### PR DESCRIPTION
## Summary
- `.hxsk/.bootstrap-version`이 `5.2.0`으로 남아있어 `bootstrap.sh`의 `5.2.1`과 불일치 → CI consistency check FAIL
- 버전을 `5.2.1`로 맞춤

## Test plan
- [ ] PR Consistency Check에서 버전 불일치 FAIL 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)