### PR TITLE
docs(setup): 3분기 감지 + 업그레이드 섹션 + 하네스 부록 (v5.5.0 정렬)

### DIFF
--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -14,16 +14,16 @@
 TARGET_VERSION=5.5.0
 CUR_VERSION=$(grep '^version:' .hxsk/.bootstrap-version 2>/dev/null | awk '{print $2}')
 case "${CUR_VERSION:-}" in
-    "")                echo "FRESH — 초기 설치" ;;
-    "$TARGET_VERSION") echo "VERIFY — 동일 버전, 정합성 확인만" ;;
-    *)                 echo "UPGRADE — v$CUR_VERSION → v$TARGET_VERSION 프레임워크 동기화 필요" ;;
+    "")                echo "FRESH" ;;
+    "$TARGET_VERSION") echo "VERIFY" ;;
+    *)                 echo "UPGRADE"; echo "  from=$CUR_VERSION to=$TARGET_VERSION" ;;
 esac
 ```
 
-분기별 이동:
-- **FRESH** → "초기 설치" (Step 1~9)
-- **VERIFY** → "일상 확인 (VERIFY)" 섹션
-- **UPGRADE** → "업그레이드 (UPGRADE)" 섹션 (Step U1~U6)
+출력 첫 줄이 분기 토큰입니다. 분기별 이동:
+- **`FRESH`** → "초기 설치" (Step 1~9)
+- **`VERIFY`** → "일상 확인 (VERIFY)" 섹션
+- **`UPGRADE`** → "업그레이드 (UPGRADE)" 섹션 (Step U1~U6, 두 번째 줄의 `from/to` 버전 활용)
 
 ### Bash 실행 불가 폴백
 
@@ -213,16 +213,25 @@ Claude Code 외 다른 하네스를 함께 쓰는 경우, 각 하네스의 훅 �
 
 `$CUR_VERSION` → `$TARGET_VERSION` 프레임워크 동기화. 프로젝트 고유 파일(SPEC, STATE, CURRENT, PATTERNS, DECISIONS 등)과 애플리케이션 코드는 건드리지 않습니다. **부록 B**의 파일 경계 참조표를 반드시 숙지하세요.
 
-### Step U1: 사전 감사 — 프레임워크 커스텀 수정 감지
+### Step U1: 사전 감사 — 프레임워크 커스텀 수정/신규 파일 감지
 
 ```bash
-git diff HEAD --name-only -- \
-    .hxsk/skills/ .hxsk/agents/ .hxsk/hooks/ .hxsk/scripts/ \
-    .hxsk/prompts/ .hxsk/templates/ .hxsk/docs/ \
-    .hxsk/workflow/ .hxsk/adapters/ .hxsk/githooks/
+FRAMEWORK_DIRS=(
+    .hxsk/skills .hxsk/agents .hxsk/hooks .hxsk/scripts
+    .hxsk/prompts .hxsk/templates .hxsk/docs
+    .hxsk/workflow .hxsk/adapters .hxsk/githooks
+)
+
+# (1) 수정·삭제된 추적 파일
+echo "-- modified --"
+git diff HEAD --name-only -- "${FRAMEWORK_DIRS[@]}"
+
+# (2) untracked(새로 추가된) 파일 — rsync --delete 가 조용히 지우는 범위
+echo "-- untracked --"
+git ls-files --others --exclude-standard -- "${FRAMEWORK_DIRS[@]}"
 ```
 
-출력이 있으면 **프레임워크 파일에 로컬 수정 존재** — Step U3의 `--delete` sync로 사라집니다.
+위 두 섹션 중 어디든 출력이 있으면 **프레임워크 파일에 로컬 수정/신규 파일 존재** — Step U3의 `rsync --delete`로 사라집니다 (untracked도 포함).
 
 **결정 트리**:
 1. 의도된 프로젝트 확장 → `.hxsk/skills-custom/`, `.hxsk/hooks-custom/` 같은 **프로젝트 고유 폴더로 이동** (sync 범위 외)
@@ -233,16 +242,26 @@ git diff HEAD --name-only -- \
 
 ### Step U2: 소스 확보
 
-HXSK 릴리즈 아카이브를 로컬 임시 경로로 획득. 두 가지 옵션 중 환경에 맞는 쪽 선택:
+HXSK 릴리즈 아카이브를 로컬 임시 경로로 획득. **아래 두 옵션 중 하나만 선택 실행**하세요 (둘 다 돌리면 경로 혼합).
+
+공통 초기화:
 
 ```bash
