### PR TITLE
fix: SPEC.md 메모리 타입 수 14→16 + _detect.sh 주석 (PR #160 리뷰 잔여)

### DIFF
--- a/.hxsk/SPEC.md
+++ b/.hxsk/SPEC.md
@@ -13,7 +13,7 @@ HExoskeleton은 Claude Code 네이티브 환경에 최적화된 AI 에이전틱 
 ## Goals
 
 1. **외부 종속성 제로** — 순수 bash + 마크다운. 프로덕션 외부 패키지 의존 없음
-2. **파일 기반 에이전트 메모리** — `.hxsk/memories/` 14개 타입, 2-hop 그래프 검색, 중복 방지
+2. **파일 기반 에이전트 메모리** — `.hxsk/memories/` 16개 타입, 2-hop 그래프 검색, 중복 방지
 3. **Agent-Skill 래핑 구조** — Skill(How) + Agent(When/With What) 분리로 재사용성 극대화
 4. **HXSK 워크플로우** — `SPEC → PLAN → EXECUTE → VERIFY` 사이클로 계획-실행 추적
 5. **멀티 플랫폼 빌드** — Claude Code Plugin / Google Antigravity / OpenCode 동시 지원
@@ -36,7 +36,7 @@ HExoskeleton은 Claude Code 네이티브 환경에 최적화된 AI 에이전틱 
 ## Success Criteria
 
 - [x] 외부 종속성 없이 Claude Code CLI만으로 에이전트 워크플로우 실행
-- [x] 14개 메모리 타입 + 2-hop 검색으로 세션 간 컨텍스트 유지
+- [x] 16개 메모리 타입 + 2-hop 검색으로 세션 간 컨텍스트 유지
 - [x] 19개 Agent + 22개 Skill (공유 스킬 2개 포함) 정의 완료
 - [x] 3개 빌드 타겟(Plugin/Antigravity/OpenCode) 스크립트 작성
 - [x] shellcheck 복잡도 CLEAN, 레이어 경계 PASS

--- a/.hxsk/adapters/hitl/_detect.sh
+++ b/.hxsk/adapters/hitl/_detect.sh
@@ -12,6 +12,7 @@ if [[ -n "${HXSK_HARNESS:-}" ]]; then
 fi
 
 # 2. Claude Desktop / Claude Code 시그니처
+# NOTE: CLAUDE_CODE 는 비공식 env var — 향후 Claude Code 공식 변수 확정 시 교체 필요
 if [[ -n "${CLAUDE_DESKTOP_APP:-}" ]] || [[ -n "${ANTHROPIC_API_KEY:-}" && -n "${CLAUDE_CODE:-}" ]]; then
   echo "claude-code"
   exit 0


### PR DESCRIPTION
## Summary

PR #160 + #162 머지 과정에서 누락된 2건을 보완합니다.

- `SPEC.md`: Goals + Success Criteria의 메모리 타입 수 `14개` → `16개` (lessons-learned + term-definition 추가 반영)
- `adapters/hitl/_detect.sh`: `CLAUDE_CODE` 비공식 env var 주석 추가

## Test Plan

- [x] `grep "16개" .hxsk/SPEC.md` → 2 matches
- [x] `grep "NOTE.*CLAUDE_CODE" .hxsk/adapters/hitl/_detect.sh` → match
- [x] doc-lint PASS (이전 커밋에서 검증 완료)

Related: #160, #161, #162
🤖 Generated with [Claude Code](https://claude.com/claude-code)