### PR TITLE
feat: 슬래시 커맨드 자동 등록 — bootstrap 심볼릭 링크

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,9 +83,13 @@ secrets/
 .agent/memory.jsonl
 **/memory.jsonl
 
+# ─── Claude Code Runtime (bootstrap.sh 자동 생성) ──
+.claude/skills/
+.claude/agents/
+.claude/worktrees/
+
 # ─── Worktrees ───────────────────────────────────
 .worktrees/
-.claude/worktrees/
 
 # ─── Database ────────────────────────────────────
 *.db

--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -59,19 +59,23 @@ test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
 
 **Claude Code 설치 방법:**
 ```bash
-# 스킬: .hxsk/skills/ → .claude/skills/
-for skill in bootstrap planner executor verifier memory-protocol; do
-    mkdir -p .claude/skills/$skill
-    cp .hxsk/skills/$skill/SKILL.md .claude/skills/$skill/SKILL.md
+# 스킬: .hxsk/skills/ → .claude/skills/ (심볼릭 링크 — 원본 수정 시 자동 반영)
+mkdir -p .claude/skills
+for skill_dir in .hxsk/skills/*/; do
+    skill_name=$(basename "$skill_dir")
+    ln -sfn "../../.hxsk/skills/$skill_name" ".claude/skills/$skill_name"
 done
 
 # 에이전트: .hxsk/agents/*.md → .claude/agents/ (INDEX.md 제외)
 mkdir -p .claude/agents
 for agent in .hxsk/agents/*.md; do
     [[ "$(basename "$agent")" == "INDEX.md" ]] && continue
-    cp "$agent" .claude/agents/
+    ln -sf "../../.hxsk/agents/$(basename "$agent")" ".claude/agents/$(basename "$agent")"
 done
 ```
+
+> 심볼릭 링크를 사용하므로 `.hxsk/`의 스킬/에이전트 수정이 `.claude/`에 즉시 반영됩니다.
+> 모든 스킬이 `/skill-name` 슬래시 커맨드로 자동 등록됩니다.
 
 **Gemini CLI** → `.agent/skills/{name}/SKILL.md`, `.agent/agents/{name}.md`에 배치
 **기타** → 에이전트 문서에 따라 배치

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -332,6 +332,48 @@ if [[ "$PERM_FIXED" -eq 0 ]]; then
 fi
 
 # ─────────────────────────────────────────────────────
+# Claude Code Slash Commands (Symlink .hxsk → .claude)
+# ─────────────────────────────────────────────────────
+
+echo ""
+echo "--- Claude Code Slash Commands ---"
+
+CLAUDE_SKILLS_DIR=".claude/skills"
+CLAUDE_AGENTS_DIR=".claude/agents"
+LINK_COUNT=0
+
+mkdir -p "$CLAUDE_SKILLS_DIR" "$CLAUDE_AGENTS_DIR"
+
+# Skills → .claude/skills/ (심볼릭 링크)
+for skill_dir in ".hxsk/skills/"*/; do
+    [[ ! -d "$skill_dir" ]] && continue
+    skill_name=$(basename "$skill_dir")
+    target="$CLAUDE_SKILLS_DIR/$skill_name"
+    if [[ ! -L "$target" && ! -d "$target" ]]; then
+        ln -sfn "../../.hxsk/skills/$skill_name" "$target"
+        ((LINK_COUNT++)) || true
+    fi
+done
+
+# Agents → .claude/agents/ (심볼릭 링크)
+for agent_file in ".hxsk/agents/"*.md; do
+    [[ ! -f "$agent_file" ]] && continue
+    bn=$(basename "$agent_file")
+    [[ "$bn" == "INDEX.md" ]] && continue
+    target="$CLAUDE_AGENTS_DIR/$bn"
+    if [[ ! -L "$target" && ! -f "$target" ]]; then
+        ln -sf "../../.hxsk/agents/$bn" "$target"
+        ((LINK_COUNT++)) || true
+    fi
+done
+
+if [[ "$LINK_COUNT" -gt 0 ]]; then
+    report_new "Slash commands" "${LINK_COUNT} symlinks created"
+else
+    report_ok "Slash commands" "all linked"
+fi
+
+# ─────────────────────────────────────────────────────
 # Prompt Patch (Optional)
 # ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `bootstrap.sh`: `.hxsk/skills/` → `.claude/skills/` 심볼릭 링크 자동 생성 (20 skills + 18 agents = 38 links)
- `setup.md`: `cp` → `ln -sfn`으로 변경, 원본 수정 시 자동 반영
- `.gitignore`: `.claude/skills/`, `.claude/agents/` 추가

모든 HXSK 스킬이 `/skill-name` 슬래시 커맨드로 Claude Code에서 사용 가능해집니다.

## Test plan
- [ ] CI 통과
- [ ] bootstrap 실행 후 `.claude/skills/planner` → `.hxsk/skills/planner` 심볼릭 링크 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)