### PR TITLE
fix: hooks 카운트 19 → 20 동기화

### DIFF
--- a/.hxsk/.bootstrap-version
+++ b/.hxsk/.bootstrap-version
@@ -3,5 +3,5 @@ last_run: 2026-04-06
 components:
   skills: 19
   agents: 17
-  hooks: 19
+  hooks: 20
   memories: 15


### PR DESCRIPTION
## Summary
- pre-commit-version-check.sh 추가로 훅이 20개가 됐으나 .bootstrap-version이 19로 남아있어 CI FAIL
- 카운트를 20으로 맞춤

## Test plan
- [ ] PR Consistency Check PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)