### PR TITLE
docs: autoresearch:learn Phase 8+9 문서 최신화

### DIFF
--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -101,7 +101,8 @@ eef848e chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티�
 | Level | 파일 | 크기 제약 | 로드 시점 |
 |-------|------|---------|---------|
 | **L1** | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` | ≤120 lines | 항상 로드 |
-| **L2** | `.hxsk/skills/*/SKILL.md`, `.hxsk/docs/*.md` | 100~300 lines | 스킬 로드/참조 |
+| **L2** | `.hxsk/skills/*/SKILL.md` (entry) | **≤200 lines** | 스킬 로드 시 |
+| **L2+** | `.hxsk/skills/*/references/*.md` | 제한 없음 | On-demand 선택 로드 |
 | **L3** | `.hxsk/research/*/RESEARCH-*.md` | 제한 없음 | On-demand 참조만 |
 
 ### 5.1 L1 규칙
@@ -109,9 +110,11 @@ eef848e chore(release): v5.4.0 — Git Forge + lessons-learned + 메모리 티�
 - 제외: 예시, 포맷, 스키마
 - ≤120 lines 강제
 
-### 5.2 Skill/Agent 규칙
+### 5.2 Skill/Agent 규칙 (Progressive Disclosure)
 - Agent body ≤ 20-30 lines — 상세는 Skill 위임
 - Skill Quick Reference ≤ 5 lines
+- **Skill entry SKILL.md ≤ 200줄** (verifier/debugger는 ≤160줄)
+- **상세 프로토콜은 `references/` 서브디렉토리**로 분리 — 필요 시만 로드
 - 기존 패턴 참조 (DRY)
 
 ### 5.3 PATTERNS.md 규칙
@@ -331,7 +334,8 @@ Python은 **시스템 내장 `python3`만 사용**. pip 의존성 추가 금지.
 | GEMINI.md | 120 lines | L1 경량 |
 | AGENTS.md | 120 lines | 하네스 공용 |
 | Skill Quick Reference | 5 lines | Description에서 본문 진입 유도 |
-| Skill body | 100~300 lines | CSO + 프로시저 |
+| **Skill entry SKILL.md** | **≤200 lines** | **Progressive Disclosure — 콜드스타트 비용 절감** |
+| Skill references/ 파일 | 제한 없음 | 선택 로드 — 필요 시만 참조 |
 | Agent | 20~30 lines | When/With What만 |
 | PATTERNS.md | 2KB / 20 items | 핵심 휴리스틱만 |
 | contextual_description | 200 chars | 메모리 요약 |

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -32,7 +32,7 @@ HExoskeleton/
     ├── context-config.yaml    # 컨텍스트/프룬 설정
     ├── skills/   (22)         # 재사용 절차
     ├── agents/   (18)         # 스킬 오케스트레이션
-    ├── hooks/    (21+)        # 이벤트 훅
+    ├── hooks/    (26)          # 이벤트 훅
     ├── scripts/  (17)         # 유틸리티
     ├── workflow/ (1)          # GATES.md
     ├── prompts/  (3)          # setup 프롬프트
@@ -52,10 +52,10 @@ HExoskeleton/
 
 | 영역 | 개수 | 총 LOC | 비고 |
 |------|------|--------|------|
-| **Skills** | 22 | ~6,032 | 각 `{name}/SKILL.md` 형식 |
+| **Skills** | 22 | ~3,500 (entry) + refs/ | 각 `{name}/SKILL.md` ≤200줄 + `references/` |
 | **Agents** | 18 | ~622 | 각 `{name}.md` 파일 |
-| **Hooks** | 21+ | ~3,246 | Claude Code 이벤트별 |
-| **Scripts** | 12 | ~2,606+ | 유틸리티 bash |
+| **Hooks** | 26 | ~3,246 | Claude Code 이벤트별 |
+| **Scripts** | 17 | ~2,606+ | 유틸리티 bash |
 | **Templates** | 33 | ~2,386 | 문서 생성 표준 |
 | **Internal Docs** | 11 | varied | `.hxsk/docs/` |
 | **Prompts** | 3 | ~495 | setup 프롬프트 |
@@ -81,16 +81,17 @@ HExoskeleton/
 | `executor` | PLAN.md → 원자 커밋 + 4-규칙 편차 처리 |
 | `handoff` | 세션 종료: 테스트→커밋→메모리→요약 |
 | `impact-analysis` | 변경 blast radius 평가 |
-| `memory-protocol` | 16 타입 메모리 저장/회상(2-hop) |
+| `memory-protocol` | 17 타입 메모리 저장/회상(2-hop) |
 | `plan-checker` | PLAN.md 6차원 검증 |
 | `planner` | 목표→PLAN.md 작성 (goal-backward) |
 | `pr-review` | 6-페르소나 코드 리뷰 (Dev/QA/Security/Arch/DevOps/UX) |
+| `refactor` | 기능 보존 리팩토링 — PREPARE→IDENTIFY→REFACTOR→VERIFY, 10개 코드 스멜 카탈로그 |
 | `skill-testing` | 스킬 TDD (RED/GREEN/REFACTOR) |
 | `verifier` | SPEC.md must-haves 대조 검증 |
 | `write-report` | 솔루션 비교 보고서 작성 (TCO+가중점수) |
 | (+ INDEX.md) | 스킬 카탈로그 인덱스 |
 
-상세: `.hxsk/skills/{name}/SKILL.md`.
+상세: `.hxsk/skills/{name}/SKILL.md` (entry ≤200줄) + `{name}/references/` (상세, 선택 로드).
 
 ## 4. Agents Inventory (18)
 
@@ -117,7 +118,7 @@ HExoskeleton/
 
 상세: `.hxsk/agents/{name}.md`.
 
-## 5. Hooks Catalog (21+)
+## 5. Hooks Catalog (26)
 
 ### 이벤트별 분류
 
@@ -140,8 +141,12 @@ HExoskeleton/
 - `save-transcript.sh` — 트랜스크립트 보존 (선택)
 
 **Memory**:
-- `md-store-memory.sh` — YAML+MD 저장, Nemori dedup; `yaml_safe()` YAML injection 방지; TYPE_DIR 자동 생성; `.hxsk/` 존재 검증
-- `md-recall-memory.sh` — 2-hop grep 검색; 결과 없음 시 stderr `[NO_MATCH]` 출력; `HXSK_RECALL_MAX` 환경변수로 스캔 깊이 제한(기본 500줄); 2-hop `related` 파싱은 frontmatter 범위로 한정
+- `md-store-memory.sh` — YAML+MD 저장, Nemori dedup; `yaml_safe()` backslash-first YAML injection 방지; TYPE_DIR 자동 생성; `.hxsk/` 존재 검증
+- `md-recall-memory.sh` — 2-hop grep 검색; `grep -li -- "$QUERY"` option-injection 방지; `find -print0 | xargs -0` null-delimiter space-safety; `HXSK_RECALL_MAX`로 스캔 깊이 제한
+
+**Security (Phase 8)**:
+- `bash-guard.py` — DESTRUCTIVE_FS(rm -rRf, shred, dd if=/dev/zero, truncate, chmod 777, git push --mirror) + DESTRUCTIVE_GIT 패턴 차단
+- `file-protect.py` — `secrets/`, `secrets.`, `.secrets`, `.gitconfig`, `credentials` 쓰기 차단
 
 **Workflow**:
 - `gate-check.sh` — GATES.md 조건 검증
@@ -156,8 +161,8 @@ HExoskeleton/
 - `scaffold-hxsk.sh` / `scaffold-infra.sh` — 초기 스캐폴드
 
 **Pre-commit Git**:
-- `pre-commit-doc-lint.sh`
-- `pre-commit-version-check.sh`
+- `pre-commit-doc-lint.sh` — doc-lint 검사 (INDEX-01은 `references/` 서브디렉토리 자동 제외)
+- `pre-commit-version-check.sh` — 버전 정합성 검증
 
 ## 6. Utility Scripts (17)
 
@@ -181,7 +186,7 @@ HExoskeleton/
 | `setup-verify.sh` (200) | 설치 검증 5개 독립 조건 — `PASS N/5 | FAIL M/5` 출력 |
 | `pre-release-check.sh` (100) | 릴리스 전 4-체크: SHA256·CHANGELOG·ISSUE COUNT·실행권한 |
 
-## 7. Memory System (16 Types)
+## 7. Memory System (17 Types)
 
 `.hxsk/memories/` 하위 디렉토리:
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -164,6 +164,7 @@ git pull --rebase
 |------|-----|---------|------------|
 | v5.3.x | v5.4.0 | Git Forge + lessons-learned A-E + 메모리 티어 | 자동 |
 | v5.4.x | v5.5.0 | 하네스 독립 prune + cap=5 + local-tier 전체 | `.hxsk/.prune-config` 새로 생성 |
+| v5.5.0 | v5.5.0+ | Phase 8 보안 강화 + Phase 9 Progressive Disclosure | 자동 (setup.md 재실행) |
 
 ## 5. Harness-Specific Installation
 
@@ -261,6 +262,12 @@ bash .hxsk/hooks/gate-check.sh status
 # 4. doc-lint
 bash .hxsk/scripts/doc-lint.sh
 ```
