### PR TITLE
feat(prune): prune-memories.sh에 --dry-run / --help 옵션 추가

### DIFF
--- a/.hxsk/scripts/prune-memories.sh
+++ b/.hxsk/scripts/prune-memories.sh
@@ -24,20 +24,42 @@ MEM_DIR="$PROJECT_DIR/.hxsk/memories"
 ARCHIVE_DIR="$MEM_DIR/_retained"
 RETENTION_DAYS=30
 DRY_RUN=0
+RETENTION_DAYS_SET=0
 
-# 인자 파싱: 숫자 = RETENTION_DAYS, --dry-run = DRY_RUN=1
+# --help용: 파일 상단의 연속 주석 블록을 종료까지 출력 (delimiter 기반)
+print_help() {
+    awk '
+        NR == 1 && /^#!/ { next }
+        /^#/ { sub(/^# ?/, ""); print; next }
+        { exit }
+    ' "$0"
+}
+
+# 인자 파싱:
+#  - --dry-run / -n: 플래그
+#  - --help / -h: 도움말 출력 후 종료
+#  - 순수 숫자: RETENTION_DAYS (한 번만 허용, 중복 거부)
+#  - 그 외: Unknown → exit 1
 for arg in "$@"; do
     case "$arg" in
         --dry-run|-n) DRY_RUN=1 ;;
         --help|-h)
-            sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+            print_help
             exit 0
             ;;
-        [0-9]*) RETENTION_DAYS="$arg" ;;
         *)
-            echo "Unknown argument: $arg" >&2
-            echo "Usage: $0 [RETENTION_DAYS] [--dry-run]" >&2
-            exit 1
+            if [[ "$arg" =~ ^[0-9]+$ ]]; then
+                if [[ "$RETENTION_DAYS_SET" -eq 1 ]]; then
+                    echo "Multiple RETENTION_DAYS values (already '$RETENTION_DAYS', got '$arg')" >&2
+                    exit 1
+                fi
+                RETENTION_DAYS="$arg"
+                RETENTION_DAYS_SET=1
+            else
+                echo "Unknown argument: $arg" >&2
+                echo "Usage: $0 [RETENTION_DAYS] [--dry-run]" >&2
+                exit 1
+            fi
             ;;
     esac
 done
@@ -88,7 +110,8 @@ for tier in "${LOCAL_TIERS[@]}"; do
         fi
         moved=$((moved + 1))
 
-        # 롤업 대상 월 기록
+        # 롤업 대상 월 기록 — session-summary tier만 (롤업은 이 tier에만 생성)
+        [[ "$tier" != "session-summary" ]] && continue
         case " $rolled_up_months " in
             *" $month "*) ;;
             *) rolled_up_months="$rolled_up_months $month" ;;

--- a/.hxsk/scripts/prune-memories.sh
+++ b/.hxsk/scripts/prune-memories.sh
@@ -2,7 +2,13 @@
 # prune-memories.sh — local-tier 메모리 리텐션 & 아카이브
 #
 # 사용법:
-#   bash .hxsk/scripts/prune-memories.sh [RETENTION_DAYS]
+#   bash .hxsk/scripts/prune-memories.sh [RETENTION_DAYS] [--dry-run]
+#
+# 예시:
+#   bash prune-memories.sh                # 30일 초과 파일 이동
+#   bash prune-memories.sh 60             # 60일 초과 파일 이동
+#   bash prune-memories.sh --dry-run      # 이동 대상만 출력 (실행 X)
+#   bash prune-memories.sh 7 --dry-run    # 7일 기준 dry-run
 #
 # 동작:
 #   1. RETENTION_DAYS(기본 30일) 초과 파일을 _retained/YYYY-MM/{tier}/로 이동
@@ -16,7 +22,25 @@ set -uo pipefail
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 MEM_DIR="$PROJECT_DIR/.hxsk/memories"
 ARCHIVE_DIR="$MEM_DIR/_retained"
