### PR TITLE
feat: Phase 1 규율 강화 — 프롬프트 + 인프라 이중 방어

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,16 @@
         ]
       },
       {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".hxsk/hooks/read-before-edit.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -35,6 +45,16 @@
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".hxsk/hooks/track-read-history.py",
+            "timeout": 2
+          }
+        ]
+      },
       {
         "matcher": "Edit|Write",
         "hooks": [

--- a/.hxsk/docs/DESIGN-PHILOSOPHY.md
+++ b/.hxsk/docs/DESIGN-PHILOSOPHY.md
@@ -1,0 +1,252 @@
+# HExoskeleton 설계 철학
+
+> AI 에이전트의 외골격 — 추상화의 늪 없이, 실제 결과물을 내는 개발 방법론의 설계 원칙과 근거.
+
+---
+
+## 1. 핵심 관찰
+
+HExoskeleton은 세 가지 관찰에서 출발합니다.
+
+### 관찰 1: 에이전트의 네이티브 도구가 이미 충분하다
+
+`Grep`, `Glob`, `Read` — 코딩 에이전트가 기본 탑재한 도구만으로 파일 시스템을 완전히 탐색할 수 있습니다.
+
+| 접근 | 채택 여부 | 이유 |
+|------|----------|------|
+| 벡터 DB (Qdrant, Weaviate) | 미채택 | 외부 서비스 의존, 설정 복잡도 증가 |
+| MCP 서버 | 미채택 | 추가 프로세스, 네트워크 오버헤드 |
+| SQLite/JSON | 미채택 | 파일 수준 가독성 저하, Git diff 불가 |
+| Python/Node 런타임 | 미채택 | 환경 구성 필수, 에이전트 도구만으로 충분 |
+| **순수 bash + 마크다운** | **채택** | 외부 종속성 0, 빌드 0, 레포 = 배포 단위 |
+
+**근거**: [Anthropic Context Engineering Guide](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — "가장 작은 고신호 토큰 집합"
+
+### 관찰 2: 파일 시스템이 곧 데이터베이스다
+
+마크다운 파일은 사람이 읽을 수 있고, `git diff`로 변경을 추적할 수 있고, 어떤 에이전트든 `Read` 한 번이면 접근할 수 있습니다.
+
+**근거**:
+- [A-Mem](https://arxiv.org/html/2502.12110v11): 7-속성 노트 + 2-hop 그래프 검색
+- [Nemori](https://arxiv.org/html/2508.03341v3): 타입 분리 + 중복 제거 + contextual description
+
+### 관찰 3: 에이전트는 "어떻게"보다 "언제, 무엇으로"가 중요하다
+
+절차는 스킬(Skill)에, 오케스트레이션은 에이전트(Agent) 정의에 분리합니다.
+
+**근거**:
+- Anthropic 내부 테스트: 시스템 프롬프트 ~1,800 토큰 최적 구간
+- Microsoft/Stanford 연구: 2,500 토큰 초과 시 환각 34% 증가
+- [RLM](https://arxiv.org/html/2512.24601v2): Agent-Skill 래핑, Phase → Plan → Task 구조
+
+---
+
+## 2. 설계 원칙
+
+### 원칙 1: Lazy Loading 문서 계층
+
+에이전트가 필요한 만큼만 읽도록 3단계로 구조화합니다.
+
+| 레벨 | 내용 | 토큰 | 규칙 |
+|------|------|------|------|
+| **L0** | YAML frontmatter | ~50 | 스캔용 |
+| **L1** | CLAUDE.md, AGENTS.md | ~200-500 | 정책·제약·트리거만. ≤120줄 |
+| **L2** | SKILL.md, Agent.md | ~300-1000 | 상세 절차. Quick Reference ≤5줄 |
+| **L3** | .hxsk/research/ | ~1000+ | 출처·근거. 필요 시에만 |
+
+**규칙**: L1에는 정책, L2에는 절차, L3에는 근거. 상위 레벨은 하위를 참조하되 내용을 복제하지 않는다.
+
+**근거**: SkillReducer (Gao et al., 2026, arXiv:2603.29919) — 55K 스킬 분석, description 압축 시 품질 2.8% 향상 (less-is-more). 60%+ 본문이 비실행 내용.
+
+### 원칙 2: Skill-Agent 분리 (How vs When)
+
+**Skill = How** (재사용 가능한 절차). **Agent = When/With What** (오케스트레이션).
+
+```
+Agent (~20줄) → "디버깅 시 systematic-debugging 스킬 사용"
+                 │ 위임
+                 ▼
+Skill (~100-300줄) → "1. 에러 수집 2. 가설 수립 3. 검증..."
+```
+
+에이전트 정의가 간결할수록 에이전트는 정확하게 동작합니다.
+
+**근거**: Anthropic Context Engineering (2025) — "smallest set of high-signal tokens that maximize the likelihood of your desired outcome."
+
+### 원칙 3: CSO (Claude Search Optimization)
+
+스킬 description에는 **트리거 조건만** 기재합니다. 워크플로우 요약을 포함하면 에이전트가 본문을 건너뜁니다.
+
+```yaml
+# Bad — 워크플로우 요약 포함
+description: "메모리를 저장하고 검색하는 프로토콜. 2-hop 검색과 14타입 분류를 지원"
+
+# Good — 트리거 조건만
+description: "Use when storing or retrieving project knowledge, after architecture decisions, bug fixes, or session ends"
+```
+
+**근거**: SkillReducer (2026) — 48% description 압축 + 2.8% 품질 향상. Anthropic 공식 문서: 시작 시 메타데이터만 프리로드, 본문은 관련성 판단 후 로딩.
+
+### 원칙 4: 경험적 검증 (Empirical Validation)
+
+"잘 되는 것 같다"는 증거가 아닙니다. 모든 주장은 실행 결과로 증명합니다.
+
+**근거**: Anthropic harness blog (2025) — 명시적 검증 도구 없이 에이전트가 허위 완료 선언.
+
+### 원칙 5: Iron Laws (밝은 선 규칙)
+
+비타협 규칙은 `NO X WITHOUT Y FIRST` 형식으로 선언합니다.
+
+```
+NO EDIT WITHOUT READ FIRST
+NO COMPLETION WITHOUT VERIFICATION
+NO WRITE TO EXISTING FILES
+```
+
+**근거**:
+- Meincke et al. (2025) SSRN #5357179: Authority 기법으로 LLM 준수율 33%→72% (N=28,000)
+- Wallace et al. (ICLR 2025) arXiv:2404.13208: 명령 계층에서 최상위 규칙이 하위 합리화를 오버라이드
+- OpenAI Model Spec (2025): "Root level rules" — 산업 표준 패턴
+
+### 원칙 6: 프롬프트 + 인프라 이중 방어
+
+프롬프트만으로는 thinking 부족 시 무시됩니다. 인프라(훅)로 이중 방어합니다.
+
+```
+Layer 1 (정책):   AGENTS.md Iron Laws          — 항상 로딩
+Layer 2 (절차):   SKILL.md 합리화 테이블/게이트  — 스킬 로딩 시
+Layer 3 (인프라): PreToolUse/Stop 훅           — thinking 무관 항상 실행
+Layer 4 (라우팅): CSO description              — 올바른 스킬 선택
+```
+
+**근거**:
+- Wallace et al. (ICLR 2025): 아키텍처 강제가 프롬프트 강제보다 일관되게 우수
+- GitHub anthropics/claude-code#42796: thinking depth 73% 감소 시 프롬프트 규칙 무시 급증
+
+### 원칙 7: 합리화 차단 (Anti-Rationalization)
+
+LLM은 RLHF 훈련으로 인해 순응·지름길을 선호합니다. `| 변명 | 현실 |` 테이블로 명시 차단합니다.
+
+| 변명 | 현실 |
+|------|------|
+| "이미 파일 내용을 안다" | 다른 에이전트가 수정했을 수 있다 |
+| "확신한다" | 확신 ≠ 증거 |
+| "단순한 변경이다" | 단순한 변경이 가장 많이 깨진다 |
+
+**근거**:
+- Sharma et al. (ICLR 2024) arXiv:2310.13548: RLHF가 아첨의 근본 원인
+- Vennemeyer et al. (2025) arXiv:2509.21305: 아첨적 동의는 잠재 공간에서 분리 가능
+
+### 원칙 8: 수렴적 부트스트랩 (Convergent Bootstrap)
+
+`bootstrap.sh`는 멱등(idempotent) 수렴 엔진입니다. 몇 번을 실행해도 동일한 최종 상태에 도달합니다.
+
+```
+fresh   → 모든 컴포넌트 생성, 카운트 기록
+update  → 기존과 비교, 변경분만 표시
+verify  → 구조 검증, 누락 자동 보충
+```
+
+### 원칙 9: 멀티 에이전트 수렴 (Multi-Agent Convergence)
+
+하나의 프로젝트를 여러 AI 에이전트가 동시에 관리합니다. 에이전트 지침은 분리하되, 워킹 상태(`.hxsk/`)는 공유합니다.
+
+**Lock-in 없음**: 순수 마크다운이므로 어떤 에이전트든 읽고 쓸 수 있습니다.
+
+---
+
+## 3. 작성 원칙
+
+### 문서 작성 규칙
+
+| 대상 | 규칙 |
+|------|------|
+| CLAUDE.md (L1) | ≤120줄. 검색 순서/트리거/제약만. 예시/포맷/스키마 제외 |
+| AGENTS.md (L1) | 정책 수준. 모든 플랫폼 공통. Iron Laws 포함 |
+| SKILL.md (L2) | Quick Reference ≤5줄. description = 트리거 조건만 (CSO) |
+| Agent.md (L2) | ~20-30줄. 탑재 스킬 목록 + 오케스트레이션 |
+| Research (L3) | 근거·출처. 필요 시에만 참조 |
+
+### 스킬 Description 규칙 (CSO)
+
+- "Use when..." 패턴으로 시작
+- 트리거 조건, 증상, 동의어 포함
+- 워크플로우 요약, 절차 설명 **금지**
+- 에러 메시지, 도구명 포함 가능
+
+### Iron Laws 작성 규칙
+
+- `NO X WITHOUT Y FIRST` 형식
+- AGENTS.md Validation 섹션에 배치
+- 3줄 이내
+- 모든 플랫폼에 적용
+
+### 합리화 테이블 작성 규칙
+
+- `| 변명 | 현실 |` 포맷
+- 규율 스킬(empirical-validation 등) 내부에 배치
+- 에이전트의 실제 우회 패턴에서 수집
+- 모델 업데이트 시 갱신 필요
+
+---
+
+## 4. 연구 기반
+
+현재 아키텍처는 다음 연구를 분석하고 선택적으로 적용한 결과입니다.
+
+### 메모리 시스템
+
+| 출처 | 적용 | 미적용 |
+|------|------|--------|
+| [A-Mem](https://arxiv.org/html/2502.12110v11) | frontmatter, related, 2-hop, compact | Memory Evolution |
+| [Nemori](https://arxiv.org/html/2508.03341v3) | 타입 분리, 중복 제거, contextual description | Predict-Calibrate |
+
+### 워크플로우
+
+| 출처 | 적용 | 미적용 |
+|------|------|--------|
+| [ReWOO](https://github.com/weitianxin/Awesome-Agentic-Reasoning) | SPEC→PLAN→EXECUTE 분리 | 전체 프레임워크 |
+| [RLM](https://arxiv.org/html/2512.24601v2) | Agent-Skill 래핑 | Persistent REPL |
+
+### 에이전트 규율
+
+| 출처 | 적용 | 미적용 |
+|------|------|--------|
+| [Superpowers](https://github.com/obra/superpowers) | Iron Laws, Gate Functions, 합리화 테이블, CSO | 스킬 TDD, 2단계 리뷰 (Phase 2) |
+| [Meincke et al. (2025)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5357179) | Authority 기반 Iron Laws (N=28,000) | — |
+| [Sharma et al. (ICLR 2024)](https://arxiv.org/abs/2310.13548) | 합리화 테이블 이론 근거 | — |
+| [SkillReducer (2026)](https://arxiv.org/abs/2603.29919) | CSO description 최적화 | 본문 자동 압축 |
+| [Wallace et al. (ICLR 2025)](https://arxiv.org/abs/2404.13208) | 명령 계층, Iron Laws 우선순위 | — |
+
+### 품질 보증
+
+| 출처 | 적용 | 미적용 |
+|------|------|--------|
+| [Anthropic harness blog](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) | Gate Function, 검증 체크포인트 | — |
+| [Anthropic Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) | Lazy Loading, 간결한 에이전트 정의 | — |
+| [Anthropic multi-agent](https://www.anthropic.com/engineering/multi-agent-research-system) | 컨텍스트 격리, 역할 분리 | — |
+
+---
+
+## 5. 방향성 (로드맵)
+
+### Phase 1: 규율 강화 (구현 완료)
+Iron Laws, 합리화 테이블, Gate Function, CSO, PreToolUse/Stop 훅
+
+### Phase 2: 검증 체계 고도화 (계획)
+Gate Function 스킬화, 보조 문서 시스템, 2단계 리뷰 (spec→quality), PreToolUse 훅 강화
+
+### Phase 3: 스킬 품질 보증 (계획)
+스킬 TDD (서브에이전트 압박 시나리오), 프롬프트 템플릿 표준화, 합리화 테이블 자동 갱신
+
+---
+
+## 참고 문서
+
+| 문서 | 위치 |
+|------|------|
+| Superpowers 분석 | `.hxsk/research/superpowers-analysis.md` |
+| 근거 논문 20개 | `.hxsk/research/superpowers-references.md` |
+| 품질 저하 완화 | `.hxsk/research/claude-code-quality-mitigation.md` |
+| Phase 1 설계 | `.hxsk/docs/PLAN-phase1-discipline.md` |
+| Phase 1 플로우차트 | `.hxsk/docs/PLAN-phase1-flowchart.md` |

--- a/.hxsk/hooks/post-turn-verify.sh
+++ b/.hxsk/hooks/post-turn-verify.sh
@@ -54,8 +54,32 @@ else
         [[ "$f" == *.py ]] && PY_CHANGES="$PY_CHANGES $f"
     done
     PY_CHANGES=$(echo "$PY_CHANGES" | xargs)
-    [[ -z "$PY_CHANGES" ]] && exit 0
-    cd "$PROJECT_DIR" && uv run ruff check --no-fix $PY_CHANGES >/dev/null 2>&1 || true
+    [[ -n "$PY_CHANGES" ]] && cd "$PROJECT_DIR" && uv run ruff check --no-fix $PY_CHANGES >/dev/null 2>&1 || true
+fi
+
+# ─────────────────────────────────────────────────────
+# 완료 검증 게이트 — 코드 변경 시 검증 명령 실행 여부 확인
+# Iron Law: NO COMPLETION WITHOUT VERIFICATION
+# ─────────────────────────────────────────────────────
+
+HXSK_DIR="$PROJECT_DIR/.hxsk"
+TRACK_LOG="$HXSK_DIR/.track-modifications.log"
+
+# stdin에서 에이전트 출력 읽기 (Stop 훅은 stop_hook_result 수신)
+AGENT_OUTPUT=""
+if [ ! -t 0 ]; then
+    AGENT_OUTPUT=$(cat 2>/dev/null || true)
+fi
+
+# 완료 키워드 탐지 (최종 완료 패턴만 — 중간 보고 제외)
+COMPLETION_KEYWORDS="(완료했습니다|완료됐습니다|모두 완료|all done|all tests pass|successfully completed)"
+if echo "$AGENT_OUTPUT" | grep -qiE "$COMPLETION_KEYWORDS"; then
+    # 코드 변경이 있는데 Bash(test/build) 실행 이력이 없으면 경고
+    BASH_RUNS=$(grep -c "Bash" "$TRACK_LOG" 2>/dev/null || echo "0")
+    if [[ "$BASH_RUNS" -eq 0 && -n "$CHANGED_FILES" ]]; then
+        echo "⚠️ 완료를 선언했으나 검증 명령(test/build) 실행 증거가 없습니다." >&2
+        echo "   Iron Law: NO COMPLETION WITHOUT VERIFICATION" >&2
+    fi
 fi
 
 exit 0

--- a/.hxsk/hooks/read-before-edit.py
+++ b/.hxsk/hooks/read-before-edit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Hook: PreToolUse (Edit) — Read 없이 Edit 차단
+
+Iron Law: NO EDIT WITHOUT READ FIRST
+세션 내에서 대상 파일을 Read한 적이 없으면 경고를 반환합니다.
+
+Exit code 2 = 차단 (stderr가 Claude에게 전달됨)
+Exit code 0 = 허용
+"""
+
+import json
+import os
+import sys
+
+HXSK_DIR = os.environ.get("HXSK_DIR", ".hxsk")
+READ_HISTORY = os.path.join(HXSK_DIR, ".read-history.log")
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, EOFError):
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {})
+file_path = tool_input.get("file_path", "")
+
+if not file_path:
+    sys.exit(0)
+
+# Edit 도구만 검사
+if tool_name != "Edit":
+    sys.exit(0)
+
+# Read history 확인
+read_files = set()
+if os.path.exists(READ_HISTORY):
+    with open(READ_HISTORY, "r") as f:
+        read_files = {line.strip() for line in f if line.strip()}
+
+# 절대 경로 정규화
+abs_path = os.path.abspath(file_path)
+
+if abs_path not in read_files and file_path not in read_files:
+    print(
+        f"Warning: '{os.path.basename(file_path)}' has not been Read in this session. "
+        "Iron Law: NO EDIT WITHOUT READ FIRST — please Read the file before editing.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+sys.exit(0)

--- a/.hxsk/hooks/session-start.sh
+++ b/.hxsk/hooks/session-start.sh
@@ -40,6 +40,9 @@ main() {
         # .session-active 마커 생성
         touch "$HXSK_DIR/.session-active" 2>/dev/null || true
 
+        # Read history 초기화 (read-before-edit 훅 연동)
+        : > "$HXSK_DIR/.read-history.log" 2>/dev/null || true
+
         # 1. CURRENT.md 로드
         CURRENT_FILE="$HXSK_DIR/CURRENT.md"
         if [ -f "$CURRENT_FILE" ]; then

--- a/.hxsk/hooks/track-read-history.py
+++ b/.hxsk/hooks/track-read-history.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Hook: PostToolUse (Read) — Read 이력 기록
+
+read-before-edit.py와 연동. Read 도구 사용 시 파일 경로를 기록합니다.
+"""
+
+import json
+import os
+import sys
+
+HXSK_DIR = os.environ.get("HXSK_DIR", ".hxsk")
+READ_HISTORY = os.path.join(HXSK_DIR, ".read-history.log")
+
+try:
+    data = json.load(sys.stdin)
+except (json.JSONDecodeError, EOFError):
+    sys.exit(0)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {})
+file_path = tool_input.get("file_path", "")
+
+if tool_name != "Read" or not file_path:
+    sys.exit(0)
+
+# 절대 경로와 원본 경로 모두 기록
+abs_path = os.path.abspath(file_path)
+
+os.makedirs(os.path.dirname(READ_HISTORY), exist_ok=True)
+
+# 중복 방지: 이미 기록된 경로는 건너뜀
+existing = set()
+if os.path.exists(READ_HISTORY):
+    with open(READ_HISTORY, "r") as f:
+        existing = {line.strip() for line in f if line.strip()}
+
+with open(READ_HISTORY, "a") as f:
+    if abs_path not in existing:
+        f.write(abs_path + "\n")
+    if file_path not in existing and file_path != abs_path:
+        f.write(file_path + "\n")
+
+sys.exit(0)

--- a/.hxsk/skills/arch-review/SKILL.md
+++ b/.hxsk/skills/arch-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arch-review
-description: Validates architectural rules and ensures design quality
+description: "Use when structural changes affect 3+ modules, before merging architecture-level PRs"
 version: 4.0.0
 allowed-tools:
   - Read

--- a/.hxsk/skills/clean/SKILL.md
+++ b/.hxsk/skills/clean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clean
-description: Runs shell script quality checks (shellcheck, shfmt) across the codebase
+description: "Use when shell scripts are modified, before committing bash/sh files"
 trigger: "코드 품질 검사, 린트, 포맷팅 수정, shellcheck, shfmt, pre-commit quality gate"
 ---
 

--- a/.hxsk/skills/codebase-mapper/SKILL.md
+++ b/.hxsk/skills/codebase-mapper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-mapper
-description: Analyzes existing codebases to understand structure, patterns, and technical debt
+description: "Use when onboarding to a new codebase, before major refactoring, or when asked about project structure"
 trigger: "코드베이스 분석, 프로젝트 구조 파악, 아키텍처 문서화, 기술 부채 조사, analyze codebase, map structure, onboarding"
 ---
 

--- a/.hxsk/skills/context-health-monitor/SKILL.md
+++ b/.hxsk/skills/context-health-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-health-monitor
-description: Monitors context complexity and triggers state dumps before quality degrades
+description: "Use when context feels stale, after 3+ failed attempts, or when conversation exceeds 50 turns"
 trigger: "컨텍스트 상태 확인, 세션 덤프, 3-strike 발동, 세션 인수인계, context health, session handoff"
 allowed-tools:
   - Read

--- a/.hxsk/skills/debugger/SKILL.md
+++ b/.hxsk/skills/debugger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugger
-description: Systematic debugging with persistent state and fresh context advantages
+description: "Use when encountering bugs, test failures, or unexpected behavior before proposing fixes"
 trigger: "버그 디버깅, 오류 원인 찾기, 에러 추적, root cause, unexpected behavior, bug investigation"
 allowed-tools:
   - Read

--- a/.hxsk/skills/dispatcher/SKILL.md
+++ b/.hxsk/skills/dispatcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatcher
-description: "MASTER/WORK 기반 6-Phase 병렬 이슈 오케스트레이션 — PLAN → 분할 → 워크트리 병렬 실행 → 머지"
+description: "Use when facing 5+ independent tasks that can be parallelized across worktrees"
 version: 2.0.0
 trigger: "dispatch|병렬 실행|wave 실행|이슈 배정|이슈 분할|work split|parallel issue|마스터플랜"
 allowed-tools:

--- a/.hxsk/skills/empirical-validation/SKILL.md
+++ b/.hxsk/skills/empirical-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: empirical-validation
-description: Requires proof before marking work complete — no "trust me, it works"
+description: "Use when claiming work is complete, before committing, or when verifying any change actually works"
 trigger: "경험적 검증, 실행 결과 확인, 증거 기반 확인, prove it works, empirical proof, validate with output"
 ---
 
@@ -81,21 +81,77 @@ npm run build
 # Bad: "Build should work now"
 ```
 
-## Forbidden Phrases
+## Gate Function — 완료 선언 전 필수
 
-Never use these as justification for completion:
-- "This should work"
-- "The code looks correct"
-- "I've made similar changes before"
-- "Based on my understanding"
-- "It follows the pattern"
+⚠️ 완료, 성공, 통과를 주장하기 전에 반드시 5단계를 거친다.
+
+1. **IDENTIFY** — 이 주장을 증명하는 명령은 무엇인가?
+2. **RUN** — 해당 명령을 전체 실행 (부분 실행, 이전 결과 재사용 금지)
+3. **READ** — 출력 전체 확인. exit code 확인. 실패 수 카운트
+4. **VERIFY** — 출력이 주장을 확인하는가? (부분 통과 ≠ 전체 통과)
+5. **CLAIM** — 4단계 모두 통과 시에만 주장 가능
+
+### 검증 유형별 필수 증거
+
+| 주장 | 필요 증거 | 불충분 |
+|------|----------|--------|
+| "테스트 통과" | 테스트 출력: 0 failures | 이전 실행, "통과할 것 같다" |
+| "버그 수정" | 원래 증상 재테스트 | 코드 변경됨, 수정 추정 |
+| "빌드 성공" | 빌드 명령 출력: exit 0 | "에러 없어 보인다" |
+| "파일 생성" | ls/cat으로 존재+내용 확인 | Write 도구 사용했으므로 |
+
+## 합리화 테이블
+
+### 허위 완료
+
+| 변명 | 현실 |
+|------|------|
+| "잘 돌아갈 것 같다" | 검증 명령을 실행하라 |
+| "확신한다" | 확신 ≠ 증거 |
+| "린터 통과했다" | 린터 ≠ 컴파일러 ≠ 테스트 |
+| "에이전트가 성공 보고했다" | 독립적으로 검증하라 |
+| "코드 변경이 명확하다" | 명확한 변경도 깨진다 |
+
+### Read 건너뛰기
+
+| 변명 | 현실 |
+|------|------|
+| "이미 파일 내용을 안다" | 다른 에이전트/사용자가 수정했을 수 있다 |
+| "단순한 변경이다" | 단순한 변경이 가장 많이 깨진다 |
+| "방금 읽었다" | "방금"이 몇 턴 전일 수 있다. 다시 읽어라 |
+| "전체 파일 덮어쓰기가 빠르다" | 덮어쓰기는 다른 변경을 날린다. Edit을 써라 |
+
+### 작업 중단
+
+| 변명 | 현실 |
+|------|------|
+| "이건 불가능하다" | 3가지 다른 접근을 시도했는가? |
+| "시간이 너무 오래 걸린다" | 사용자에게 보고하고 판단을 맡겨라 |
+| "다음 세션에서 하자" | 현재 컨텍스트가 가장 풍부하다. 지금 시도하라 |
+
+## Thinking Budget
+
+깊은 추론이 필요한 상황에서 명시적으로 깊은 thinking을 요청한다.
+
+### 필수 (항상 깊은 thinking)
+- 아키텍처 결정 — 3+ 모듈에 영향을 미치는 변경
+- 디버깅 근본 원인 분석 — 에러 재현 후 원인 추적
+- 리팩토링 임팩트 분석 — 삭제/이동 전 의존성 파악
+- 머지 충돌 해결 — 양쪽 변경의 의도 파악
+- 보안 관련 코드 — 인증, 권한, 입력 검증
+
+### 조건부 (복잡도에 따라)
+- 5+ 파일 동시 변경 — 상호 의존성 추론
+- 테스트 실패 원인 불명 — 에러 메시지가 모호
+- 사용자가 "왜?"라고 물을 때 — 설명에 깊은 이해 필요
 
 ## Integration
 
 This skill integrates with:
 - `/verify` — Primary workflow using this skill
 - `/execute` — Must validate before marking tasks complete
-- `CLAUDE.md` Validation 섹션 — 경험적 증거 기반 검증 원칙
+- `CLAUDE.md` Validation + Thinking Budget 섹션
+- `AGENTS.md` Iron Laws — 이 스킬의 상세 절차를 구현
 
 ## Failure Handling
 

--- a/.hxsk/skills/executor/SKILL.md
+++ b/.hxsk/skills/executor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: executor
-description: Executes HXSK plans with atomic commits, deviation handling, checkpoint protocols, and state management
+description: "Use when executing a written PLAN.md, implementing tasks with atomic commits"
 trigger: "플랜 실행, 계획 실행, PLAN.md 실행, execute plan, start implementation"
 allowed-tools:
   - Read

--- a/.hxsk/skills/handoff/SKILL.md
+++ b/.hxsk/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: Session handoff workflow — status check, test, commit, memory store, summary output
+description: "Use at session end, when switching contexts, or when another agent will continue the work"
 trigger: "세션 종료, 핸드오프, session end, handoff, 인수인계, wrap up session"
 allowed-tools:
   - Read

--- a/.hxsk/skills/impact-analysis/SKILL.md
+++ b/.hxsk/skills/impact-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impact-analysis
-description: Analyzes change impact before code modifications to prevent regression
+description: "Use before refactoring, deleting code, or modifying shared modules to assess blast radius"
 version: 4.0.0
 allowed-tools:
   - Read

--- a/.hxsk/skills/memory-protocol/SKILL.md
+++ b/.hxsk/skills/memory-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-protocol
-description: Memory operation rules — file-based recall/store protocol, field requirements, type registry
+description: "Use when storing or retrieving project knowledge, after architecture decisions, bug fixes, or session ends"
 version: 4.0.0
 trigger: "메모리 저장, 과거 기록 검색, 메모리 조회, store memory, recall memory, search past decisions"
 allowed-tools:

--- a/.hxsk/skills/plan-checker/SKILL.md
+++ b/.hxsk/skills/plan-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-checker
-description: Validates plans before execution to catch issues early
+description: "Use before executing a plan, when reviewing PLAN.md for completeness and feasibility"
 trigger: "플랜 검증, 계획 점검, PLAN.md 검사, validate plan, check plan before execution"
 ---
 

--- a/.hxsk/skills/planner/SKILL.md
+++ b/.hxsk/skills/planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planner
-description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification
+description: "Use when a SPEC.md exists and implementation planning is needed, before writing code"
 trigger: "플랜 작성, 계획 수립, 태스크 분해, create plan, break down tasks, make PLAN.md"
 ---
 

--- a/.hxsk/skills/pr-review/SKILL.md
+++ b/.hxsk/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Multi-persona code review (Dev, QA, Security, Arch, DevOps, UX) with severity triage and actionable feedback
+description: "Use when reviewing pull requests, after feature completion, or before merging to main"
 trigger: "코드 리뷰, PR 리뷰, 풀 리퀘스트 검토, review PR, code review, security review"
 ---
 

--- a/.hxsk/skills/verifier/SKILL.md
+++ b/.hxsk/skills/verifier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verifier
-description: Validates implemented work against spec requirements with empirical evidence
+description: "Use after implementation is complete, before marking a phase done, to verify against SPEC.md"
 trigger: "구현 검증, 완료 확인, 페이즈 검증, verify implementation, check phase completion, validate against spec"
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,11 @@ Architecture decisions, bug root causes, patterns, session ends 등 발생 시 �
 
 검증은 경험적 증거 기반. "잘 되는 것 같다"는 증거가 아님.
 
+### Iron Laws
+- `NO EDIT WITHOUT READ FIRST` — 파일을 읽지 않고 수정하지 않는다
+- `NO COMPLETION WITHOUT VERIFICATION` — 검증 증거 없이 완료를 선언하지 않는다
+- `NO WRITE TO EXISTING FILES` — 기존 파일 수정은 Edit을 사용한다. Write는 새 파일 전용
+
 - **결과 우선**: 기능 동작 확인 후 스타일 수정
 - **실패 전수 보고**: 모든 실패를 수집하여 보고
 - **조건부 성공**: 실제 결과 확인 후에만 성공 출력

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ CLAUDE.md, SKILL.md, Agent 정의 파일을 수정할 때:
 - L1(CLAUDE.md): 포함=검색 순서/트리거/제약, 제외=예시/포맷/스키마. ≤120줄
 - Skill/Agent: Quick Reference ≤5줄, 기존 패턴 참조
 
+## Thinking Budget
+깊은 추론이 필요한 작업(아키텍처 결정, 디버깅 근본 원인, 리팩토링 임팩트) 시
+`empirical-validation` 스킬의 Thinking Budget 섹션 참조.
+
 ## Agent Boundaries (Claude Code Specific)
 ### Never
 - `--dangerously-skip-permissions` 사용 금지

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ make setup
 
 | 문서 | 설명 |
 |------|------|
+| [**Design Philosophy**](.hxsk/docs/DESIGN-PHILOSOPHY.md) | **설계 철학 — 9가지 원칙, 작성 규칙, 연구 근거, 방향성** |
 | [Skills](.hxsk/docs/SKILLS.md) | 19개 스킬 상세 |
 | [Agents](.hxsk/docs/AGENTS.md) | 17개 에이전트 상세 |
 | [Hooks](.hxsk/docs/HOOKS.md) | 훅 시스템 + settings.json 전체 예시 |
@@ -361,7 +362,7 @@ make setup
 | [Workflows](.hxsk/docs/WORKFLOWS.md) | SPEC→PLAN→EXECUTE→VERIFY |
 | [Conventions](.hxsk/docs/CONVENTIONS.md) | 개발 컨벤션 (Issue, Branch, Commit, PR) |
 | [Build](.hxsk/docs/BUILD.md) | Self-Configure 배포 가이드 |
-| [Research](.hxsk/research/INDEX.md) | 30개 연구 문서 카탈로그 |
+| [Research](.hxsk/research/INDEX.md) | 33개 연구 문서 카탈로그 |
 
 ---
 


### PR DESCRIPTION
## Summary
Phase 1 로드맵 구현 — 에이전트 품질 저하 완화를 위한 7개 항목.

### 프롬프트 레벨 (5개)
- **Iron Laws**: AGENTS.md에 3개 비타협 규칙 추가
- **합리화 테이블**: empirical-validation에 12항목 (허위 완료/Read 건너뛰기/작업 중단)
- **Gate Function**: 완료 선언 전 5단계 게이트 (IDENTIFY→RUN→READ→VERIFY→CLAIM)
- **Ultrathink**: CLAUDE.md 참조 + empirical-validation 상세
- **CSO**: 15개 SKILL.md description 트리거 조건 최적화

### 인프라 레벨 (2개)
- **read-before-edit.py**: PreToolUse — Read 없이 Edit 차단
- **완료 검증 게이트**: Stop 훅 — 검증 명령 없이 완료 선언 시 경고

### 근거
- Meincke et al. (2025): Authority 준수율 33%→72%
- GitHub #42796: Edit-without-Read 444% 증가 대응
- SkillReducer (2026): description 압축 시 품질 2.8% 향상

## Test plan
- [ ] CI consistency check 통과
- [ ] Iron Laws가 AGENTS.md에 표시되는지 확인
- [ ] read-before-edit.py 동작 테스트 (Read 없이 Edit 시 경고)
- [ ] CSO 적용 후 스킬 트리거 정확도 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)