### PR TITLE
fix(skill/dispatcher): 서브에이전트 프롬프트 외부 펜스 4-backtick으로 교체 (closes #002)

### DIFF
--- a/.hxsk/issues/002-dispatcher-nested-codeblock.md
+++ b/.hxsk/issues/002-dispatcher-nested-codeblock.md
@@ -3,7 +3,7 @@ id: 002
 title: "dispatcher/SKILL.md 서브에이전트 프롬프트 중첩 코드블록 GFM 렌더링 모호성"
 type: improvement
 priority: P3
-status: open
+status: resolved
 wave: null
 created: 2026-04-13
 assignee: null

--- a/.hxsk/skills/dispatcher/SKILL.md
+++ b/.hxsk/skills/dispatcher/SKILL.md
@@ -109,7 +109,7 @@ MASTER 문서의 branch 필드 기록. status를 `in-progress`로 변경.
 3. WORK 문서에 worktree, worktree_branch 기록
 
 **서브에이전트 프롬프트 템플릿:**
-```
+````
 You are executing {WORK_ID}.
 Main root: resolve via `git worktree list | head -1 | awk '{print $1}'`
 Read your work spec: {main_root}/.hxsk/issues/{WORK_ID}.md
@@ -151,7 +151,7 @@ REASON:   {왜 그렇게 결정}
 ALT:      {고려한 다른 옵션}
 
 결정이 없었다면: DECISION LOG: none
-```
+````
 
 ---
 


### PR DESCRIPTION
## Summary
- dispatcher/SKILL.md 서브에이전트 프롬프트 템플릿의 외부 펜스를 3-backtick → 4-backtick으로 교체
- 중첩 코드블록으로 인한 GFM 렌더링 모호성 해소 (Issue #002)

## Changes
- `.hxsk/skills/dispatcher/SKILL.md:112,154` — ` ``` ` → ` ```` `
- `.hxsk/issues/002-dispatcher-nested-codeblock.md` — status: open → resolved

## Test Plan
- [x] doc-lint PASS 7/7
- [x] 코드블록 경계 확인: L112(````), L128(```bash), L131(```), L154(````)

## HXSK Context
- Issue: #002 (arch-review 2026-04-13 발견)