-HX_SRC=/tmp/hxsk-upgrade-$TARGET_VERSION
+# TMPDIR 폴백: /tmp 없는 환경(일부 컨테이너) 대응
+HX_SRC="${TMPDIR:-/tmp}/hxsk-upgrade-$TARGET_VERSION"
+rm -rf "$HX_SRC"   # 이전 시도 잔재 제거 (멱등)
+```
 
-# 옵션 A — git clone (네트워크/인증 여유)
+**옵션 A — git clone** (네트워크/인증 여유 있음):
+
+```bash
 git clone --depth 1 -b setup-v$TARGET_VERSION \
     https://github.com/SukbeomH/HExoskeleton.git "$HX_SRC"
+```
 
-# 옵션 B — Release tarball (corp proxy, 오프라인 후속, 경량)
+**옵션 B — Release tarball** (corp proxy, 오프라인 후속, 경량 환경):
+
+```bash
 mkdir -p "$HX_SRC"
 curl -sL "https://github.com/SukbeomH/HExoskeleton/archive/refs/tags/setup-v$TARGET_VERSION.tar.gz" \
     | tar xz -C "$HX_SRC" --strip-components=1
@@ -277,18 +296,26 @@ mkdir -p "$TG/.hxsk/memories/lessons-learned"
 cp "$HX_SRC/.hxsk/.bootstrap-version" "$TG/.hxsk/.bootstrap-version"
 ```
 
-**`.claude/settings.json` 교체 전 diff 확인** (프로젝트 커스텀 훅 보호):
+**`.claude/settings.json` 교체 전 diff 확인** (프로젝트 커스텀 훅 보호). Claude Code를 사용하지 않는 프로젝트(Gemini CLI 전용 등)는 이 파일이 없을 수 있으므로 존재 여부로 분기:
 
 ```bash
-diff "$TG/.claude/settings.json" "$HX_SRC/.claude/settings.json" | head -40
+if [[ -f "$TG/.claude/settings.json" && -f "$HX_SRC/.claude/settings.json" ]]; then
+    diff "$TG/.claude/settings.json" "$HX_SRC/.claude/settings.json" | head -40
+    # 차이가 경로·version 차이뿐이면 그대로 교체:
+    #   cp "$HX_SRC/.claude/settings.json" "$TG/.claude/settings.json"
+    # 프로젝트 고유 훅 블록(테스트 실행, 린터 등)이 있으면 수동 병합 후 사용자 확인 필수
+elif [[ -f "$HX_SRC/.claude/settings.json" ]]; then
+    # 대상에 settings.json 없음 → Claude Code 신규 도입이면 복사
+    # mkdir -p "$TG/.claude" && cp "$HX_SRC/.claude/settings.json" "$TG/.claude/settings.json"
+    echo "target has no .claude/settings.json — Claude Code 미사용 프로젝트면 건너뛰기"
+fi
 ```
 
-- 차이가 경로·version 차이뿐이면 그대로 교체: `cp "$HX_SRC/.claude/settings.json" "$TG/.claude/settings.json"`
-- 프로젝트 고유 훅 블록(예: 테스트 실행, 린터)이 있으면 **수동 병합** 후 사용자 확인 필수
-
-**롤백**:
+**롤백** (문제 발생 시):
 ```bash
