### PR TITLE
feat(memory): 하네스 독립 prune + 임계치 5 + 전 local-tier cap (v5.5.0)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a2e7e254-1de3-4778-aa4d-a9d521d71e4f","pid":36700,"acquiredAt":1776312979043}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a2e7e254-1de3-4778-aa4d-a9d521d71e4f","pid":36700,"acquiredAt":1776312979043}

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ secrets/
 .claude/skills/
 .claude/agents/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # ─── Worktrees ───────────────────────────────────
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ secrets/
 .hxsk/.session-active
 .hxsk/.track-modifications.log
 .hxsk/.context-save.log
+.hxsk/.last-prune-ts
+.hxsk/.prune-lock/
+.hxsk/.prune-config
 .hxsk/context-config.yaml
 .hxsk/prd-*.json
 .hxsk/issues/MASTER-*.md

--- a/.hxsk/.bootstrap-version
+++ b/.hxsk/.bootstrap-version
@@ -1,5 +1,5 @@
-version: 5.4.0
-last_run: 2026-04-15
+version: 5.5.0
+last_run: 2026-04-16
 components:
   skills: 21
   agents: 18

--- a/.hxsk/CHANGELOG.md
+++ b/.hxsk/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ---
 
+### [2026-04-16] v5.5.0 — 하네스 독립 prune + 임계치 5 + 전 local-tier cap
+
+#### 신규
+- **prune-tick.sh** — 하네스 독립 opportunistic 트리거. sentinel mtime + mkdir atomic lock, cooldown 60s 기본. 메모리 툴 호출 시 자연 발화.
+- **--auto 모드** (`prune-memories.sh`) — 설정 파일(`.hxsk/.prune-config`) 기반으로 전 local-tier에 tier별 cap 일괄 적용. 기본 cap=5 (bootstrap=1).
+- **하네스 어댑터 템플릿** (`.hxsk/adapters/`) — Cursor / Gemini CLI / Copilot CLI / Windsurf / OpenCode / Codex CLI 각각의 훅 시스템용 설정 스니펫.
+- **git 훅 폴백** (`.hxsk/githooks/post-commit`, `post-merge`) — lifecycle 훅 미지원 하네스(Aider/Continue/Antigravity)용. `core.hooksPath .hxsk/githooks`.
+- **`.hxsk/.prune-config` 템플릿** — shell-sourceable 설정 샘플(`templates/prune-config.sample`).
+
+#### 개선
+- Stop 훅: 단일 tier hardcode → `--auto` 단일 호출로 전 tier 통합 관리. COUNT > 20 게이트 제거.
+- PreCompact 훅: session-summary(20) + session-snapshot(10) 두 줄 → `--auto` 한 줄로 단순화.
+- md-store-memory.sh / md-recall-memory.sh / bootstrap.sh 말미에 `prune-tick.sh` 비동기 호출 삽입.
+- 기본 cap 20 → 5 (모든 local-tier). bootstrap은 1개만 유지.
+
+#### 연구
+- AI 에이전트 하네스 9종 훅 지원 현황 조사 (Cursor/Gemini CLI/Copilot CLI/Windsurf/OpenCode/Codex CLI/Aider/Continue/Antigravity).
+- Opportunistic self-trigger 패턴 (sentinel mtime + mkdir atomic lock, BashFAQ/045) 적용.
+
+---
+
 ### [2026-04-15] v5.4.0 — Git Forge 통합 작업 관리 + lessons-learned + 메모리 티어 최적화
 
 #### 신규 — Git Forge 통합 작업 관리 (PR #131)

--- a/.hxsk/adapters/README.md
+++ b/.hxsk/adapters/README.md
@@ -1,0 +1,44 @@
+# Harness Adapters
+
+HXSK 메모리 prune 정책을 Claude Code 외의 에이전트 하네스에서도 활성화하는 방법.
+
+## 우선순위
+
+1. **자동 발화 (기본)** — `md-store-memory.sh`, `md-recall-memory.sh`, `bootstrap.sh`가 호출되면 내부 `prune-tick.sh`가 opportunistic하게 실행됨. **어떤 하네스에서도 기본 동작**. 추가 설정 불필요.
+
+2. **하네스별 명시적 훅 (선택)** — 아래 표를 참고해 하네스가 제공하는 훅 시스템에 `prune-memories.sh --auto`를 등록하면 Stop/PreCompact 이벤트에서도 정리.
+
+3. **git 훅 (폴백)** — 하네스가 훅을 지원하지 않거나 메모리 툴을 건너뛰는 경우(Aider, Continue.dev, Antigravity 등)에 `.hxsk/githooks/` 설치로 커밋 시 정리.
+
+## 하네스별 어댑터
+
+| 하네스 | 설정 파일 | 발화 이벤트 | 비고 |
+|---|---|---|---|
+| **Claude Code** | `.claude/settings.json` | Stop, PreCompact | 이미 통합됨 (.hxsk/hooks/stop-context-save.sh 등) |
+| **Cursor 1.7+** | `.cursor/hooks.json` | stop, preCompact | [cursor-hooks.json](cursor-hooks.json) 복사 |
+| **Gemini CLI** | `~/.gemini/settings.json` 또는 프로젝트 `.gemini/settings.json` | SessionEnd, PreCompress | [gemini-settings.json](gemini-settings.json) 참고 |
+| **GitHub Copilot CLI** | `.copilot/hooks.json` | sessionEnd, agentStop | [copilot-hooks.json](copilot-hooks.json) 참고 |
+| **Windsurf Cascade** | `.windsurf/hooks.json` | post_cascade_response | SessionEnd·PreCompact 부재, 턴 종료로 대체 |
+| **OpenCode** | `~/.config/opencode/plugin/hxsk.ts` (JS 플러그인) | session.idle, session.compacting | 순수 bash 불가, 얇은 JS wrapper 필요 |
+| **OpenAI Codex CLI** | `.codex/hooks.json` (`codex_hooks=true` 필요) | stop | PreCompact 없음 |
+| **Aider / Continue / Antigravity** | (lifecycle 훅 미지원) | — | git 훅 폴백 사용 |
+
+## 설치 (선택)
+
+해당 하네스의 설정 파일 위치에 `.hxsk/adapters/<harness>.json`을 복사하거나 병합하세요.
+
+```bash
+# Cursor 예시
+mkdir -p .cursor
+cp .hxsk/adapters/cursor-hooks.json .cursor/hooks.json
+
+# git 훅 폴백 (모든 하네스 공통)
+git config core.hooksPath .hxsk/githooks
+```
+
+## 설계 근거
+
+- **Opportunistic tick**: 메모리 툴(`md-*`)은 하네스와 무관하게 스킬에서 호출되므로 여기 붙이면 자연 발화
+- **Cooldown + atomic lock**: `prune-tick.sh`가 60초 cooldown과 `mkdir` atomic lock을 내장해 스팸·race 방지
+- **git 훅**: `core.hooksPath`로 리포지토리 내부 훅 관리, Husky 불필요
+- **OS 스케줄러 제외**: launchd/cron/systemd는 크로스 플랫폼·외부 종속성 측면에서 HXSK 원칙(순수 bash + 외부 종속성 0)에 위배

