### PR TITLE
chore: Dependabot + pre-commit 버전 검증 + CHANGELOG v5.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.hxsk/CHANGELOG.md
+++ b/.hxsk/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ---
 
+### [2026-04-07] v5.2.1 — CI 안정화 + 버전 동기화 가드레일
+
+#### 수정
+- `check-consistency.sh` — memory type 검증 fail → warn 전환 (gitignore 대상, CI 미존재)
+- `.bootstrap-version` — 5.2.0 → 5.2.1 동기화
+- `actions/checkout` v4 → v6 (Node.js 20 deprecation 대응)
+
+#### 신규
+- `dependabot.yml` — GitHub Actions 버전 자동 업데이트 (월 1회)
+- `pre-commit-version-check.sh` — bootstrap.sh ↔ .bootstrap-version 버전 불일치 커밋 차단
+
+---
+
 ### [2026-04-02] v5.2.0 — 정합성 자동 검증 + pre-PR 자동화 + 문서 체계화
 
 #### 신규

--- a/.hxsk/hooks/pre-commit-version-check.sh
+++ b/.hxsk/hooks/pre-commit-version-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pre-commit hook: bootstrap.sh 버전과 .bootstrap-version 파일 동기화 검증
+# 둘 중 하나라도 스테이징에 포함되면 버전 일치 여부 확인
+
+HXSK_DIR=".hxsk"
+VERSION_FILE="$HXSK_DIR/.bootstrap-version"
+BOOTSTRAP_SH="$HXSK_DIR/scripts/bootstrap.sh"
+
+# 스테이징된 파일 중 버전 관련 파일이 있는지 확인
+STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+
+if echo "$STAGED" | grep -qE "(bootstrap\.sh|\.bootstrap-version)"; then
+    VER_SH=$(grep '^BOOTSTRAP_VERSION=' "$BOOTSTRAP_SH" 2>/dev/null | head -1 | sed 's/.*="//' | sed 's/"//')
+    VER_FILE=$(grep '^version:' "$VERSION_FILE" 2>/dev/null | sed 's/^version: *//' | tr -d '"[:space:]')
+
+    if [[ -n "$VER_SH" && -n "$VER_FILE" && "$VER_SH" != "$VER_FILE" ]]; then
+        echo "❌ 버전 불일치: bootstrap.sh=$VER_SH, .bootstrap-version=$VER_FILE"
+        echo "   두 파일의 버전을 맞춘 뒤 다시 커밋하세요."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Summary
- `dependabot.yml` 추가: GitHub Actions 버전 월간 자동 업데이트 (actions/checkout 등)
- `pre-commit-version-check.sh` 추가: bootstrap.sh와 .bootstrap-version 버전 불일치 시 커밋 차단
- CHANGELOG에 v5.2.1 항목 추가 (pre-PR check FAIL 해소)

## Test plan
- [ ] PR Consistency Check + Pre-PR Check 모두 PASS 확인
- [ ] 머지 후 Dependabot이 `.github/dependabot.yml`을 인식하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)