-cp "$TG/.claude/settings.json.v$CUR_VERSION.bak" "$TG/.claude/settings.json"
+# settings.json은 백업이 있을 때만 복원
+[[ -f "$TG/.claude/settings.json.v$CUR_VERSION.bak" ]] && \
+    cp "$TG/.claude/settings.json.v$CUR_VERSION.bak" "$TG/.claude/settings.json"
 cp "$TG/.hxsk/.bootstrap-version.v$CUR_VERSION.bak" "$TG/.hxsk/.bootstrap-version"
 # 프레임워크 파일은 git checkout HEAD -- .hxsk/{범주} 또는 HX_SRC에서 재sync
 ```
@@ -369,7 +396,7 @@ bash .hxsk/scripts/bootstrap.sh
 
 | 하네스 | 최소 버전 / 전제 | 설치 명령 | 공식 문서 |
 |---|---|---|---|
-| **Cursor** | 1.7+ (hooks.json 지원) | `cp .hxsk/adapters/cursor-hooks.json .cursor/hooks.json` | [cursor.com/docs/hooks](https://cursor.com/docs/hooks) |
+| **Cursor** | 1.7+ (hooks.json 지원) | `mkdir -p .cursor && cp .hxsk/adapters/cursor-hooks.json .cursor/hooks.json` (기존 `hooks.json` 있으면 병합 필요) | [cursor.com/docs/hooks](https://cursor.com/docs/hooks) |
 | **Gemini CLI** | 최신 | `mkdir -p .gemini && cp .hxsk/adapters/gemini-settings.json .gemini/settings.json` (프로젝트 우선, 글로벌은 `~/.gemini/`) | [geminicli.com/docs/hooks](https://geminicli.com/docs/hooks/) |
 | **Copilot CLI** | 2026-02 GA+ | `mkdir -p .copilot && cp .hxsk/adapters/copilot-hooks.json .copilot/hooks.json` | [GitHub Docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-hooks) |
 | **Windsurf** | Cascade 활성 | `mkdir -p .windsurf && cp .hxsk/adapters/windsurf-hooks.json .windsurf/hooks.json` | [docs.windsurf.com/windsurf/cascade/hooks](https://docs.windsurf.com/windsurf/cascade/hooks) |

--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -1,15 +1,37 @@
 # HXSK Setup
 
-아래 지침에 따라 현재 프로젝트에 HExoskeleton(HXSK) 개발 방법론을 구성하세요.
+> **Last aligned with: v5.5.0** — 이 파일은 릴리즈마다 갱신됩니다. `TARGET_VERSION` 값이 실제 타겟 버전과 다르면 상위 setup.md를 가져오세요.
+>
+> **지원 하네스**: Claude Code, Gemini CLI, Cursor, Windsurf, GitHub Copilot CLI, OpenCode, Codex CLI, Aider, Continue.dev, Antigravity
+>
+> **에이전트 하네스 주의**: 이 프롬프트의 bash 명령을 직접 실행할 수 없는 하네스(Continue.dev, Antigravity 일부, IDE 확장)는 **Step 0 하단 "Bash 실행 불가 폴백"** 섹션을 따르세요.
 
-## Step 0: 상태 감지
+아래 지침에 따라 현재 프로젝트에 HExoskeleton(HXSK) 개발 방법론을 구성·유지하세요.
+
+## Step 0: 상태 감지 (3분기)
 
 ```bash