+
+### 6.3 보안 체크리스트
+- [ ] `bash-guard.py` DESTRUCTIVE_FS 패턴 활성 (rm -rRf, shred, dd if=/dev/zero, truncate, chmod 777, git push --mirror)
+- [ ] `file-protect.py` secrets 경로 차단 (`secrets/`, `.secrets`, `.gitconfig`, `credentials`)
+- [ ] setup.md 다운로드 시 SHA256 검증 완료 (필수 — Phase 8)
+- [ ] doc-lint INDEX-01: `references/` 서브디렉토리 자동 제외 확인
 
 ## 7. Environment Variables
 

--- a/docs/plans/2026-04-23-dspy-applicability-analysis.md
+++ b/docs/plans/2026-04-23-dspy-applicability-analysis.md
@@ -1,0 +1,153 @@
+# DSPy 적용 적합성 분석
+
+**날짜**: 2026-04-23  
+**대상**: HExoskeleton v5.5.0  
+**결론 요약**: 핵심 시스템에 DSPy 직접 통합 — **부적합**. 관리 대상 프로젝트용 선택적 스킬로는 **조건부 적합**.
+
+---
+
+## 1. 적합성 판단: 불가 (핵심 아키텍처)
+
+### 1.1 근본적 아키텍처 불일치
+
+| 항목 | DSPy | HExoskeleton |
+|------|------|--------------|
+| 작동 방식 | Python 런타임이 LLM API 호출을 직접 가로채어 최적화 | 마크다운 파일을 AI 하네스(Claude Code·Cursor 등)가 읽어 추론 |
+| 프롬프트 위치 | Python Signature/Module 객체 안 | `.hxsk/skills/*/SKILL.md`, `AGENTS.md` 파일 |
+| LLM 호출 소유권 | 프레임워크가 직접 소유 | AI 하네스(Claude Code 등)가 소유, HXSK는 관여 불가 |
+| 최적화 대상 | API 콜 파라미터·few-shot | 마크다운 텍스트 (컴파일 불가) |
+
+DSPy는 LLM 콜 체인 사이에 끼어들어야 작동합니다.  
+Hexoskeleton의 프롬프트(SKILL.md, AGENTS.md)는 Claude Code나 Cursor가 파일로 읽어가는 구조이므로 **DSPy가 개입할 진입점 자체가 없습니다**.
+
+### 1.2 제로 의존성 원칙 위반
+
+```
+AGENTS.md: "외부 종속성 없음: 순수 bash 스크립트 + 마크다운 파일 기반."
+```
+
+`dspy-ai` 패키지 추가 → pyproject.toml·.venv 생성 → 설치/버전 관리 부담 → 멀티 하네스 환경에서 일관성 깨짐.  
+이는 HXSK 설계의 **1번 원칙**을 파기합니다.
+
+### 1.3 멀티 하네스 비호환
+
+HXSK는 Claude Code·Cursor·Copilot·Gemini·Windsurf 동시 지원이 핵심 가치입니다.  
+DSPy는 특정 Python 환경에서만 실행되므로, 최적화 결과가 특정 하네스에만 유효할 수 있습니다.
+
+---
+
+## 2. HXSK가 이미 DSPy를 대체하는 방법
+
+DSPy가 해결하려는 문제를 HXSK는 이미 다른 방식으로 해결하고 있습니다.
+
+| DSPy 기능 | HXSK 대응 메커니즘 |
+|-----------|-------------------|
+| Few-shot 자동 생성 | `lessons-learned` 메모리 → 패턴 누적 (A/B/C/D/E 분류) |
+| 프롬프트 컴파일·최적화 | CSO(Claude Search Optimization) — description에 트리거 조건만 |
+| 메트릭 기반 반복 개선 | `empirical-validation` 스킬 + `autoresearch` 통합 |
+| Hypothesis 검증 | `debugger` 스킬의 3-Strike Rule |
+| 결과 추적 | `iteration-log.tsv` + `md-store-memory.sh` |
+
+**CSO는 DSPy SkillReducer 논문 기반** (48% description 압축 + 2.8% 품질 향상)으로 이미 구현된 상태입니다.  
+DSPy를 추가해도 동일 기능 중복이 됩니다.
+
+---
+
+## 3. 조건부 적용 가능 영역
+
+HXSK 코어가 아닌 **HXSK가 관리하는 외부 Python 프로젝트**에 DSPy를 도입하고,  
+HXSK 스킬이 그것을 오케스트레이션하는 구조는 타당합니다.
+
+### 3.1 적용 패턴: `dspy-optimizer` 스킬
+
+```
+.hxsk/skills/dspy-optimizer/
+├── SKILL.md              # 트리거·진입점·Quick Reference
+└── references/
+    ├── when-to-use.md    # 적용 판단 기준
+    ├── setup-guide.md    # 대상 프로젝트에 DSPy 셋업
+    └── metric-design.md  # HXSK 메트릭 → DSPy metric 함수 변환
+```
+
+**트리거 조건** (SKILL.md description):
+
+```
+Use when managing an external Python LLM project where:
+- The project owns its own LLM API calls (openai/anthropic SDK 직접 사용)
+- Manual prompt iterations have regressed 2+ times
+- A measurable output metric exists (F1, pass-rate, etc.)
+- autoresearch iterations > 5 without improvement
+```
+
+### 3.2 적용 가능 외부 프로젝트 유형
+
+| 유형 | 적합도 | 이유 |
+|------|--------|------|
+| PDF 파싱 파이프라인 (kdb-parsing-llm-test 등) | ★★★★★ | LLM API 직접 소유, F1 메트릭 명확, 수동 회귀 이력 있음 |
+| RAG 검색 품질 개선 | ★★★★☆ | Retrieval 정확도 메트릭 정의 가능 |
+| 분류/추출 파이프라인 | ★★★★☆ | Pydantic 스키마 → DSPy Signature 자연스럽게 매핑 |
+| 코드 생성 도구 | ★★★☆☆ | 메트릭 정의 어려움, 결과 검증 복잡 |
+| 범용 챗봇 | ★☆☆☆☆ | 메트릭 불명확, 도메인 특화 어려움 |
+
+---
+
+## 4. 현재 HXSK에서 프롬프트 품질을 높이는 올바른 경로
+
+DSPy 대신 HXSK 고유 방법론으로 스킬 품질을 개선하는 순서입니다.
+
+### Step 1 — 현재 스킬 성능 측정 (`empirical-validation`)
+
+```bash
+# 스킬 실행 결과를 iteration-log.tsv에 기록
+echo "$(date -I)\t{skill}\t{metric}\t{result}" >> .hxsk/reports/iteration-log.tsv
+```
+
+### Step 2 — 회귀 원인 분류 (`lessons-learned`)
+
+| 카테고리 | 내용 |
+|---------|------|
+| A-Doc-Drift | SKILL.md와 실제 동작 불일치 |
+| B-Test-Quality | 검증 기준이 너무 약함 |
+| C-State-Sync | 메모리/STATE.md 미갱신 |
+| D-Lifecycle | Hook 타이밍 문제 |
+| E-Compat | 하네스 간 호환성 깨짐 |
+
+### Step 3 — CSO 원칙으로 description 재작성
+
+```markdown
+# Bad (현재 description)
+"Task planning and execution workflow management"
+
+# Good (CSO 적용)
+"Use when SPEC.md exists and tasks need decomposing into 2-3 atomic steps.
+Triggers: new feature, bug with unknown scope, or 3+ file changes needed."
+```
+
+### Step 4 — `autoresearch` 통합으로 자동 반복
+
+```
+/autoresearch "skill {name} 실패율 감소" Iterations: 10
+```
+
+---
+
+## 5. 결론
+
+```
+핵심 시스템 통합:  ✗ 불가
+  - LLM 콜 체인 진입점 없음
+  - 제로 의존성 원칙 위반
+  - 멀티 하네스 비호환
+
+관리 프로젝트용 스킬:  △ 조건부 가능
+  - Python LLM 프로젝트 한정
+  - HXSK는 오케스트레이터 역할만 담당
+  - dspy-optimizer 스킬로 캡슐화 권장
+
+현재 대안:  ✓ 이미 동등한 메커니즘 존재
+  - CSO + lessons-learned + empirical-validation + autoresearch
+  - 추가 의존성 없이 동일한 반복 개선 달성 가능
+```
+
+**권장 행동**: DSPy 통합 보류. 관리 대상 Python 프로젝트(kdb-parsing-llm-test 등)에
+`dspy-optimizer` 스킬을 통해 선택적으로 적용. HXSK 코어 품질 개선은 CSO + autoresearch 경로 유지.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -21,6 +21,8 @@
 
 | 버전 | 날짜 | 주제 | PR |
 |------|------|------|-----|