-RETENTION_DAYS="${1:-30}"
+RETENTION_DAYS=30
+DRY_RUN=0
+
+# 인자 파싱: 숫자 = RETENTION_DAYS, --dry-run = DRY_RUN=1
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run|-n) DRY_RUN=1 ;;
+        --help|-h)
+            sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        [0-9]*) RETENTION_DAYS="$arg" ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [RETENTION_DAYS] [--dry-run]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # local-tier만 정리 (shared-tier는 git으로 관리)
 LOCAL_TIERS=(
@@ -56,8 +80,12 @@ for tier in "${LOCAL_TIERS[@]}"; do
         fi
 
         dest_dir="$ARCHIVE_DIR/$month/$tier"
-        mkdir -p "$dest_dir"
-        mv "$f" "$dest_dir/"
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+            echo "[dry-run] would move: $f → $dest_dir/"
+        else
+            mkdir -p "$dest_dir"
+            mv "$f" "$dest_dir/"
+        fi
         moved=$((moved + 1))
 
         # 롤업 대상 월 기록
@@ -69,10 +97,17 @@ for tier in "${LOCAL_TIERS[@]}"; do
 done
 
 # 월별 롤업 파일 생성 (session-summary만 해당)
+# dry-run 모드에선 파일이 실제로 이동하지 않아 summary_dir가 없으므로 skip
 for month in $rolled_up_months; do
     [[ -z "$month" || "$month" == "unknown" ]] && continue
     rollup="$ARCHIVE_DIR/$month/${month}_rollup.md"
     summary_dir="$ARCHIVE_DIR/$month/session-summary"
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        echo "[dry-run] would write rollup: $rollup"
+        continue
+    fi
+
     [[ -d "$summary_dir" ]] || continue
 
     {
@@ -93,6 +128,10 @@ for month in $rolled_up_months; do
     } > "$rollup"
 done
 
-echo "pruned: $moved files (retention=${RETENTION_DAYS}d)"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "[dry-run] would prune: $moved files (retention=${RETENTION_DAYS}d)"
+else
+    echo "pruned: $moved files (retention=${RETENTION_DAYS}d)"
+fi
 [[ -n "$rolled_up_months" ]] && echo "rollups:$rolled_up_months"
 exit 0


### PR DESCRIPTION
## Summary

PR #123 리뷰에서 후속으로 남긴 항목. `prune-memories.sh`는 30일 초과 파일을 `_retained/`로 이동하는 destructive 작업인데 실행 전 확인 수단이 없었음. `--dry-run` 추가로 안전한 예행 연습을 가능하게 함.

## Changes

**`.hxsk/scripts/prune-memories.sh`**
- 인자 파싱 확장:
  - 숫자 → `RETENTION_DAYS`
  - `--dry-run` / `-n` → 플래그
  - `--help` / `-h` → 헤더 주석 출력
  - 알 수 없는 인자 → `Usage` 메시지 + `exit 1`
- 파일 이동: dry-run 모드에선 `mv` 대신 `[dry-run] would move: ... → ...` 출력
- 롤업 생성: dry-run 모드에선 `[dry-run] would write rollup: ...` 출력
- 최종 요약: `[dry-run] would prune: N files` 구분

## Test Plan

- [x] `bash -n prune-memories.sh` 구문 OK
- [x] `--help` → usage 출력
- [x] `1 --dry-run` → 93 파일 이동 안내 + 2 롤업 안내, **디스크 변화 0**
- [x] 알 수 없는 인자 → exit 1 + usage
- [x] `doc-lint.sh` → PASS 6/6 (회귀 없음)

## 영향도

- **Breaking 없음**: 기존 호출부(Stop 훅의 `bash prune-memories.sh 30`)는 변함없이 동작.
- **Size**: +44 / -5 lines, 파일 1개.

## HXSK Context

- 관련 PR: #123 (dry-run을 Medium 리뷰 코멘트로 받음, "후속"으로 이월했던 항목)
- 후속 고려: Stop 훅에서 150개 초과 자동 호출 시 dry-run으로 먼저 확인하는 2단계 안전장치는 현재 설계엔 불필요 판단 (비동기 백그라운드라 확인 주체가 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)