-test -f .hxsk/.bootstrap-version && echo "UPDATE" || echo "FRESH"
+TARGET_VERSION=5.5.0
+CUR_VERSION=$(grep '^version:' .hxsk/.bootstrap-version 2>/dev/null | awk '{print $2}')
+case "${CUR_VERSION:-}" in
+    "")                echo "FRESH — 초기 설치" ;;
+    "$TARGET_VERSION") echo "VERIFY — 동일 버전, 정합성 확인만" ;;
+    *)                 echo "UPGRADE — v$CUR_VERSION → v$TARGET_VERSION 프레임워크 동기화 필요" ;;
+esac
 ```
 
-- **FRESH** → 아래 "초기 설치" (Step 1~8)
-- **UPDATE** → 아래 "업데이트"
+분기별 이동:
+- **FRESH** → "초기 설치" (Step 1~9)
+- **VERIFY** → "일상 확인 (VERIFY)" 섹션
+- **UPGRADE** → "업그레이드 (UPGRADE)" 섹션 (Step U1~U6)
+
+### Bash 실행 불가 폴백
+
+이 세션에서 shell 명령을 직접 실행할 수 없는 경우(Continue.dev 등):
+
+1. 사용자에게 터미널에서 위 감지 스니펫을 실행해 달라고 요청
+2. 결과(`FRESH` / `VERIFY` / `UPGRADE`)를 대화에 붙여넣도록 안내
+3. 이후 단계의 `bash` 명령도 동일 패턴으로 "사용자 수동 실행 → 결과 붙여넣기" 반복
 
 ---
 
@@ -161,6 +183,12 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact
 [![HExoskeleton](https://img.shields.io/badge/assisted%20with-HExoskeleton-blueviolet?style=flat-square)](https://github.com/SukbeomH/HExoskeleton)
 ```
 
+### Step 9: Multi-Harness 활성화 (선택, v5.5.0+)
+
+Claude Code 외 다른 하네스를 함께 쓰는 경우, 각 하네스의 훅 시스템에 HXSK prune을 연결합니다. **부록 A** 참고.
+
+기본 발화(opportunistic tick)는 하네스 무관하게 작동하므로 필수는 아닙니다 — `md-store-memory.sh`/`md-recall-memory.sh`/`bootstrap.sh`가 호출되면 자동 정리.
+
 ### 완료 확인
 
 - [ ] 에이전트 지침 파일이 프로젝트 루트에 존재
@@ -181,11 +209,133 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact
 
 ---
 
-## 업데이트
+## 업그레이드 (UPGRADE)
 
-이전 설치가 감지되었습니다.
+`$CUR_VERSION` → `$TARGET_VERSION` 프레임워크 동기화. 프로젝트 고유 파일(SPEC, STATE, CURRENT, PATTERNS, DECISIONS 등)과 애플리케이션 코드는 건드리지 않습니다. **부록 B**의 파일 경계 참조표를 반드시 숙지하세요.
 