+| **v5.5.0+** | 2026-04-23 | Phase 9: Progressive Disclosure + refactor 스킬 (skills 21→22, entry ≤200줄) | #144 |
+| **v5.5.0+** | 2026-04-23 | Phase 8: 보안 강화 (bash-guard DESTRUCTIVE_FS, file-protect .secrets, grep option-injection, yaml_safe backslash, SHA256 필수) | — |
 | **v5.5.0+** | 2026-04-22 | execution-summary + test 메모리 타입 + reason 세션 출력 | #138 |
 | **v5.5.0+** | 2026-04-22 | Plan 6.1 신뢰성 패치 17건 수정 | #137 |
 | **v5.5.0+** | 2026-04-22 | 하네스 비종속 신뢰성 + 1-liner 설치 개선 (Wave 1·2·3) | #140 |
@@ -66,6 +68,8 @@
 | ✅ Plan 6.1 신뢰성 17건 수정 (YAML injection, race condition, stale lock, etc.) | ✅ done | #137 |
 | ✅ execution-summary + test 메모리 타입 + reason 세션 출력 | ✅ done | #138 |
 | ✅ Phase 7: 신뢰성 개선 + install.sh + hxsk-harness-sync.sh + [필수]/[선택] UX | ✅ done | #140 |
+| ✅ Phase 8: 보안 강화 (STRIDE/OWASP 감사 + P0/P1/P2 수정) | ✅ done | — |
+| ✅ Phase 9: Progressive Disclosure (refactor 스킬 + executor/planner/verifier/debugger 분할) | ✅ done | #144 |
 
 ### Phase 3: 배포 최적화 (2026-Q3) 📋 계획
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -66,9 +66,10 @@ graph LR
         AB[Body<br/>## 탑재 Skills<br/>## 실행 순서]
     end
 
-    subgraph Skill["Skill (How) — 100~300 lines"]
+    subgraph Skill["Skill (How) — entry ≤200줄 + references/"]
         SF[Frontmatter<br/>name, description, trigger]
-        SB[Quick Reference ≤5 lines<br/>+ 상세 Procedures<br/>+ Anti-Patterns]
+        SB[Quick Reference ≤5 lines<br/>+ 핵심 흐름 요약<br/>+ references/ 링크]
+        SR[references/<br/>execution-flow.md<br/>deviation-rules.md 등]
     end
 
     subgraph Infra["Infrastructure"]
@@ -81,12 +82,15 @@ graph LR
     H -->|enforces| Skill
 ```
 
-**크기 제약**:
+**크기 제약 (Progressive Disclosure — Phase 9)**:
 - Agent body ≤ 20-30 lines (상세는 Skill에 위임)
 - Skill Quick Reference ≤ 5 lines
-- Skill 총 크기 100~300 lines
+- **Skill entry SKILL.md ≤ 200줄** (verifier/debugger ≤ 160줄)
+- **Skill 상세는 `references/` 서브디렉토리로 분리** (선택 로드)
 - CLAUDE.md ≤ 120 lines
 - PATTERNS.md ≤ 2KB / 20 items
+
+Phase 9 분할 결과: executor 681→98줄, planner 566→177줄, verifier 452→135줄, debugger 365→119줄 (~65-86% 절감).
 
 근거: **SkillReducer 연구(2026)**는 48% 설명 압축 + 2.8% 품질 개선을 보고. **Anthropic 내부**는 시스템 프롬프트 ~1,800 tokens 최적, >2,500 tokens에서 34% 환각 증가를 관찰.
 
@@ -326,7 +330,8 @@ sequenceDiagram
 
     U->>H: /skill executor (PLAN.md 주어짐)
     H->>A: Invoke executor agent
-    A->>S: Load executor SKILL.md
+    A->>S: Load executor SKILL.md (entry ≤200줄)
+    Note over S: 필요 시 references/ 선택 로드<br/>(execution-flow, deviation-rules 등)
     S->>MP: Recall past deviations (2-hop)
     MP-->>S: 관련 lessons-learned
 


### PR DESCRIPTION
## Summary

- `codebase-summary.md`: hooks 21+→26, scripts 12→17, refactor 스킬 추가, Security 섹션 (bash-guard/file-protect), memory-protocol 16→17 타입
- `system-architecture.md`: Progressive Disclosure (entry ≤200줄 + references/), Skill 서브그래프 업데이트
- `code-standards.md`: L2 SKILL.md ≤200줄 규칙 추가, references/ 선택 로드 계층 명시
- `deployment-guide.md`: 6.3 보안 체크리스트 신규, Phase 8+9 업그레이드 행 추가
- `project-roadmap.md`: Phase 8 보안 강화 + Phase 9 Progressive Disclosure 완료 항목 추가

## Test plan

- [x] doc-lint 7/7 PASS (LINK-01/02, INDEX-01, COUNT-01, REF-01, ORPHAN-01, DUP-01)
- [x] 모든 docs ≤800줄 (최대: configuration-guide.md 487줄)
- [x] learn-results.tsv 기록 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)