### PR TITLE
fix: pre-PR check 브랜치 감지 오탐 수정

### DIFF
--- a/.hxsk/hooks/pre-pr-check.sh
+++ b/.hxsk/hooks/pre-pr-check.sh
@@ -91,7 +91,8 @@ fi
 
 # ─── 4. 브랜치가 master가 아닌지 ─────────────────
 
-BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "unknown")
+# CI에서는 GITHUB_HEAD_REF (PR 소스 브랜치), 로컬에서는 git branch
+BRANCH="${GITHUB_HEAD_REF:-$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "unknown")}"
 if [[ "$BRANCH" == "master" || "$BRANCH" == "main" ]]; then
     fail "On $BRANCH branch — create a feature branch first"
 else


### PR DESCRIPTION
## Summary
- `pre-pr-check.sh`: `GITHUB_HEAD_REF` 환경변수 우선 사용으로 CI에서 PR 소스 브랜치 정확히 감지
- 근본 원인: `actions/checkout`이 PR merge commit을 체크아웃 → `git branch --show-current`가 master 반환

## Test plan
- [ ] 이 PR의 CI에서 "On master branch" FAIL이 사라지고 실제 브랜치명 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)