-### Step 1: bootstrap 실행
+### Step U1: 사전 감사 — 프레임워크 커스텀 수정 감지
+
+```bash
+git diff HEAD --name-only -- \
+    .hxsk/skills/ .hxsk/agents/ .hxsk/hooks/ .hxsk/scripts/ \
+    .hxsk/prompts/ .hxsk/templates/ .hxsk/docs/ \
+    .hxsk/workflow/ .hxsk/adapters/ .hxsk/githooks/
+```
+
+출력이 있으면 **프레임워크 파일에 로컬 수정 존재** — Step U3의 `--delete` sync로 사라집니다.
+
+**결정 트리**:
+1. 의도된 프로젝트 확장 → `.hxsk/skills-custom/`, `.hxsk/hooks-custom/` 같은 **프로젝트 고유 폴더로 이동** (sync 범위 외)
+2. 프레임워크에 기여할 만한 개선 → 별도 PR로 상위 레포에 반영 후 신버전으로 받기
+3. 단발성 실험 → `git stash` 또는 `git commit`으로 일단 보존 후 필요 시 cherry-pick
+
+미결정 상태로 Step U2로 진행하지 마세요.
+
+### Step U2: 소스 확보
+
+HXSK 릴리즈 아카이브를 로컬 임시 경로로 획득. 두 가지 옵션 중 환경에 맞는 쪽 선택:
+
+```bash
+HX_SRC=/tmp/hxsk-upgrade-$TARGET_VERSION
+
+# 옵션 A — git clone (네트워크/인증 여유)
+git clone --depth 1 -b setup-v$TARGET_VERSION \
+    https://github.com/SukbeomH/HExoskeleton.git "$HX_SRC"
+
+# 옵션 B — Release tarball (corp proxy, 오프라인 후속, 경량)
+mkdir -p "$HX_SRC"
+curl -sL "https://github.com/SukbeomH/HExoskeleton/archive/refs/tags/setup-v$TARGET_VERSION.tar.gz" \
+    | tar xz -C "$HX_SRC" --strip-components=1
+```
+
+성공 확인: `cat "$HX_SRC/.hxsk/.bootstrap-version"` 에 `version: $TARGET_VERSION` 표시.
+
+### Step U3: 프레임워크 동기화
+
+```bash
+TG="$(pwd)"
+
+# 백업 (롤백 대비)
+[[ -f "$TG/.claude/settings.json" ]] && \
+    cp "$TG/.claude/settings.json" "$TG/.claude/settings.json.v$CUR_VERSION.bak"
+cp "$TG/.hxsk/.bootstrap-version" "$TG/.hxsk/.bootstrap-version.v$CUR_VERSION.bak"
+
+# 프레임워크 delete-and-sync (루프는 멱등 — 중단 시 같은 명령 재실행 안전)
+for d in skills agents hooks scripts prompts templates docs workflow adapters githooks; do
+    if command -v rsync >/dev/null; then
+        rsync -a --delete "$HX_SRC/.hxsk/$d/" "$TG/.hxsk/$d/"
+    else
+        # rsync 없는 환경(Windows Git Bash, minimal container) 폴백
+        rm -rf "$TG/.hxsk/$d" && cp -r "$HX_SRC/.hxsk/$d" "$TG/.hxsk/$d"
+    fi
+done
+
+# 신규 memory tier (v5.4+ lessons-learned, 이후 버전도 동일 패턴)
+mkdir -p "$TG/.hxsk/memories/lessons-learned"
+
+# 메타 파일 교체
+cp "$HX_SRC/.hxsk/.bootstrap-version" "$TG/.hxsk/.bootstrap-version"
+```
+
+**`.claude/settings.json` 교체 전 diff 확인** (프로젝트 커스텀 훅 보호):
+
+```bash
+diff "$TG/.claude/settings.json" "$HX_SRC/.claude/settings.json" | head -40
+```
+
+- 차이가 경로·version 차이뿐이면 그대로 교체: `cp "$HX_SRC/.claude/settings.json" "$TG/.claude/settings.json"`
+- 프로젝트 고유 훅 블록(예: 테스트 실행, 린터)이 있으면 **수동 병합** 후 사용자 확인 필수
+
+**롤백**:
+```bash
+cp "$TG/.claude/settings.json.v$CUR_VERSION.bak" "$TG/.claude/settings.json"
+cp "$TG/.hxsk/.bootstrap-version.v$CUR_VERSION.bak" "$TG/.hxsk/.bootstrap-version"
+# 프레임워크 파일은 git checkout HEAD -- .hxsk/{범주} 또는 HX_SRC에서 재sync
+```
+
+### Step U4: 검증 (4종)
+
+```bash
+bash .hxsk/scripts/bootstrap.sh                        # 구조 (PASS/FAIL/WARN)
+bash .hxsk/hooks/check-consistency.sh                  # 정합성 (INDEX/경로/버전)
+bash .hxsk/scripts/doc-lint.sh                         # 문서 링크
+bash .hxsk/scripts/prune-memories.sh --auto --dry-run  # v5.5+ 모드 smoke
+```
+
+프로젝트 테스트 수트는 `CLAUDE.md` 또는 `AGENTS.md`의 **Project Context > Test** 블록 참조하여 실행 (pytest / npm test / cargo test / go test 등).
+
+### Step U5: 사후 설정 (선택)
+
+- **tier별 cap 커스터마이즈** — 공격적 정리 또는 특정 tier만 여유:
+    ```bash
+    cp .hxsk/templates/prune-config.sample .hxsk/.prune-config
+    # 편집: PRUNE_DEFAULT_CAP=3 또는 PRUNE_CAP_session_summary=10 등
+    ```
+- **다른 하네스도 사용 중** → **부록 A**의 설치 명령 실행
+- **Aider/Continue.dev/Antigravity 사용** → git 훅 폴백:
+    ```bash
+    git config core.hooksPath .hxsk/githooks
+    ```
+
+### Step U6: 커밋
+
+```bash
+# 백업 파일 제거 (검증 완료 후)
+rm -f .claude/settings.json.v$CUR_VERSION.bak .hxsk/.bootstrap-version.v$CUR_VERSION.bak
+
+git add -A
+git commit -m "chore(hxsk): v$CUR_VERSION → v$TARGET_VERSION 프레임워크 동기화"
+```
+
+PR 생성 여부는 팀 컨벤션에 따라. 단일 저장소에서 직접 머지하거나 릴리즈 PR 생성 모두 가능.
+
+---
+
+## 일상 확인 (VERIFY)
+
+버전이 동일한 경우의 정합성 체크.
+
+### Step V1: bootstrap 실행
 
 ```bash
 bash .hxsk/scripts/bootstrap.sh
@@ -196,20 +346,66 @@ bash .hxsk/scripts/bootstrap.sh
 - `[NEW]` — 새로 추가됨
 - `[UPDATED]` — 변경됨 (↳ 관련: 2-hop 컨텍스트 표시)
 
-### Step 2: 에이전트별 설정 갱신
+### Step V2: 에이전트별 설정 동기화
 
 `[NEW]` 또는 `[UPDATED]`가 있는 경우:
-- 스킬 추가/변경 → 에이전트 스킬 디렉토리 갱신
-- 에이전트 지침 변경 → CLAUDE.md/GEMINI.md/AGENTS.md 갱신
+- 스킬 추가/변경 → 에이전트 스킬 디렉토리 갱신 (심볼릭 링크 환경이면 자동)
+- 에이전트 지침 변경 → 루트 지침 파일은 건드리지 않음. `.hxsk/agents/*.md`만 갱신됨
+- Claude Code: 훅 변경 시 `.claude/settings.json` 수동 병합
 
-**Claude Code인 경우 추가로:**
-- 훅 변경 → `.claude/settings.json` 갱신
-- 스킬 변경 → `.claude/skills/{name}/SKILL.md` 복사
-
-### Step 3: 확인
+### Step V3: 재확인
 
 ```bash
 bash .hxsk/scripts/bootstrap.sh
 ```
 
-모든 항목이 `[OK]`이면 업데이트 완료.
+모든 항목이 `[OK]`이면 완료.
+
+---
+
+## 부록 A: Multi-Harness 활성화
+
+기본 opportunistic tick은 하네스 무관하게 발화하지만, 각 하네스의 훅 시스템에 명시적 연결을 원하면 아래 어댑터 설치.
+
+| 하네스 | 최소 버전 / 전제 | 설치 명령 | 공식 문서 |
+|---|---|---|---|
+| **Cursor** | 1.7+ (hooks.json 지원) | `cp .hxsk/adapters/cursor-hooks.json .cursor/hooks.json` | [cursor.com/docs/hooks](https://cursor.com/docs/hooks) |
+| **Gemini CLI** | 최신 | `mkdir -p .gemini && cp .hxsk/adapters/gemini-settings.json .gemini/settings.json` (프로젝트 우선, 글로벌은 `~/.gemini/`) | [geminicli.com/docs/hooks](https://geminicli.com/docs/hooks/) |
+| **Copilot CLI** | 2026-02 GA+ | `mkdir -p .copilot && cp .hxsk/adapters/copilot-hooks.json .copilot/hooks.json` | [GitHub Docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-hooks) |
+| **Windsurf** | Cascade 활성 | `mkdir -p .windsurf && cp .hxsk/adapters/windsurf-hooks.json .windsurf/hooks.json` | [docs.windsurf.com/windsurf/cascade/hooks](https://docs.windsurf.com/windsurf/cascade/hooks) |
+| **Codex CLI** | `codex_hooks=true` 활성 | `codex config set experimental.codex_hooks true && mkdir -p .codex && cp .hxsk/adapters/codex-hooks.json .codex/hooks.json` | [developers.openai.com/codex/hooks](https://developers.openai.com/codex/hooks) |
+| **OpenCode** | Bun 런타임 필요 | `mkdir -p ~/.config/opencode/plugin && cp .hxsk/adapters/opencode-plugin.ts ~/.config/opencode/plugin/hxsk.ts` | [opencode.ai/docs/plugins](https://opencode.ai/docs/plugins/) |
+| **Aider** | lifecycle 훅 부재 | `git config core.hooksPath .hxsk/githooks` | [aider.chat](https://aider.chat/) |
+| **Continue.dev** | 동일 (VS Code 확장 제약) | 동일 | [docs.continue.dev](https://docs.continue.dev/) |
+| **Antigravity** | 동일 | 동일 | [antigravity.google](https://antigravity.google/) |
+
+### 버전 체크 (설치 전 권장)
+
+```bash
+# Cursor 1.7+ 확인
+cursor --version 2>/dev/null | head -1
+
+# Codex feature flag 확인
+codex config get experimental.codex_hooks 2>/dev/null
+```
+
+미달 시 설치해도 훅이 무시됨 — 해당 하네스는 기본 opportunistic tick만 활용.
+
+---
+
+## 부록 B: 파일 경계 참조표
+
+업그레이드 시 각 파일이 어떻게 다뤄지는지 정리. Step U3의 `rsync --delete` 대상을 명확히 파악하세요.
+
+| 범주 | 경로 | sync 동작 | 사용자 수정 시 |
+|---|---|---|---|
+| **프레임워크 코어** | `.hxsk/{skills,agents,hooks,scripts,prompts,templates,docs,workflow,adapters,githooks}/` | `--delete` 완전 교체 | Step U1에서 감지 → 프로젝트 고유 폴더로 이동 또는 상위 PR |
+| **프레임워크 메타** | `.hxsk/.bootstrap-version`, `.claude/settings.json` | 백업 후 교체 (settings.json은 diff 확인 후) | settings.json은 수동 병합 |
+| **프로젝트 명세** | `.hxsk/{SPEC,STATE,CURRENT,PATTERNS,DECISIONS,ARCHITECTURE,STACK}.md` 및 프로젝트별 추가 문서 | 건드리지 않음 | 프로젝트 작업 산출물 — 자유롭게 유지 |
+| **프로젝트 메모리** | `.hxsk/memories/*/*.md` | 내용 보존, 신규 tier 디렉터리만 `mkdir -p` | 그대로 유지 |
+| **프로젝트 산출물** | `.hxsk/{issues,phases,reports,research,examples,archive}/` | 보존 | 그대로 유지 |
+| **루트 지침** | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.cursorrules`, `.windsurfrules`, `llms.txt` (선택) | 건드리지 않음 (초기 설치 시만 생성) | Project Context 블록에 프로젝트 정보 기재 |
+| **런타임 상태** | `.hxsk/{.track-modifications.log, .context-save.log, .last-prune-ts, .prune-lock/}`, `.hxsk/memories/*/*.bak` 등 | 건드리지 않음 (gitignore 대상) | 자동 생성/회전 |
+| **사용자 설정** | `.hxsk/.prune-config`, `.hxsk/context-config.yaml` | 건드리지 않음 (있으면 보존) | 필요 시 템플릿에서 복사 생성 |
+
+**주의**: 프레임워크 코어 범주에 프로젝트별 커스텀 스킬/훅을 직접 추가하면 업그레이드 시 사라집니다. 프로젝트 고유 확장은 `skills-custom/`, `hooks-custom/` 같은 범주 외 폴더에 두는 것을 권장.