--- a/.hxsk/adapters/codex-hooks.json
+++ b/.hxsk/adapters/codex-hooks.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "OpenAI Codex CLI hook config — HXSK prune. Requires feature flag codex_hooks=true. Copy/merge to .codex/hooks.json",
+  "hooks": {
+    "Stop": [
+      {
+        "command": "bash",
+        "args": [".hxsk/scripts/prune-memories.sh", "--auto"]
+      }
+    ]
+  }
+}

--- a/.hxsk/adapters/copilot-hooks.json
+++ b/.hxsk/adapters/copilot-hooks.json
@@ -1,0 +1,15 @@
+{
+  "$comment": "GitHub Copilot CLI hook config — HXSK prune integration. Copy/merge to .copilot/hooks.json",
+  "hooks": {
+    "sessionEnd": [
+      {
+        "command": "bash .hxsk/scripts/prune-memories.sh --auto"
+      }
+    ],
+    "agentStop": [
+      {
+        "command": "bash .hxsk/scripts/prune-memories.sh --auto"
+      }
+    ]
+  }
+}

--- a/.hxsk/adapters/cursor-hooks.json
+++ b/.hxsk/adapters/cursor-hooks.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "Cursor 1.7+ hook config — HXSK prune integration. Copy/merge to .cursor/hooks.json",
+  "hooks": {
+    "stop": [
+      {
+        "command": ".hxsk/scripts/prune-memories.sh",
+        "args": ["--auto"],
+        "timeout": 10
+      }
+    ],
+    "preCompact": [
+      {
+        "command": ".hxsk/scripts/prune-memories.sh",
+        "args": ["--auto"],
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.hxsk/adapters/gemini-settings.json
+++ b/.hxsk/adapters/gemini-settings.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Gemini CLI settings — HXSK prune integration. Merge into .gemini/settings.json or ~/.gemini/settings.json",
+  "hooks": {
+    "SessionEnd": [
+      {
+        "command": "bash",
+        "args": [".hxsk/scripts/prune-memories.sh", "--auto"]
+      }
+    ],
+    "PreCompress": [
+      {
+        "command": "bash",
+        "args": [".hxsk/scripts/prune-memories.sh", "--auto"]
+      }
+    ]
+  }
+}

--- a/.hxsk/adapters/opencode-plugin.ts
+++ b/.hxsk/adapters/opencode-plugin.ts
@@ -1,0 +1,32 @@
+// OpenCode plugin — HXSK prune integration.
+//
+// 설치:
+//   mkdir -p ~/.config/opencode/plugin
+//   cp .hxsk/adapters/opencode-plugin.ts ~/.config/opencode/plugin/hxsk.ts
+//
+// 또는 프로젝트 로컬:
+//   mkdir -p .opencode/plugin && cp .hxsk/adapters/opencode-plugin.ts .opencode/plugin/hxsk.ts
+//
+// 효과: session.idle 또는 session.compacting 이벤트 시 .hxsk/scripts/prune-memories.sh --auto 실행.
+
+import { $ } from "bun";
+
+export const plugin = {
+  name: "hxsk-prune",
+  events: {
+    async "session.idle"() {
+      try {
+        await $`bash .hxsk/scripts/prune-memories.sh --auto`.quiet();
+      } catch {
+        // silent — prune 실패는 세션에 영향 없음
+      }
+    },
+    async "session.compacting"() {
+      try {
+        await $`bash .hxsk/scripts/prune-memories.sh --auto`.quiet();
+      } catch {
+        // silent
+      }
+    },
+  },
+};

--- a/.hxsk/adapters/windsurf-hooks.json
+++ b/.hxsk/adapters/windsurf-hooks.json
@@ -1,0 +1,12 @@
+{
+  "$comment": "Windsurf Cascade hook config — HXSK prune integration. Copy/merge to .windsurf/hooks.json. post_cascade_response는 Stop의 대체로 매 턴 종료에 발화.",
+  "hooks": {
+    "post_cascade_response": [
+      {
+        "command": "bash",
+        "args": [".hxsk/scripts/prune-memories.sh", "--auto"],
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.hxsk/githooks/post-commit
+++ b/.hxsk/githooks/post-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# HXSK git post-commit hook — 하네스 훅 미지원 시 폴백
+#
+# 설치 방법 (리포지토리 루트에서):
+#   git config core.hooksPath .hxsk/githooks
+#
+# Aider / Continue.dev / Antigravity 등 lifecycle 훅이 없는 하네스에서도
+# 커밋 시점에 메모리 prune을 발화시킴. `prune-tick.sh`가 cooldown을 내장해
+# 매 커밋마다 실제로 돌지는 않음(기본 60초).
+#
+# 무거운 작업을 git 훅에서 돌리지 않는 것이 원칙이지만,
+# prune-tick.sh는 백그라운드 실행 + cooldown이라 커밋 속도 영향 없음.
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+TICK="$REPO_ROOT/.hxsk/scripts/prune-tick.sh"
+
+[[ -f "$TICK" ]] || exit 0
+
+# 백그라운드 + 출력 무시 — 커밋 훅 속도 유지
+CLAUDE_PROJECT_DIR="$REPO_ROOT" bash "$TICK" >/dev/null 2>&1 &
+disown 2>/dev/null || true
+
+exit 0

--- a/.hxsk/githooks/post-merge
+++ b/.hxsk/githooks/post-merge
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# HXSK git post-merge hook — pull/merge 후 메모리 prune 기회 제공.
+# 역할·제한은 post-commit과 동일.
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+TICK="$REPO_ROOT/.hxsk/scripts/prune-tick.sh"
+
+[[ -f "$TICK" ]] || exit 0
+
+CLAUDE_PROJECT_DIR="$REPO_ROOT" bash "$TICK" >/dev/null 2>&1 &
+disown 2>/dev/null || true
+
+exit 0

--- a/.hxsk/hooks/compact-context.sh
+++ b/.hxsk/hooks/compact-context.sh
@@ -208,9 +208,9 @@ else
 fi
 
 # ─────────────────────────────────────────────────────
-# 5. Memory cleanup — local-tier cap 기반 prune
-#    정책: session-summary 최신 20개, session-snapshot 최신 10개 유지
-#    shared-tier(execution-summary 등)는 git으로 관리하므로 자동 정리 제외
+# 5. Memory cleanup — --auto 모드 (설정 기반 전 tier 통합)
+#    .hxsk/.prune-config의 PRUNE_DEFAULT_CAP / PRUNE_CAP_<tier> 참조.
+#    shared-tier(execution-summary, root-cause 등)는 git 관리이므로 자동 정리 제외.
 # ─────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -222,8 +222,7 @@ if [[ -f "$PRUNE_SCRIPT" ]]; then
     echo "--- Memory Cleanup ---"
     dry_flag=()
     [[ "$DRY_RUN" == true ]] && dry_flag=(--dry-run)
-    bash "$PRUNE_SCRIPT" --max-count 20 --tier session-summary "${dry_flag[@]}" 2>/dev/null || true
-    bash "$PRUNE_SCRIPT" --max-count 10 --tier session-snapshot "${dry_flag[@]}" 2>/dev/null || true
+    bash "$PRUNE_SCRIPT" --auto "${dry_flag[@]}" 2>/dev/null || true
 else
     echo ""
     echo "--- Memory Cleanup ---"

--- a/.hxsk/hooks/md-recall-memory.sh
+++ b/.hxsk/hooks/md-recall-memory.sh
@@ -118,3 +118,8 @@ while IFS= read -r filepath; do
         echo ""
     fi
 done <<< "$RESULTS"
+
+# ── Opportunistic prune tick (하네스 독립) ──
+# 메모리 검색 시점에도 prune 기회 제공. cooldown·lock 내장으로 중복 안전.
+TICK_SCRIPT="$PROJECT_PATH/.hxsk/scripts/prune-tick.sh"
+[[ -f "$TICK_SCRIPT" ]] && bash "$TICK_SCRIPT" >/dev/null 2>&1 &

--- a/.hxsk/hooks/md-store-memory.sh
+++ b/.hxsk/hooks/md-store-memory.sh
@@ -123,3 +123,9 @@ fi
 } > "$FILEPATH"
 
 echo "$FILEPATH"
+
+# ── Opportunistic prune tick (하네스 독립) ──
+# Claude Code 훅이 없는 하네스(Cursor/Gemini CLI/OpenCode 등)에서도 메모리 저장 시
+# 자연 발화. cooldown·lock 내장이라 과다 호출 안전. 백그라운드 실행으로 호출자 블로킹 없음.
+TICK_SCRIPT="$PROJECT_DIR/.hxsk/scripts/prune-tick.sh"
+[[ -f "$TICK_SCRIPT" ]] && bash "$TICK_SCRIPT" >/dev/null 2>&1 &

--- a/.hxsk/hooks/stop-context-save.sh
+++ b/.hxsk/hooks/stop-context-save.sh
@@ -154,17 +154,13 @@ modifications_count: $MODIFICATIONS_COUNT"
     # ── 4. track-modifications.log 초기화 ──
     rm -f "$TRACK_LOG"
 
-    # ── 5. session-summary 누적 시 자동 prune (cap 기반, 최신 20개 유지)
-    #    git log/PR이 실행 이력을 대체하므로 로컬은 개수 상한으로 제어.
-    #    TTL 대신 FIFO 캡: 오래된 파일을 항상 정리하므로 7일 이내 누적도 해소.
-    SUMMARY_DIR="$PROJECT_DIR/.hxsk/memories/session-summary"
-    if [[ -d "$SUMMARY_DIR" ]]; then
-        COUNT=$(ls -1 "$SUMMARY_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
-        if [[ "$COUNT" -gt 20 ]]; then
-            bash "$PROJECT_DIR/.hxsk/scripts/prune-memories.sh" \
-                --max-count 20 --tier session-summary \
-                >> "$LOG_FILE" 2>&1 || true
-        fi
+    # ── 5. 모든 local-tier 자동 prune (설정 기반)
+    #    --auto: .hxsk/.prune-config의 tier별 cap(기본 5, bootstrap 1) 적용.
+    #    Stop은 매 턴 발화하지만 --auto는 cap 초과 tier만 처리하여 매우 빠름.
+    #    단일 tier 하드코드 대신 전 tier 통합 관리.
+    PRUNE_SCRIPT="$PROJECT_DIR/.hxsk/scripts/prune-memories.sh"
+    if [[ -f "$PRUNE_SCRIPT" ]]; then
+        bash "$PRUNE_SCRIPT" --auto >> "$LOG_FILE" 2>&1 || true
     fi
 ) &
 

--- a/.hxsk/memories/lessons-learned/2026-04-16_session-2026-04-16-13-16-27-master.md
+++ b/.hxsk/memories/lessons-learned/2026-04-16_session-2026-04-16-13-16-27-master.md
@@ -1,0 +1,44 @@
+---
+title: "Session [2026-04-16 13:16:27]: master"
+tags:
+  - session-summary
+  - branch:master
+  - auto
+type: session-summary
+created: 2026-04-16T04:16:27Z
+contextual_description: "[master] 1 files. chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133)"
+keywords:
+  - scheduled_tasks.lock
+---
+
+## Session [2026-04-16 13:16:27]: master
+
+# Current Session Context
+
+## Session Narrative
+> On 2026-04-16 13:16:27, the developer was working on the **master** branch, modifying 1 files across `.claude`. The recent work involved: chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133).
+
+## Context Snapshot
+- **Active Task**: chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133)
+- **Branch**: master
+- **Files Changed**: 1
+- **Last Updated**: 2026-04-16 13:16:27
+
+## Working Files
+```
+?? .claude/scheduled_tasks.lock
+```
+
+## Recent Commits
+```
+eef848e chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133)
+163aad7 chore(memory): 세션 누적 파일 정리 정책 개선 (#132)
+f5c1fb3 feat(workflow): Git Forge 통합 작업 관리 시스템 (GATES, forge-detect, gate-check) (#131)
+```
+
+## Diff Stats
+```
+No diff available
+```
+fingerprint: eef848e|a5a32108b7b55912fadc0c8246c1fc93
+modifications_count: 0

--- a/.hxsk/memories/lessons-learned/2026-04-16_session-2026-04-16-13-26-18-master.md
+++ b/.hxsk/memories/lessons-learned/2026-04-16_session-2026-04-16-13-26-18-master.md
@@ -1,0 +1,50 @@
+---
+title: "Session [2026-04-16 13:26:18]: master"
+tags:
+  - session-summary
+  - branch:master
+  - auto
+type: session-summary
+created: 2026-04-16T04:26:19Z
+contextual_description: "[master] 15 files. chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133)"
+keywords:
+  - .gitignore
+  - CHANGELOG.md
+  - compact-context.sh
+  - md-recall-memory.sh
+  - md-store-memory.sh
+---
+
+## Session [2026-04-16 13:26:18]: master
+
+# Current Session Context
+
+## Session Narrative
+> On 2026-04-16 13:26:18, the developer was working on the **master** branch, modifying 15 files across `.,.hxsk,.hxsk/hooks`. The recent work involved: chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133).
+
+## Context Snapshot
+- **Active Task**: chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티어 최적화 (#133)
+- **Branch**: master
+- **Files Changed**: 15
+- **Last Updated**: 2026-04-16 13:26:18
+
+## Working Files
+```
+ M .gitignore
+ M .hxsk/CHANGELOG.md
+ M .hxsk/hooks/compact-context.sh
+ M .hxsk/hooks/md-recall-memory.sh
+ M .hxsk/hooks/md-store-memory.sh
+ M .hxsk/hooks/stop-context-save.sh
+ M .hxsk/scripts/bootstrap.sh
+ M .hxsk/scripts/prune-memories.sh
+ M .hxsk/templates/context-config.yaml
+ M README.md
+?? .claude/scheduled_tasks.lock
+?? .hxsk/adapters/
+?? .hxsk/githooks/
+?? .hxsk/scripts/prune-tick.sh
+?? .hxsk/templates/prune-config.sample
+```
+fingerprint: eef848e|1e598d42033324aaa682b59904b2a37c
+modifications_count: 0

--- a/.hxsk/scripts/bootstrap.sh
+++ b/.hxsk/scripts/bootstrap.sh
@@ -17,7 +17,7 @@ set -o pipefail
 # Version & Mode Detection
 # ─────────────────────────────────────────────────────
 
-BOOTSTRAP_VERSION="5.4.0"
+BOOTSTRAP_VERSION="5.5.0"
 VERSION_FILE=".hxsk/.bootstrap-version"
 HOOK_DIR=".hxsk/hooks"
 MODE="fresh"
@@ -448,5 +448,11 @@ if [[ "$REQUIRED_FAIL" -gt 0 ]]; then
 else
     echo " RESULT: ALL REQUIRED CHECKS PASSED"
     echo "================================================================"
+
+    # ── Opportunistic prune tick (하네스 독립) ──
+    # 부트스트랩 성공 직후에도 한 번 기회를 줌. cooldown·lock 내장.
+    TICK_SCRIPT="${CLAUDE_PROJECT_DIR:-.}/.hxsk/scripts/prune-tick.sh"
+    [[ -f "$TICK_SCRIPT" ]] && bash "$TICK_SCRIPT" >/dev/null 2>&1 &
+
     exit 0
 fi

--- a/.hxsk/scripts/prune-memories.sh
+++ b/.hxsk/scripts/prune-memories.sh
@@ -2,22 +2,31 @@
 # prune-memories.sh — local-tier 메모리 리텐션 정리
 #
 # 사용법:
+#   bash .hxsk/scripts/prune-memories.sh --auto                   # 설정 기반 자동 (권장)
 #   bash .hxsk/scripts/prune-memories.sh [RETENTION_DAYS] [--dry-run]
 #   bash .hxsk/scripts/prune-memories.sh --max-count N [--tier TIER] [--dry-run]
 #
 # 예시:
+#   bash .hxsk/scripts/prune-memories.sh --auto                  # 모든 local-tier에 cap 적용 (기본 5, bootstrap 1)
+#   bash .hxsk/scripts/prune-memories.sh --auto --dry-run        # auto 모드 dry-run
 #   bash .hxsk/scripts/prune-memories.sh                         # 7일 초과 삭제 (TTL)
 #   bash .hxsk/scripts/prune-memories.sh 30                      # 30일 초과 삭제
-#   bash .hxsk/scripts/prune-memories.sh --dry-run               # TTL 대상만 출력
 #   bash .hxsk/scripts/prune-memories.sh 0 --dry-run             # 전체 대상 (0=모든 파일)
-#   bash .hxsk/scripts/prune-memories.sh --max-count 20          # tier별 최신 20개만 유지 (FIFO)
-#   bash .hxsk/scripts/prune-memories.sh --max-count 20 --tier session-summary  # 특정 tier만
+#   bash .hxsk/scripts/prune-memories.sh --max-count 5           # tier별 최신 5개만 유지 (FIFO)
+#   bash .hxsk/scripts/prune-memories.sh --max-count 5 --tier session-summary  # 특정 tier만
 #
 # 동작:
+#   - --auto 모드(권장): .hxsk/.prune-config로 tier별 cap 설정, 없으면 기본값 적용
+#   - --max-count 모드: tier별 mtime 최신 N개 유지, 나머지 삭제 (cap 기반, 전 tier 동일 N)
 #   - 기본 모드: RETENTION_DAYS(기본 7일) 초과 파일 삭제 (TTL 기반)
-#   - --max-count 모드: tier별 mtime 최신 N개 유지, 나머지 삭제 (cap 기반)
 #   - 대상: local-tier (gitignore 대상). shared-tier는 건드리지 않음
 #   - git log/PR이 실행 이력을 대체하므로 _retained 이동 불필요
+#
+# 하네스 독립성 (v5.5+):
+#   Claude Code 훅 외에도 md-store-memory.sh / md-recall-memory.sh / bootstrap.sh 말미에서
+#   prune-tick.sh를 통해 opportunistic하게 자동 호출됨. 즉, 어떤 에이전트 하네스에서도
+#   메모리 툴이 호출되면 자연스럽게 prune이 발화. Cursor/Gemini CLI/Copilot CLI는
+#   각자의 훅 시스템에서 .hxsk/hooks/stop-context-save.sh를 호출하면 된다.
 #
 # 가치 기반 승격 (삭제 직전 구제):
 #   frontmatter tags에 다음 키워드가 있으면 삭제 대신 shared-tier로 이동:
@@ -39,6 +48,25 @@ DRY_RUN=0
 RETENTION_DAYS_SET=0
 MAX_COUNT=""
 TIER_FILTER=""
+AUTO_MODE=0
+
+# ── 기본 cap (v5.5+ hands-off 정책) ──
+# .hxsk/.prune-config로 오버라이드 가능 (shell-sourceable).
+PRUNE_DEFAULT_CAP=5
+PRUNE_CAP_bootstrap=1       # bootstrap은 최신 1개만 (멱등 snapshot)
+PRUNE_TICK_COOLDOWN=60      # prune-tick.sh가 참조 (여기서도 노출)
+
+# Optional config override
+PRUNE_CFG="$PROJECT_DIR/.hxsk/.prune-config"
+# shellcheck disable=SC1090
+[[ -f "$PRUNE_CFG" ]] && source "$PRUNE_CFG"
+
+# tier별 cap 조회 (미지정 tier는 PRUNE_DEFAULT_CAP)
+resolve_cap() {
+    local tier="$1"
+    local var="PRUNE_CAP_${tier//-/_}"
+    echo "${!var:-$PRUNE_DEFAULT_CAP}"
+}
 
 # --help용: 파일 상단의 연속 주석 블록을 종료까지 출력 (delimiter 기반)
 print_help() {
@@ -58,6 +86,7 @@ while [[ $# -gt 0 ]]; do
     arg="$1"
     case "$arg" in
         --dry-run|-n) DRY_RUN=1 ;;
+        --auto) AUTO_MODE=1 ;;
         --help|-h)
             print_help
             exit 0
@@ -88,7 +117,7 @@ while [[ $# -gt 0 ]]; do
                 RETENTION_DAYS_SET=1
             else
                 echo "Unknown argument: $arg" >&2
-                echo "Usage: $0 [RETENTION_DAYS] [--dry-run] | $0 --max-count N [--tier T] [--dry-run]" >&2
+                echo "Usage: $0 --auto [--dry-run] | $0 [RETENTION_DAYS] [--dry-run] | $0 --max-count N [--tier T] [--dry-run]" >&2
                 exit 1
             fi
             ;;
@@ -168,31 +197,46 @@ delete_file() {
     fi
 }
 
-if [[ -n "$MAX_COUNT" ]]; then
-    # ── cap 기반: tier별 최신 MAX_COUNT개 유지, 나머지 삭제 ──
+# tier별 cap 적용 공통 함수
+apply_cap_to_tier() {
+    local tier="$1"
+    local cap="$2"
+    local src="$MEM_DIR/$tier"
+    [[ -d "$src" ]] || return 0
+
+    # mtime 최신→오래된 순 정렬. 0 기반 skip 후 나머지 삭제.
+    # stat 이식성: BSD(%m)/GNU(%Y) 모두 epoch 초.
+    local files_sorted
+    files_sorted=$(
+        find "$src" -maxdepth 1 -type f -name "*.md" -print0 2>/dev/null |
+        while IFS= read -r -d '' f; do
+            ts=$(stat -f '%m' "$f" 2>/dev/null || stat -c '%Y' "$f" 2>/dev/null || echo 0)
+            printf '%s\t%s\n' "$ts" "$f"
+        done |
+        sort -rn -k1,1 |
+        cut -f2-
+    )
+    local idx=0
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        idx=$((idx + 1))
+        [[ "$idx" -le "$cap" ]] && continue
+        delete_file "$f"
+    done <<< "$files_sorted"
+}
+
+if [[ "$AUTO_MODE" -eq 1 ]]; then
+    # ── auto 모드: 설정 기반, tier별 개별 cap 적용 ──
     for tier in "${LOCAL_TIERS[@]}"; do
         [[ -n "$TIER_FILTER" && "$tier" != "$TIER_FILTER" ]] && continue
-        src="$MEM_DIR/$tier"
-        [[ -d "$src" ]] || continue
-
-        # mtime 최신→오래된 순 정렬. 0 기반 skip 후 나머지 삭제.
-        # stat 이식성: BSD(%m)/GNU(%Y) 모두 epoch 초.
-        files_sorted=$(
-            find "$src" -maxdepth 1 -type f -name "*.md" -print0 2>/dev/null |
-            while IFS= read -r -d '' f; do
-                ts=$(stat -f '%m' "$f" 2>/dev/null || stat -c '%Y' "$f" 2>/dev/null || echo 0)
-                printf '%s\t%s\n' "$ts" "$f"
-            done |
-            sort -rn -k1,1 |
-            cut -f2-
-        )
-        idx=0
-        while IFS= read -r f; do
-            [[ -z "$f" ]] && continue
-            idx=$((idx + 1))
-            [[ "$idx" -le "$MAX_COUNT" ]] && continue
-            delete_file "$f"
-        done <<< "$files_sorted"
+        cap=$(resolve_cap "$tier")
+        apply_cap_to_tier "$tier" "$cap"
+    done
+elif [[ -n "$MAX_COUNT" ]]; then
+    # ── 수동 cap: 전 tier 동일 MAX_COUNT 적용 ──
+    for tier in "${LOCAL_TIERS[@]}"; do
+        [[ -n "$TIER_FILTER" && "$tier" != "$TIER_FILTER" ]] && continue
+        apply_cap_to_tier "$tier" "$MAX_COUNT"
     done
 else
     # ── TTL 기반: RETENTION_DAYS 초과 파일 삭제 ──
@@ -214,7 +258,9 @@ else
     done
 fi
 
-if [[ -n "$MAX_COUNT" ]]; then
+if [[ "$AUTO_MODE" -eq 1 ]]; then
+    mode_desc="auto (default=${PRUNE_DEFAULT_CAP}, bootstrap=${PRUNE_CAP_bootstrap})${TIER_FILTER:+, tier=$TIER_FILTER}"
+elif [[ -n "$MAX_COUNT" ]]; then
     mode_desc="max-count=${MAX_COUNT}${TIER_FILTER:+, tier=$TIER_FILTER}"
 else
     mode_desc="retention=${RETENTION_DAYS}d${TIER_FILTER:+, tier=$TIER_FILTER}"

--- a/.hxsk/scripts/prune-memories.sh
+++ b/.hxsk/scripts/prune-memories.sh
@@ -61,11 +61,31 @@ PRUNE_CFG="$PROJECT_DIR/.hxsk/.prune-config"
 # shellcheck disable=SC1090
 [[ -f "$PRUNE_CFG" ]] && source "$PRUNE_CFG"
 
-# tier별 cap 조회 (미지정 tier는 PRUNE_DEFAULT_CAP)
+# 설정 값 정규화: 비정상 값이면 기본값으로 폴백 (bash 산술 에러 방지)
+# 주의: `local name=.. val=${!name-}` 한 줄은 indirect expansion 실패 (name 미확정).
+sanitize_uint() {
+    local name="$1"
+    local fallback="$2"
+    local val="${!name-}"
+    if [[ ! "$val" =~ ^[0-9]+$ ]]; then
+        echo "[warn] $name=\"$val\" invalid, falling back to $fallback" >&2
+        printf -v "$name" '%d' "$fallback"
+    fi
+}
+sanitize_uint PRUNE_DEFAULT_CAP 5
+sanitize_uint PRUNE_CAP_bootstrap 1
+sanitize_uint PRUNE_TICK_COOLDOWN 60
+
+# tier별 cap 조회 (미지정 tier는 PRUNE_DEFAULT_CAP, 비정상 값은 폴백)
 resolve_cap() {
     local tier="$1"
     local var="PRUNE_CAP_${tier//-/_}"
-    echo "${!var:-$PRUNE_DEFAULT_CAP}"
+    local val="${!var:-$PRUNE_DEFAULT_CAP}"
+    if [[ ! "$val" =~ ^[0-9]+$ ]]; then
+        echo "[warn] $var=\"$val\" invalid, using PRUNE_DEFAULT_CAP=$PRUNE_DEFAULT_CAP" >&2
+        val="$PRUNE_DEFAULT_CAP"
+    fi
+    echo "$val"
 }
 
 # --help용: 파일 상단의 연속 주석 블록을 종료까지 출력 (delimiter 기반)

--- a/.hxsk/scripts/prune-tick.sh
+++ b/.hxsk/scripts/prune-tick.sh
@@ -35,6 +35,12 @@ PRUNE_CFG="$HXSK_DIR/.prune-config"
 # shellcheck disable=SC1090
 [[ -f "$PRUNE_CFG" ]] && source "$PRUNE_CFG"
 
+# 설정 값 정규화: 비정상 값(빈/음수/문자열)이면 기본값 폴백.
+# 산술 비교 시 "integer expression expected" 또는 부호 혼동 방지.
+if [[ ! "$PRUNE_TICK_COOLDOWN" =~ ^[0-9]+$ ]]; then
+    PRUNE_TICK_COOLDOWN=60
+fi
+
 # ── 선행 체크 ──
 [[ -f "$PRUNE_SCRIPT" ]] || exit 0
 [[ -d "$HXSK_DIR/memories" ]] || exit 0

--- a/.hxsk/scripts/prune-tick.sh
+++ b/.hxsk/scripts/prune-tick.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# prune-tick.sh — 하네스 독립 opportunistic prune 트리거
+#
+# 목적:
+#   Claude Code 외 하네스(Cursor/Gemini CLI/OpenCode/Aider/Continue 등)에서도
+#   HXSK 메모리 툴(md-store-memory.sh, md-recall-memory.sh, bootstrap.sh)이
+#   호출될 때마다 자연스럽게 prune이 발화하도록 하는 얇은 어댑터.
+#
+# 설계:
+#   - sentinel mtime 기반 cooldown — 지정된 초 이내 재실행 skip
+#   - mkdir atomic lock — 동시 실행 방지 (BashFAQ/045)
+#   - 백그라운드 실행 — 호출자 블로킹 없음
+#   - 실패해도 조용히 종료 — 호출자 동작에 영향 없음
+#
+# 호출자 스니펫 (md-store-memory.sh 등 말미):
+#   bash "$PROJECT_DIR/.hxsk/scripts/prune-tick.sh" >/dev/null 2>&1 &
+#
+# 설정: .hxsk/.prune-config (shell-sourceable, 선택)
+#   PRUNE_TICK_COOLDOWN=60          # 재실행 쿨다운(초)
+#   PRUNE_DEFAULT_CAP=5             # tier별 기본 cap
+#   PRUNE_CAP_bootstrap=1           # tier별 개별 오버라이드
+
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+HXSK_DIR="$PROJECT_DIR/.hxsk"
+TICK_FILE="$HXSK_DIR/.last-prune-ts"
+LOCK_DIR="$HXSK_DIR/.prune-lock"
+PRUNE_SCRIPT="$HXSK_DIR/scripts/prune-memories.sh"
+LOG_FILE="$HXSK_DIR/.context-save.log"
+
+# 기본 cooldown (60초). 설정으로 오버라이드 가능.
+PRUNE_TICK_COOLDOWN=60
+PRUNE_CFG="$HXSK_DIR/.prune-config"
+# shellcheck disable=SC1090
+[[ -f "$PRUNE_CFG" ]] && source "$PRUNE_CFG"
+
+# ── 선행 체크 ──
+[[ -f "$PRUNE_SCRIPT" ]] || exit 0
+[[ -d "$HXSK_DIR/memories" ]] || exit 0
+
+# ── Cooldown 체크: 마지막 실행으로부터 충분한 시간이 흘렀는가? ──
+if [[ -f "$TICK_FILE" ]]; then
+    LAST=$(stat -f '%m' "$TICK_FILE" 2>/dev/null || stat -c '%Y' "$TICK_FILE" 2>/dev/null || echo 0)
+    NOW=$(date +%s)
+    if [[ $((NOW - LAST)) -lt "$PRUNE_TICK_COOLDOWN" ]]; then
+        exit 0
+    fi
+fi
+
+# ── Atomic lock: 동시 실행 방지 ──
+# mkdir은 POSIX 원자적 연산. 이미 존재하면 실패 → 다른 tick이 진행 중.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
+
+# 타임스탬프 선갱신 — prune이 실패해도 재시도 폭주 방지
+touch "$TICK_FILE"
+
+# ── 실제 prune 실행 ──
+# --auto 모드: 설정 기반 tier별 cap 적용.
+# stderr은 로그로, stdout도 로그로 (호출자에 노출 X).
+{
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] prune-tick fired (cooldown=${PRUNE_TICK_COOLDOWN}s)"
+    bash "$PRUNE_SCRIPT" --auto 2>&1
+} >> "$LOG_FILE" 2>&1 || true
+
+exit 0

--- a/.hxsk/templates/context-config.yaml
+++ b/.hxsk/templates/context-config.yaml
@@ -28,16 +28,21 @@ archive:
     archive_format: "prd-{year}-{month}.json"
 
 # Memory retention policy (.hxsk/memories/)
-# 정책: local-tier(gitignored)만 자동 정리. cap 기반 FIFO + TTL 보조.
+# v5.5+ 정책: local-tier cap 기반 FIFO + opportunistic tick (하네스 독립).
 # 가치 태그(decision, root-cause, incident, security, pattern, lesson)는
 # 삭제 직전 shared-tier로 자동 승격되어 git으로 보존됨.
+#
+# 실제 설정 값은 .hxsk/.prune-config (shell-sourceable)를 사용:
+#   cp .hxsk/templates/prune-config.sample .hxsk/.prune-config
+# YAML은 문서화 용도. 스크립트는 bash 변수를 직접 소스.
 memory:
-  session-summary:
-    max_files: 20           # 최신 20개만 유지 (FIFO, cap 기반)
-    ttl_days: 7             # 보조 TTL (stop hook 외부 수동 실행 시)
-  session-snapshot:
-    max_files: 10           # 최신 10개 유지 (임시 스냅샷)
-    ttl_days: 7
+  default_cap: 5            # 모든 local-tier 기본 cap (PRUNE_DEFAULT_CAP)
+  bootstrap:
+    max_files: 1            # PRUNE_CAP_bootstrap=1
+  tick_cooldown_sec: 60     # opportunistic tick 쿨다운 (PRUNE_TICK_COOLDOWN)
+  # 나머지 local-tier(session-*, health-event, debug-*, general, deviation)는
+  # default_cap=5 적용. .hxsk/.prune-config로 tier별 오버라이드 가능.
+  #
   # shared-tier (git 관리, 자동 정리 제외):
   #   architecture-decision, root-cause, pattern-discovery, security-finding,
   #   lessons-learned, execution-summary

--- a/.hxsk/templates/prune-config.sample
+++ b/.hxsk/templates/prune-config.sample
@@ -1,0 +1,29 @@
+# HXSK prune 설정 샘플 (shell-sourceable)
+#
+# 사용:
+#   cp .hxsk/templates/prune-config.sample .hxsk/.prune-config
+#   # 이후 필요한 값만 수정
+#
+# prune-memories.sh --auto / prune-tick.sh / Claude Code 훅이 모두 참조.
+# 값이 정의되지 않으면 스크립트 내부 기본값 사용.
+
+# ── Tier별 cap (FIFO) ──
+# 미지정 tier는 PRUNE_DEFAULT_CAP 적용.
+PRUNE_DEFAULT_CAP=5
+
+# tier 이름의 하이픈은 언더스코어로 치환:
+#   session-summary → PRUNE_CAP_session_summary
+PRUNE_CAP_bootstrap=1        # 최신 snapshot 1개만
+# PRUNE_CAP_session_summary=5
+# PRUNE_CAP_session_snapshot=5
+# PRUNE_CAP_session_handoff=5
+# PRUNE_CAP_health_event=5
+# PRUNE_CAP_debug_blocked=5
+# PRUNE_CAP_debug_eliminated=5
+# PRUNE_CAP_general=5
+# PRUNE_CAP_deviation=5
+
+# ── opportunistic tick cooldown (초) ──
+# md-store/md-recall/bootstrap 호출 시 prune-tick.sh가 참조.
+# 너무 짧으면 연속 호출로 I/O 낭비, 너무 길면 누적.
+PRUNE_TICK_COOLDOWN=60

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen?style=flat-square" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/stack-bash%20%2B%20markdown-blue?style=flat-square" alt="Bash + Markdown" />
   <img src="https://img.shields.io/badge/multi--agent-5%20platforms-blueviolet?style=flat-square" alt="Multi-Agent" />
-  <img src="https://img.shields.io/badge/v5.4.0%20%C2%B7%2021%20skills%20%C2%B7%2018%20agents%20%C2%B7%2026%20hooks-orange?style=flat-square" alt="Components" />
+  <img src="https://img.shields.io/badge/v5.5.0%20%C2%B7%2021%20skills%20%C2%B7%2018%20agents%20%C2%B7%2026%20hooks-orange?style=flat-square" alt="Components" />
   <img src="https://img.shields.io/github/license/SukbeomH/HExoskeleton?style=flat-square" alt="License" />
 </p>
 
@@ -211,7 +211,7 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 | **실행** | `execution-summary` | 실행 결과 요약 |
 | | `deviation` | 계획 대비 이탈 |
 | | `lessons-learned` | PR 리뷰·실행 이탈 A/B/C/D/E 분류 (v5.4.0+) |
-| **세션** | `session-summary` | 세션 종료 요약 (자동, cap=20 FIFO) |
+| **세션** | `session-summary` | 세션 종료 요약 (자동, cap=5 FIFO, v5.5+) |
 | | `session-snapshot` | Pre-compact 스냅샷 |
 | | `session-handoff` | 세션 인수인계 |
 | **시스템** | `health-event` | 컨텍스트 건강 이벤트 |
@@ -220,6 +220,8 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 | | `general` | 기타 |
 
 > v5.4.0부터 `tags: [decision|root-cause|incident|security|pattern|lesson]` 매칭 파일은 삭제 직전 shared-tier 폴더로 자동 승격됩니다. 로컬 누적은 cap 기반 FIFO로 제어.
+>
+> v5.5.0부터 **하네스 독립 prune**: `prune-tick.sh`가 `md-store-memory.sh`/`md-recall-memory.sh`/`bootstrap.sh` 말미에서 opportunistic하게 발화. Cursor/Gemini CLI/Copilot CLI/OpenCode 등 Claude Code 외 하네스에서도 자동 동작. 설정은 `.hxsk/.prune-config` (기본 cap=5, bootstrap=1, cooldown=60s). 하네스별 어댑터는 `.hxsk/adapters/`, git 훅 폴백은 `.hxsk/githooks/`.
 
 </details>
 


### PR DESCRIPTION
## Summary

임계치(20→5), 범위(session-summary→전 9 local-tier), 발화 메커니즘(Claude Code 훅 전용→모든 하네스) 세 축 동시 확장.

## 조사

9개 하네스 훅 지원 현황 비교:
- **Claude Code 수준 훅**: Cursor 1.7+, Gemini CLI, Copilot CLI
- **부분 지원**: OpenCode(JS 플러그인 필요), Windsurf(SessionEnd 없음), Codex CLI(PreCompact 없음)
- **lifecycle 훅 부재**: Aider, Continue.dev, Antigravity

크로스 플랫폼 self-scheduling: **opportunistic tick** (sentinel mtime + mkdir atomic lock, BashFAQ/045) 채택. OS scheduler(launchd/cron) 제외 — HXSK 외부 종속성 0 원칙.

## 구현

### 3-layer 정리 메커니즘
1. **자동 발화**: `md-store/md-recall/bootstrap` 말미 → `prune-tick.sh` 백그라운드 호출
2. **명시적 훅**: 각 하네스 어댑터(`.hxsk/adapters/*.json` + OpenCode `.ts`)
3. **폴백**: `.hxsk/githooks/post-commit`, `post-merge` (`core.hooksPath`)

### 신규 파일
- `prune-tick.sh` — cooldown 60s, atomic lock, 백그라운드 prune 호출
- `prune-memories.sh --auto` — `.hxsk/.prune-config` shell-sourceable, tier별 cap
- `.hxsk/adapters/{cursor,gemini,copilot,windsurf,codex}-*.json` + `opencode-plugin.ts` + `README.md`
- `.hxsk/githooks/post-commit`, `post-merge`
- `.hxsk/templates/prune-config.sample`

### 수정
- Stop 훅: `COUNT > 20` 게이트 + 단일 tier → `--auto` 한 줄
- PreCompact 훅: session-summary/snapshot 두 줄 → `--auto` 한 줄
- md-store/md-recall/bootstrap: prune-tick.sh 1줄 삽입

## 버전
5.4.0 → 5.5.0 (bootstrap.sh, .bootstrap-version, README 배지, CHANGELOG)

## Test plan
- [x] 9 스크립트 `bash -n` PASS
- [x] 5 JSON 어댑터 validity PASS
- [x] `check-consistency.sh` PASS 19 / FAIL 0 (버전 5.5.0 일치)
- [x] `doc-lint.sh` PASS 7/7 (LINK/INDEX/COUNT/REF/ORPHAN/DUP)
- [x] end-to-end: md-store 호출 → prune-tick 백그라운드 발화 → session-summary cap 5 적용 확인
- [x] cooldown 재호출 시 skip 확인

## 참고 URL
- Cursor hooks: https://cursor.com/docs/hooks
- OpenCode plugins: https://opencode.ai/docs/plugins/
- OpenCode SessionStart issue: https://github.com/sst/opencode/issues/5409
- Windsurf Cascade hooks: https://docs.windsurf.com/windsurf/cascade/hooks
- Gemini CLI hooks: https://geminicli.com/docs/hooks/
- Copilot CLI hooks: https://docs.github.com/en/copilot/how-tos/copilot-cli/use-hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)