### PR TITLE
docs(internal): lessons-learned 타입 등록 — memory-protocol, type-relations, AGENTS.md

### DIFF
--- a/.hxsk/memories/_schema/type-relations.yaml
+++ b/.hxsk/memories/_schema/type-relations.yaml
@@ -97,6 +97,20 @@ types:
       may_generate: [root-cause]
       informs: [architecture-decision]
 
+  lessons-learned:
+    description: "PR 리뷰/실행 중 발견된 반복 패턴 (A-E 카테고리)"
+    primary_tags: [lessons-learned, pattern]
+    subcategories:
+      A-doc-drift: "코드↔문서 drift (docstring, plan 불일치)"
+      B-test-quality: "테스트 품질 (mock-only, resource close 누락)"
+      C-state-sync: "상태 동기화/의미론 (invariant 위반, timing 오류)"
+      D-lifecycle: "Resource/Lifecycle (thread safety, cleanup 누락)"
+      E-compat: "Forward-compat (미사용 param, dead weight)"
+    relations:
+      derived_from: [deviation, root-cause]
+      informs: [pattern-discovery, architecture-decision]
+      prevents: [deviation]
+
   general:
     description: "기타"
     primary_tags: []
@@ -129,3 +143,4 @@ search_hints:
   architecture_chain: [bootstrap, architecture-decision, pattern-discovery]
   session_chain: [session-snapshot, session-summary, session-handoff]
   execution_chain: [deviation, execution-summary, pattern-discovery]
+  quality_chain: [lessons-learned, pattern-discovery, architecture-decision]

--- a/.hxsk/memories/architecture-decision/2026-04-13_lessons-learned-agent-workflow-pr-127.md
+++ b/.hxsk/memories/architecture-decision/2026-04-13_lessons-learned-agent-workflow-pr-127.md
@@ -1,0 +1,36 @@
+---
+title: "lessons-learned 메모리 타입 통합 (agent-workflow PR #127)"
+tags:
+  - architecture-decision
+  - agent-workflow
+  - lessons-learned
+  - pr-127
+type: architecture-decision
+created: 2026-04-13T07:59:53Z
+contextual_description: "agent-workflow 통합: lessons-learned 메모리 타입 신규 도입, 5개 스킬 확장 (PR #127)"
+keywords:
+  - lessons-learned
+  - cross_phase_invariants
+  - agent-workflow
+  - deviation
+  - A-E-category
+---
+
+## lessons-learned 메모리 타입 통합 (agent-workflow PR #127)
+
+## 결정
+기존 HXSK 스킬 5개에 agent-workflow-template 4개 컴포넌트를 Approach C(신규 스크립트 없이)로 통합.
+PR #127 머지 완료 (2026-04-13).
+
+## 변경 내용
+- .hxsk/memories/lessons-learned/{A~E}/ 디렉토리 신규 생성
+- PLAN.md 템플릿에 cross_phase_invariants 필드 추가
+- planner: Pre-Planning recall + invariants 체크리스트
+- executor: Cross-Phase Invariants 파싱 + A/B/C/D/E deviation 분류
+- create-pr: Pre-PR Self-Check A/B/C/D/E 블록
+- pr-review: 리뷰 후 lessons-learned 저장 섹션
+- dispatcher: LESSONS-LEARNED 참조 + Self-Review 표 + Ambiguity Log
+
+## 코파일럿 리뷰 발견 (전원 타당, 수정 완료)
+- md-recall-memory.sh 2번째 인자는 PROJECT_ROOT여야 함 (".") — 직접 메모리 경로 전달 시 경로 왜곡
+- A/B/C/D/E 테이블 경로 lessons-learned/ prefix 누락 → general/ 폴백 위험

--- a/.hxsk/skills/memory-protocol/SKILL.md
+++ b/.hxsk/skills/memory-protocol/SKILL.md
@@ -255,6 +255,11 @@ session_chain: [session-snapshot, session-summary, session-handoff]
 | `session-summary` | 세션 종료 요약 | `session,auto` | `memories/session-summary/` |
 | `session-snapshot` | Pre-compact 스냅샷 | `session-snapshot,pre-compact` | `memories/session-snapshot/` |
 | `security-finding` | 보안 발견 사항 | `security,finding` | `memories/security-finding/` |
+| `lessons-learned/A-doc-drift` | 코드↔문서 drift 패턴 | `lessons-learned,category-A` | `memories/lessons-learned/A-doc-drift/` |
+| `lessons-learned/B-test-quality` | 테스트 품질 패턴 | `lessons-learned,category-B` | `memories/lessons-learned/B-test-quality/` |
+| `lessons-learned/C-state-sync` | 상태 동기화/의미론 패턴 | `lessons-learned,category-C` | `memories/lessons-learned/C-state-sync/` |
+| `lessons-learned/D-lifecycle` | Resource/Lifecycle 패턴 | `lessons-learned,category-D` | `memories/lessons-learned/D-lifecycle/` |
+| `lessons-learned/E-compat` | Forward-compat 패턴 | `lessons-learned,category-E` | `memories/lessons-learned/E-compat/` |
 | `general` | 기타 | context-dependent | `memories/general/` |
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,15 @@ SPEC.md → PLAN.md → EXECUTE → VERIFY. Working docs in `.hxsk/`
 ### Search (우선순위)
 | 방식 | 용도 |
 |------|------|
-| `bash .hxsk/hooks/md-recall-memory.sh <query>` | 훅 기반 검색 (2-hop 지원) |
+| `bash .hxsk/hooks/md-recall-memory.sh <query> "." 5 compact` | 훅 기반 검색 (2-hop 지원) |
 | 파일 검색: `.hxsk/memories/` | Broad context |
 | 타입별 필터: `.hxsk/memories/{type}/*.md` | Narrow filter |
+| lessons-learned 조회: `md-recall-memory.sh "query lessons-learned" "." 5` | 반복 패턴 방지 |
 
 ### Storage Triggers
-Architecture decisions, bug root causes, patterns, session ends 등 발생 시 자동 저장. 상세: `.hxsk/skills/memory-protocol/SKILL.md`
+Architecture decisions, bug root causes, patterns, session ends 등 발생 시 자동 저장.
+PR 리뷰/실행 이탈 발견 시 → `lessons-learned/{A-E}` 카테고리로 분류 저장.
+상세: `.hxsk/skills/memory-protocol/SKILL.md`
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- PR #127 머지 후 신규 `lessons-learned` 메모리 타입을 내부 문서 시스템에 등록
- 코드 변경 없음, 순수 문서/스키마 업데이트

## Changes
- `memory-protocol/SKILL.md` Type Registry — `lessons-learned/A~E` 5개 서브타입 행 추가
- `_schema/type-relations.yaml` — `lessons-learned` 타입 정의 + `quality_chain` search hint 추가
- `AGENTS.md` Memory Protocol — recall 인자 정정(`"."`) + lessons-learned Storage Trigger 명시
- `memories/architecture-decision/` — PR #127 아키텍처 결정 메모리 저장

## HXSK Context
- 연관 PR: #127 (feat/agent-workflow-integration)
- 설계 문서: `.hxsk/docs/plans/2026-04-13-agent-workflow-integration-design.md`