### PR DESCRIPTION
## Summary

v5.4/v5.5 신규 구조를 `.hxsk/prompts/setup.md`에 반영. 2개 프로젝트(AvatarBySheets, QuanTrade)에 수동 sync하며 부족했던 흐름을 표준 절차로 고정.

## 변경 규모
- **215줄 → 411줄** (+196)
- 단일 파일: `.hxsk/prompts/setup.md`

## 주요 변경

### 구조
```
# HXSK Setup (버전 앵커 + 지원 하네스 10종 명시 + Bash 폴백 공지)
## Step 0: 3분기 감지 (FRESH / VERIFY / UPGRADE) + Bash 실행 불가 폴백
## 초기 설치 (FRESH, Step 1~9)   ← Step 9 Multi-Harness 추가
## 업그레이드 (UPGRADE, U1~U6)    ← 신규
## 일상 확인 (VERIFY, V1~V3)      ← 기존 "업데이트" 명칭 변경
## 부록 A: Multi-Harness 활성화    ← 신규 (9 하네스 × 버전/경로/URL)
## 부록 B: 파일 경계 참조표        ← 신규 (8 범주 × sync 동작)
```

### 신규 섹션 핵심

**업그레이드 (UPGRADE)** — v5.3→v5.5 같은 버전 점프 시 수행 절차
- U1 사전 감사: `git diff HEAD -- .hxsk/{skills,...}`로 프레임워크 커스텀 수정 감지 + 3안 결정 트리
- U2 소스 확보: `git clone` / Release tarball 2옵션
- U3 프레임워크 동기화: rsync + `cp -r` 폴백, `.claude/settings.json` diff 후 수동 병합, 롤백 스니펫
- U4 검증 4종: bootstrap / check-consistency / doc-lint / prune `--auto --dry-run`
- U5 사후 설정: `.prune-config`, adapters, `core.hooksPath` 폴백
- U6 커밋: 백업 제거 + atomic commit

