### PR TITLE
feat: add project Codex harness support

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "OpenAI Codex CLI hook config — HXSK prune. Requires feature flag codex_hooks=true.",
+  "hooks": {
+    "Stop": [
+      {
+        "command": "bash",
+        "args": [".hxsk/scripts/prune-memories.sh", "--auto"]
+      }
+    ]
+  }
+}

--- a/.hxsk/adapters/README.md
+++ b/.hxsk/adapters/README.md
@@ -20,7 +20,7 @@ HXSK 메모리 prune 정책을 Claude Code 외의 에이전트 하네스에서�
 | **GitHub Copilot CLI** | `.copilot/hooks.json` | sessionEnd, agentStop | [copilot-hooks.json](copilot-hooks.json) 참고 |
 | **Windsurf Cascade** | `.windsurf/hooks.json` | post_cascade_response | SessionEnd·PreCompact 부재, 턴 종료로 대체 |
 | **OpenCode** | `~/.config/opencode/plugin/hxsk.ts` (JS 플러그인) | session.idle, session.compacting | 순수 bash 불가, 얇은 JS wrapper 필요 |
-| **OpenAI Codex CLI** | `.codex/hooks.json` (`codex_hooks=true` 필요) | stop | PreCompact 없음 |
+| **OpenAI Codex CLI** | `.codex/hooks.json` (`codex_hooks=true` 필요) + `.hxsk/githooks/pre-push` | stop, git pre-push | PreCompact 없음. 프로젝트 공용 `.codex/hooks.json` 제공 |
 | **Aider / Continue / Antigravity** | (lifecycle 훅 미지원) | — | git 훅 폴백 사용 |
 
 ## 설치 (선택)
@@ -31,6 +31,10 @@ HXSK 메모리 prune 정책을 Claude Code 외의 에이전트 하네스에서�
 # Cursor 예시
 mkdir -p .cursor
 cp .hxsk/adapters/cursor-hooks.json .cursor/hooks.json
+
+# Codex 예시 (프로젝트 공용 hooks.json + 로컬 검증 git hook)
+bash .hxsk/scripts/install.sh --harness codex
+# Codex 전역 설정에서 codex_hooks=true 활성 필요
 
 # git 훅 폴백 (모든 하네스 공통)
 git config core.hooksPath .hxsk/githooks

--- a/.hxsk/prompts/setup.md
+++ b/.hxsk/prompts/setup.md
@@ -450,7 +450,7 @@ bash .hxsk/scripts/bootstrap.sh
 | **Gemini CLI** | 최신 | `mkdir -p .gemini && cp .hxsk/adapters/gemini-settings.json .gemini/settings.json` (프로젝트 우선, 글로벌은 `~/.gemini/`) | [geminicli.com/docs/hooks](https://geminicli.com/docs/hooks/) |
 | **Copilot CLI** | 2026-02 GA+ | `mkdir -p .copilot && cp .hxsk/adapters/copilot-hooks.json .copilot/hooks.json` | [GitHub Docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-hooks) |
 | **Windsurf** | Cascade 활성 | `mkdir -p .windsurf && cp .hxsk/adapters/windsurf-hooks.json .windsurf/hooks.json` | [docs.windsurf.com/windsurf/cascade/hooks](https://docs.windsurf.com/windsurf/cascade/hooks) |
-| **Codex CLI** | `codex_hooks=true` 활성 | `codex config set experimental.codex_hooks true && mkdir -p .codex && cp .hxsk/adapters/codex-hooks.json .codex/hooks.json` | [developers.openai.com/codex/hooks](https://developers.openai.com/codex/hooks) |
+| **Codex CLI** | `codex_hooks=true` 활성 | `bash .hxsk/scripts/install.sh --harness codex` (`.codex/hooks.json` + `.hxsk/githooks/pre-push`) | [developers.openai.com/codex/hooks](https://developers.openai.com/codex/hooks) |
 | **OpenCode** | Bun 런타임 필요 | `mkdir -p ~/.config/opencode/plugin && cp .hxsk/adapters/opencode-plugin.ts ~/.config/opencode/plugin/hxsk.ts` | [opencode.ai/docs/plugins](https://opencode.ai/docs/plugins/) |
 | **Aider** | lifecycle 훅 부재 | `git config core.hooksPath .hxsk/githooks` | [aider.chat](https://aider.chat/) |
 | **Continue.dev** | 동일 (VS Code 확장 제약) | 동일 | [docs.continue.dev](https://docs.continue.dev/) |

--- a/.hxsk/scripts/install.sh
+++ b/.hxsk/scripts/install.sh
@@ -59,7 +59,10 @@ install_harness() {
     codex)
       mkdir -p .codex
       safe_copy "$ADAPTER_DIR/codex-hooks.json" ".codex/hooks.json"
-      echo "[OK] OpenAI Codex CLI: .codex/hooks.json 설치 완료" ;;
+      git config core.hooksPath .hxsk/githooks
+      echo "[OK] OpenAI Codex CLI: .codex/hooks.json 설치 완료"
+      echo "[OK] git 훅 폴백: core.hooksPath .hxsk/githooks 설정 완료"
+      echo "[INFO] Codex hooks require codex_hooks=true in Codex config." ;;
     git-hook)
       git config core.hooksPath .hxsk/githooks
       echo "[OK] git 훅 폴백: core.hooksPath .hxsk/githooks 설정 완료" ;;

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
 > | Claude Code | `bash .hxsk/scripts/install.sh --harness claude-code` |
 > | Cursor 1.7+ | `bash .hxsk/scripts/install.sh --harness cursor` |
 > | GitHub Copilot CLI | `bash .hxsk/scripts/install.sh --harness copilot` |
-> | 기타 (Gemini·Windsurf·Codex 등) | [Tier 2·3 설치 안내](.hxsk/adapters/README.md) |
+> | OpenAI Codex CLI | `bash .hxsk/scripts/install.sh --harness codex` |
+> | 기타 (Gemini·Windsurf·OpenCode 등) | [Tier 2·3 설치 안내](.hxsk/adapters/README.md) |
 >
 > 처음이라면: `.hxsk/prompts/setup.md` Step 1(필수) → Step 4(필수) → 위 명령 순서로 실행
 

--- a/llms.txt
+++ b/llms.txt
@@ -54,6 +54,10 @@
 1. `.hxsk/prompts/setup.md` Step 1·4·6(필수) 실행
 2. `.hxsk/adapters/README.md` 의 해당 하네스 섹션 참조
 
+### OpenAI Codex CLI
+1. `bash .hxsk/scripts/install.sh --harness codex`
+2. Codex 설정에서 `codex_hooks=true` 활성
+
 ### Aider / Continue / Antigravity (Tier 3 — 커뮤니티 기여)
 1. `.hxsk/prompts/setup.md` Step 1·4(필수) 실행
 2. `bash .hxsk/scripts/install.sh --harness git-hook`


### PR DESCRIPTION
## Summary
- Track project-level .codex/hooks.json for OpenAI Codex CLI
- Wire install.sh --harness codex to install Codex hooks and configure local git hooks
- Document Codex setup in README, llms.txt, setup.md, and adapters guide

## Verification
- [x] bash .hxsk/scripts/local-verify.sh
- [x] bash .hxsk/scripts/install.sh --harness codex

## Notes
- GitHub Actions are disabled for this repository; validation is local-first via .hxsk/scripts/local-verify.sh and .hxsk/githooks/pre-push.