**부록 A — Multi-Harness 활성화**
9개 하네스 표(최소 버전, 설치 명령, 공식 문서 URL).
- Cursor 1.7+, Gemini CLI, Copilot CLI, Windsurf, Codex CLI (feature flag), OpenCode (Bun plugin), Aider/Continue/Antigravity (git hooks 폴백)

**부록 B — 파일 경계 참조표**
8 범주(프레임워크 코어/메타, 프로젝트 명세/메모리/산출물, 루트 지침, 런타임 상태, 사용자 설정) × sync 동작 × 수정 가이드.

## 에이전트 하네스 관점 리뷰 반영 (8건 전부)

1. **rsync 미지원 환경** (Windows Git Bash) → `cp -r` 폴백 분기
2. **Bash 실행 불가 하네스** (Continue/Antigravity) → 사용자 수동 실행 + 결과 붙여넣기 폴백
3. **설치 경로 모호성** → 각 하네스별 정확 경로 + 공식 URL 명시
4. **하네스 버전 게이팅** → 최소 버전 컬럼 + 사전 버전 체크 스니펫
5. **부분 실행 중단 복구** → 루프 멱등성 명시 + 롤백 스니펫
6. **커스텀 프레임워크 처리** → Step U1 3안 결정 트리 (프로젝트 고유 폴더 이동 / 상위 PR / stash)
7. **프로젝트 테스트 수트 명령** → CLAUDE.md Project Context 참조로 하드코딩 회피
8. **settings.json 커스텀 훅 보호** → diff 후 수동 병합 안내

## Test plan
- [x] `doc-lint.sh` PASS 7/7 (LINK/INDEX/COUNT/REF/ORPHAN/DUP)
- [x] 섹션 구조 grep 확인
- [x] 버전 앵커 명시 (`Last aligned with: v5.5.0`)
- [ ] (수동) 다른 프로젝트에서 Step 0 감지 → UPGRADE 분기 재현 확인

## 배경
AvatarBySheets / QuanTrade에 v5.4/v5.5 수동 sync하며 setup.md에 빠진 흐름(프레임워크 커스텀 수정 감지, 파일 경계, settings.json 병합, 하네스별 어댑터)을 표준화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)