### PR TITLE
docs: refresh autoresearch learn documentation

### DIFF
--- a/.hxsk/docs/AGENTS.md
+++ b/.hxsk/docs/AGENTS.md
@@ -9,7 +9,7 @@ Claude Code의 **Agents**는 특정 작업에 특화된 서브프로세스입니
 | 항목 | 설명 |
 |------|------|
 | **위치** | `.hxsk/agents/*.md` |
-| **개수** | 17개 |
+| **개수** | 18개 (`.hxsk/agents/INDEX.md` 기준) |
 | **호출 방식** | Claude가 필요 시 자동 위임 또는 Task 도구로 명시적 호출 |
 | **컨텍스트** | 메인 대화와 분리된 별도 서브프로세스 |
 
@@ -25,6 +25,7 @@ Claude Code의 **Agents**는 특정 작업에 특화된 서브프로세스입니
 | `plan-checker` | `plan-checker.md` | 계획 검증 (6차원 분석) | Read, Grep, Glob |
 | `executor` | `executor.md` | 계획 실행 + atomic commits | Read, Write, Edit, Bash, Grep, Glob |
 | `verifier` | `verifier.md` | 구현 검증 + 증거 수집 | Read, Bash, Grep, Glob |
+| `spec-reviewer` | `spec-reviewer.md` | SPEC.md 요구사항 대비 구현 적합성 1차 심사 | Read, Bash, Grep, Glob |
 | `debugger` | `debugger.md` | 체계적 디버깅 (3-strike rule) | Read, Write, Edit, Bash, Grep, Glob |
 | `bootstrap` | `bootstrap.md` | 프로젝트 초기 설정 | Read, Write, Edit, Bash, Grep, Glob |
 

--- a/.hxsk/docs/BUILD.md
+++ b/.hxsk/docs/BUILD.md
@@ -14,7 +14,7 @@
 | `AGENTS.md` | 범용 에이전트 지침 (Copilot, Cursor, Windsurf 등) |
 | `CLAUDE.md` | Claude Code 전용 설정 |
 | `GEMINI.md` | Gemini CLI 전용 설정 |
-| `.hxsk/prompts/setup.md | 통합 setup 프롬프트 (모든 에이전트 지원) |
+| `.hxsk/prompts/setup.md` | 통합 setup 프롬프트 (모든 에이전트 지원) |
 
 ### 사용법
 

--- a/.hxsk/docs/HOOKS.md
+++ b/.hxsk/docs/HOOKS.md
@@ -10,7 +10,7 @@ Claude Code의 **Hooks**는 특정 이벤트에 자동으로 응답하는 스크
 |------|------|
 | **설정 파일** | `.claude/settings.json` |
 | **스크립트 위치** | `.hxsk/hooks/` |
-| **개수** | 17개 스크립트 |
+| **개수** | 27개 스크립트 (`.hxsk/hooks/INDEX.md` 기준) |
 | **이벤트 종류** | SessionStart, PreToolUse, PostToolUse, PreCompact, Stop, SubagentStop, SessionEnd |
 
 ---

--- a/.hxsk/docs/LINTING.md
+++ b/.hxsk/docs/LINTING.md
@@ -13,10 +13,10 @@
 
 ```bash
 # ShellCheck: 모든 스크립트 검사
-find scripts .hxsk/hooks -name '*.sh' -exec shellcheck {} +
+find .hxsk/scripts .hxsk/hooks -name '*.sh' -exec shellcheck {} +
 
 # shfmt: 포매팅 검사
-find scripts .hxsk/hooks -name '*.sh' -exec shfmt -d {} +
+find .hxsk/scripts .hxsk/hooks -name '*.sh' -exec shfmt -d {} +
 ```
 
 ## Markdown

--- a/.hxsk/docs/WORKFLOWS.md
+++ b/.hxsk/docs/WORKFLOWS.md
@@ -8,12 +8,12 @@ Claude Code의 **Workflows**는 슬래시 명령어(`/command`)로 호출되는 
 
 | 항목 | 설명 |
 |------|------|
-| **소스** | `.hxsk/agents/*.md` (빌드 시 워크플로우로 변환) |
-| **빌드 출력** | Plugin: `commands/`, Antigravity: `.agent/workflows/`, OpenCode: `.opencode/commands/` |
-| **호출 방식** | `/hxsk:<command>` 또는 `/<command>` |
+| **소스** | `.hxsk/skills/*/SKILL.md`, `.hxsk/agents/*.md`, `.hxsk/workflow/GATES.md` |
+| **배포 방식** | Self-Configure: `llms.txt` → `.hxsk/prompts/setup.md` → `install.sh --harness <name>` |
+| **호출 방식** | 하네스별 스킬/에이전트 호출 (`/skill ...`, Task 위임, 또는 어댑터 명령) |
 | **인자 전달** | `$ARGUMENTS` 변수로 전달 |
 
-> **Note**: 워크플로우 파일은 소스에 직접 존재하지 않고, `scripts/build-*.sh`가 agents에서 자동 생성합니다.
+> **Note**: 과거 `scripts/build-*.sh` 기반 플러그인/보일러플레이트 생성 경로는 superseded 상태입니다. 현재 운영 경로는 레포 자체를 배포 단위로 두고 setup/install 스크립트가 각 하네스 표면을 수렴시키는 Self-Configure 모델입니다.
 
 ---
 

--- a/.hxsk/scripts/doc-lint.sh
+++ b/.hxsk/scripts/doc-lint.sh
@@ -63,6 +63,7 @@ mapfile -t ALL_MD < <(
         -not -path "./.hxsk/memories/*" \
         -not -path "./.hxsk/archive/*" \
         -not -path "./.hxsk/reports/*" \
+        -not -path "./.hxsk/runtime/*" \
         -not -path "./.claude/worktrees/*" \
         -not -path "*/.venv/*" \
         -not -path "*/venv/*" \
@@ -582,7 +583,7 @@ rule_dup_01() {
             # write-report.md: agents/는 에이전트 정의, examples/는 사용 예시 — 의도적 구분
             write-report.md) continue ;;
             # autoresearch 세션 출력 파일 — scenario/predict/learn/reason 세션마다 생성
-            overview.md|summary.md|findings.md|scenarios.md|edge-cases.md) continue ;;
+            overview.md|summary.md|findings.md|scenarios.md|edge-cases.md|scout-context.md|validation-report.md) continue ;;
             # predict 세션 분석 파일 — 세션마다 생성되는 의도적 중복
             codebase-analysis.md|component-clusters.md|dependency-map.md|hypothesis-queue.md) continue ;;
             # plan SUMMARY 파일 — 각 Phase마다 동일 번호 plan이 존재하는 의도적 중복

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen?style=flat-square" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/stack-bash%20%2B%20markdown-blue?style=flat-square" alt="Bash + Markdown" />
   <img src="https://img.shields.io/badge/multi--agent-5%20platforms-blueviolet?style=flat-square" alt="Multi-Agent" />
-  <img src="https://img.shields.io/badge/v5.5.x%20%C2%B7%2024%20skills%20%C2%B7%2018%20agents%20%C2%B7%2027%20hooks-orange?style=flat-square" alt="Components" />
+  <img src="https://img.shields.io/badge/v5.7.x%20%C2%B7%2024%20skills%20%C2%B7%2018%20agents%20%C2%B7%2027%20hooks-orange?style=flat-square" alt="Components" />
   <img src="https://img.shields.io/github/license/SukbeomH/HExoskeleton?style=flat-square" alt="License" />
 </p>
 
@@ -180,7 +180,7 @@ bash .hxsk/hooks/md-recall-memory.sh "검색어" "." 5 compact 2
 ```
 
 <details>
-<summary><strong>canonical 17개 메모리 디렉토리 + ADR-006 historical (v5.5.x)</strong></summary>
+<summary><strong>canonical 17개 메모리 타입 + ADR-006 historical (v5.7.x)</strong></summary>
 
 디버깅: `root-cause`, `debug-eliminated`, `debug-blocked` · 아키텍처: `architecture-decision`, `pattern-discovery` · 실행: `execution-summary`, `deviation`, `lessons-learned` · 세션: `session-summary`, `session-snapshot`, `session-handoff` · 시스템: `health-event`, `bootstrap`, `security-finding`, `general` · 용어: `term-definition` · 테스트: `test` · historical: `ADR-006`
 
@@ -255,7 +255,7 @@ AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝�
 │   ├── workflow/              # 게이트 기반 작업 관리 (GATES.md)
 │   ├── docs/                  # 상세 운영 문서
 │   ├── prompts/               # Setup + 마이그레이션 프롬프트
-│   ├── templates/             # 문서 템플릿
+│   ├── templates/             # 문서 템플릿 (34)
 │   ├── memories/              # 파일 기반 메모리 + 스키마
 │   ├── research/              # 연구·근거 문서
 │   ├── issues/                # 파일 기반 이슈 레지스트리
@@ -298,7 +298,7 @@ AI 에이전트에게 setup 프롬프트를 전달하면 자동으로 프로젝�
 
 ## 로드맵
 
-현재 공개 문서 기준 라인은 **v5.6.x**입니다. 최근 반영된 완료 범위는 하네스 독립 prune(v5.5.0), 신뢰성 17건 수정(PR #137), test 메모리 확장(PR #138), 보안 강화(Phase 8), Progressive Disclosure(PR #144), 그리고 release lineage 재정렬(v5.6.1)입니다.
+현재 공개 문서 기준 라인은 **v5.7.x**입니다. 최근 반영된 완료 범위는 하네스 독립 prune(v5.5.0), 신뢰성 17건 수정(PR #137), test 메모리 확장(PR #138), 보안 강화(Phase 8), Progressive Disclosure(PR #144), release lineage 재정렬(v5.6.1), 그리고 active-state / Hermes / HITL 표면 정비(v5.7.0)입니다.
 
 주요 완료 마일스톤: Iron Laws · 합리화 테이블 · CSO · Git Forge 통합(GATES.md) · 하네스 독립 prune · 보안 강화 · Progressive Disclosure.
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -2,17 +2,17 @@
 
 > HExoskeleton 리포지토리의 파일 인벤토리, 의존성, 구성 요소 카운트.
 >
-> Version 5.6.1 문서 스냅샷 · 2026-04-30 기준 로컬 스캔 반영
+> Version 5.7.0 문서 스냅샷 · 2026-05-06 기준 로컬 스캔 반영
 
 ## 1. Repository Layout
 
 ```
 HExoskeleton/
-├── README.md                  # 공개 랜딩 페이지 (312 lines)
+├── README.md                  # 공개 랜딩 페이지 (314 lines)
 ├── CLAUDE.md                  # Claude Code 진입점
-├── AGENTS.md                  # 하네스 공용 지침 (125 lines)
+├── AGENTS.md                  # 하네스 공용 지침 (155 lines)
 ├── GEMINI.md                  # Gemini CLI 진입점 (12 lines)
-├── llms.txt                   # Self-Configure 인덱스 (35 lines)
+├── llms.txt                   # Self-Configure 인덱스 (67 lines)
 ├── CHANGELOG.md               # 릴리스 히스토리
 ├── Makefile                   # 빌드 타겟 (74 lines)
 ├── .envrc / .env.example      # 환경 설정
@@ -35,14 +35,14 @@ HExoskeleton/
     ├── skills/   (24)         # 재사용 절차
     ├── agents/   (18)         # 스킬 오케스트레이션
     ├── hooks/    (27)         # 이벤트 훅
-    ├── scripts/  (22)         # 유틸리티 bash/Python
+    ├── scripts/  (23)         # 유틸리티 bash/Python
     ├── workflow/ (1)          # GATES.md
     ├── prompts/  (3)          # setup 프롬프트
-    ├── templates/ (33)        # 문서 템플릿
+    ├── templates/ (34)        # 문서 템플릿
     ├── adapters/              # 하네스별 어댑터 + 설정 파일
     ├── githooks/              # git post-commit/post-merge
     ├── memories/              # 파일 기반 메모리 + 스키마
-    ├── research/              # L3 근거 문서 (42 markdown / 8 subdirs + root-level studies)
+    ├── research/              # L3 근거 문서 (43 markdown / 8 subdirs + root-level studies)
     ├── issues/                # 파일 기반 이슈 레지스트리
     ├── docs/                  # 내부 심화 문서 (15 root markdown + plans/)
     ├── reports/               # 생성 보고서
@@ -70,9 +70,9 @@ HXSK의 작업 재진입 표면은 아래 문서를 canonical로 본다.
 | **Skills** | 24 | index 기준 | 각 `{name}/SKILL.md` + `references/` |
 | **Agents** | 18 | index 기준 | 각 `{name}.md` 파일 |
 | **Hooks** | 27 | index 기준 | 7개 Claude Code 이벤트 + 보조 훅 |
-| **Scripts** | 22 | 로컬 스캔 기준 | 설치·검증·릴리스·유지보수 유틸리티 |
-| **Templates** | 33 | 로컬 스캔 기준 | 문서 생성 표준 |
-| **Internal Docs** | 15 root markdown | 로컬 스캔 기준 | `.hxsk/docs/` + `plans/` 심화 문서 |
+| **Scripts** | 23 | 로컬 스캔 기준 | 설치·검증·릴리스·유지보수 유틸리티 |
+| **Templates** | 34 | 로컬 스캔 기준 | 문서 생성 표준 |
+| **Internal Docs** | 35 root markdown | 로컬 스캔 기준 | `.hxsk/docs/` + `plans/` 심화 문서 |
 | **Prompts** | 3 | 로컬 스캔 기준 | setup 프롬프트 |
 | **Adapters** | mixed | 설정 파일/문서 혼합 | 하네스별 훅 설정 |
 | **Memory Surface** | canonical 17 + ADR-006 historical | 스키마/디렉토리 혼합 | `term-definition`, `test`, `lessons-learned` 포함 |
@@ -182,13 +182,13 @@ HXSK의 작업 재진입 표면은 아래 문서를 canonical로 본다.
 - `pre-commit-doc-lint.sh` — doc-lint 검사 (INDEX-01은 `references/` 서브디렉토리 자동 제외)
 - `pre-commit-version-check.sh` — 버전 정합성 검증
 
-## 6. Utility Scripts (22)
+## 6. Utility Scripts (23)
 
 | Script | 목적 |
 |--------|------|
-| `bootstrap.sh` (458 lines) | 환경 수렴 엔진 — fresh/update/verify; FAIL 시 "다음 단계: setup.md 열어 수동 수정" 안내 |
+| `bootstrap.sh` | 환경 수렴 엔진 — fresh/update/verify; FAIL 시 setup.md 또는 setup-verify.sh 안내 |
 | `detect-language.sh` (221) | Python/Node/Go/Rust + 패키지 매니저 감지 |
-| `doc-lint.sh` (619) | 마크다운 구조 검증; ORPHAN_EXCLUDE_DIRS에 `./scenario ./predict ./.hxsk/docs ./.hxsk/phases` 포함 |
+| `doc-lint.sh` | 마크다운 구조 검증; ORPHAN_EXCLUDE_DIRS에 `./scenario ./predict ./.hxsk/docs ./.hxsk/phases` 포함 |
 | `issue-create.sh` (166) | master/work/legacy 모드 이슈 생성 |
 | `issue-list.sh` (137) | 이슈 인덱스 출력 |
 | `merge-worktrees.sh` (63) | 워크트리 병합 |
@@ -196,13 +196,16 @@ HXSK의 작업 재진입 표면은 아래 문서를 canonical로 본다.
 | `prune-tick.sh` (75) | 하네스 독립 opportunistic 트리거 (60s 쿨다운); stale lock 300s 감지·제거; `.prune-config` source 안전 검증 |
 | `generate-llms-txt.sh` (61) | llms.txt 자동 생성 |
 | `forge-detect.sh` (170) | GitHub/GitLab/Gitea + auth 감지 |
-| `verify-self-configure.sh` (341) | 자가 구성 검증 |
+| `verify-self-configure.sh` | 자가 구성 검증 |
 | `check-reliability.sh` | 14-패턴 신뢰성 이슈 카운터; `bash .hxsk/scripts/check-reliability.sh` → `ISSUE COUNT: N` 출력 |
 | `install.sh` (70) | 하네스별 1-liner 설치 — `--harness <name>` (Tier 1: claude-code·cursor·copilot 완전 지원) |
 | `install-hooks.sh` (228) | Claude Code settings.json 훅 설치/병합 — `--merge` 기존 설정 보존, python3 원자적 교체 |
 | `hxsk-harness-sync.sh` (35) | 어댑터 드리프트 감지/동기화 — `--check`/`--sync` 모드 |
 | `setup-verify.sh` (200) | 설치 검증 5개 독립 조건 — `PASS N/5 | FAIL M/5` 출력 |
 | `pre-release-check.sh` (100) | 릴리스 전 4-체크: SHA256·CHANGELOG·ISSUE COUNT·실행권한 |
+| `local-verify.sh` | 로컬 우선 검증 번들 — doc-lint, consistency, skill test dry-run, pre-pr 순서 실행 |
+| `active-state.sh` | CURRENT/STATE/SESSION_HANDOFF/VERIFICATION active-state spine 관리 유틸리티 |
+| `glossary-rebuild.sh` / `hitl-ask.sh` | ADR-006 용어/정의 재빌드와 HITL 어댑터 질의 지원 |
 
 ## 7. Memory System (Canonical 17 + ADR-006 historical)
 
@@ -299,7 +302,7 @@ HXSK의 작업 재진입 표면은 아래 문서를 canonical로 본다.
 
 ## 11. Research Foundation
 
-`.hxsk/research/` 에는 **42개 markdown 문서**가 있으며, 이 중 **41개 연구 문서 + 1개 인덱스**로 구성된다. 구조는 **8개 하위 디렉토리 + 5개 루트 문서** 기준으로 정리된다:
+`.hxsk/research/` 에는 **43개 markdown 문서**가 있으며, 이 중 **42개 연구 문서 + 1개 인덱스**로 구성된다. 구조는 **8개 하위 디렉토리 + 루트 문서** 기준으로 정리된다:
 
 - **memory-systems/** (8) — A-Mem, Nemori, ReWOO, RLM, 컨텍스트 압축, 하이브리드 검색
 - **platform-integration/** (9) — Claude Code/OpenCode/Antigravity 통합 및 OpenCode 실증 검증

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -460,7 +460,7 @@ tasks:
 
 루트의 `llms.txt`는 `llms.txt v1.0` 스펙 준수. HXSK 버전이 포함:
 ```
-> Last Updated: 2026-04-30 · Format: llms.txt v1.0 · HXSK v5.6.1
+> Last Updated: 2026-05-04 · Format: llms.txt v1.0 · HXSK v5.7.0
 ```
 
 주요 섹션:
@@ -473,8 +473,8 @@ tasks:
 ## 15. Version File (`.hxsk/.bootstrap-version`)
 
 ```yaml
-version: 5.6.1
-last_run: 2026-04-30
+version: 5.7.0
+last_run: 2026-05-04
 components:
   skills: 24
   agents: 18

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -66,7 +66,7 @@ llms.txt → .hxsk/prompts/setup.md 순서로 읽고 실행
 setup.md의 Step 0은 `.bootstrap-version` 존재 여부와 `version:` 라인 유무를 기준으로 **4분기**를 수행한다. `CORRUPTED`는 `git status` 실패가 아니라 **`.bootstrap-version`이 존재하지만 `version:` 필드가 없거나 손상된 경우**에 진입한다.
 
 ```bash
-TARGET_VERSION=5.6.1
+TARGET_VERSION=5.7.0
 VERSION_FILE=".hxsk/.bootstrap-version"
 if [ ! -f "$VERSION_FILE" ]; then
     echo "FRESH"
@@ -171,6 +171,7 @@ git pull --rebase
 | v5.3.x | v5.4.0 | Git Forge + lessons-learned A-E + 메모리 티어 | 자동 |
 | v5.4.x | v5.5.0 | 하네스 독립 prune + cap=5 + local-tier 전체 | `.hxsk/.prune-config` 새로 생성 |
 | v5.5.x | v5.6.x | setup release lineage 정렬 + Codex/OpenCode 표면 정비 + 검증/정합성 하드닝 | 자동 (setup.md 재실행 후 local-verify 권장) |
+| v5.6.x | v5.7.x | active-state spine 정비 + Hermes/HITL 표면 보강 + docs/verification sync | 자동 (setup.md 재실행 후 `bash .hxsk/scripts/local-verify.sh`) |
 
 ## 5. Harness-Specific Installation
 
@@ -239,13 +240,21 @@ setup.md의 완료 체크리스트 각 항목에는 검증 명령이 포함되�
 
 ## 6. Self-Configure 검증
 
-설치 후 검증: `bash .hxsk/scripts/setup-verify.sh` → PASS 5/5 확인
+설치 후 1차 검증: `bash .hxsk/scripts/setup-verify.sh` → PASS 5/5 확인. 변경/PR 전 종합 검증은 `bash .hxsk/scripts/local-verify.sh`를 우선 실행한다.
 
 ### 6.1 verify-self-configure.sh
 설치 후 검증:
 ```bash
 bash .hxsk/scripts/verify-self-configure.sh
 ```
+
+### 6.1.1 local-verify.sh
+문서·구조·PR 전 검증을 한 번에 묶은 로컬 우선 진입점:
+```bash
+bash .hxsk/scripts/local-verify.sh
+```
+
+실행 순서: `doc-lint.sh` → `check-consistency.sh` → 스킬 테스트 dry-run(시나리오 존재 시) → `pre-pr-check.sh`.
 
 검증 항목:
 - 훅이 Claude 설정에 등록되었는가

--- a/docs/project-overview-pdr.md
+++ b/docs/project-overview-pdr.md
@@ -2,7 +2,7 @@
 
 > **H**Exoskeleton: AI 에이전트를 위한 외골격 — 절제된 제약이 자율성을 만든다.
 >
-> Version 5.6.1 · Pure bash + markdown · Zero external dependencies
+> Version 5.7.0 · Pure bash + markdown · Zero external dependencies
 
 ## 1. Problem Statement
 
@@ -18,7 +18,7 @@ HXSK는 이 세 문제를 **단일 외부 의존성 없는 파일 기반 보일�
 
 > "AI 에이전트가 팀원처럼 일하게 하려면, 팀원에게 주는 것을 똑같이 주라 — 공유 메모리, 일관된 워크플로우, 그리고 질문 대신 규율."
 
-HXSK는 Claude Code 네이티브 환경에 최적화되었지만, Gemini·Copilot·Cursor·Windsurf·OpenCode·Codex·Antigravity·Aider·Continue까지 9개 하네스에서 동일한 `.hxsk/` 상태 디렉토리를 공유하도록 설계되었다. 플랫폼이 바뀌어도 에이전트의 "외골격"은 따라간다.
+HXSK는 Claude Code 네이티브 환경에 최적화되었지만, Gemini·Copilot·Cursor·Windsurf·OpenCode·Codex·Hermes·Antigravity·Aider·Continue까지 10+ 하네스에서 동일한 `.hxsk/` 상태 디렉토리를 공유하도록 설계되었다. 플랫폼이 바뀌어도 에이전트의 "외골격"은 따라간다.
 
 ## 3. Core Principles (Why)
 
@@ -76,10 +76,10 @@ HXSK는 Claude Code 네이티브 환경에 최적화되었지만, Gemini·Copilo
     │ skills/  (24)    │  How — 재사용 가능한 절차
     │ agents/  (18)    │  When/With What — 스킬 오케스트레이션
     │ hooks/   (27)    │  Event-driven 가드레일
-    │ scripts/ (22)    │  유틸리티 (이슈/메모리/설치/검증)
+    │ scripts/ (23)    │  유틸리티 (이슈/메모리/설치/검증)
     │ memories/        │  17 types × 2-hop search
     │ workflow/        │  GATES.md
-    │ templates/       │  33 templates
+    │ templates/       │  34 templates
     │ research/        │  L3 근거 자료
     └──────────────────┘
 ```
@@ -127,7 +127,7 @@ claude code         # 또는 Cursor/Gemini/Copilot 등
 
 ## 8. Versioning & Release
 
-- **Current**: v5.6.1 (2026-04-30)
+- **Current**: v5.7.0 (2026-05-04)
 - **Scheme**: SemVer (Major.Minor.Patch)
 - **Breaking changes**: `.hxsk/CHANGELOG.md`에 명시
 - **Major milestones**: @project-roadmap.md

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -4,10 +4,10 @@
 >
 > 원본 로드맵: `.hxsk/ROADMAP.md` · 전체 CHANGELOG: `.hxsk/CHANGELOG.md`
 
-## 1. Current Version: v5.6.1
+## 1. Current Version: v5.7.0
 
-**기준일**: 2026-04-30
-**현재 라인**: v5.6.1 공개 문서 기준. v5.5.0의 하네스 독립 prune 위에 Phase 8 보안 강화, Phase 9 Progressive Disclosure, Phase 10 CSO 최적화, Phase 11 용어/메모리 정화, Codex/OpenCode 표면 정비, release lineage 정렬이 누적된 상태.
+**기준일**: 2026-05-06
+**현재 라인**: v5.7.0 공개 문서 기준. v5.5.0의 하네스 독립 prune 위에 Phase 8 보안 강화, Phase 9 Progressive Disclosure, Phase 10 CSO 최적화, Phase 11 용어/메모리 정화, Codex/OpenCode 표면 정비, release lineage 정렬, active-state spine / Hermes / HITL 표면 정비가 누적된 상태.
 
 ### 현재 라인의 핵심 변경
 - **하네스 독립 메모리 프룬** — cron/launchd 의존 없이 메모리 툴 호출 시 자연 발화 (sentinel mtime + mkdir atomic lock)
@@ -21,6 +21,7 @@
 
 | 버전 | 날짜 | 주제 | PR |
 |------|------|------|-----|
+| **v5.7.0** | 2026-05-04 | active-state spine, Hermes/HITL surface, local verification sync | — |
 | **v5.6.1** | 2026-04-30 | 공개 version lineage 정렬, README/docs 현행화 | #172 |
 | **v5.6.1** | 2026-04-30 | release lineage 재정렬 | #171 |
 | **v5.6.x** | 2026-04-30 | 검증/정합성 하드닝 + Codex harness 지원 | #167, #169 |
@@ -230,6 +231,7 @@ Non-goals로 설계된 항목. 단기에 변경 없음:
 
 | HXSK 버전 | Claude Code | Gemini | Cursor | Copilot | Windsurf | OpenCode | Codex | Aider | Continue | Antigravity |
 |----------|-------------|--------|--------|---------|----------|----------|-------|-------|----------|-------------|
+| v5.7.x | ✅ | ✅ | ✅ 1.7+ | ✅ | ✅ | ✅ | ✅ | ✅ (git) | ✅ (git) | ✅ (git) |
 | v5.6.x | ✅ | ✅ | ✅ 1.7+ | ✅ | ✅ | ✅ | ✅ | ✅ (git) | ✅ (git) | ✅ (git) |
 | v5.5.x | ✅ | ✅ | ✅ 1.7+ | ✅ | ✅ | ✅ | ✅ | ✅ (git) | ✅ (git) | ✅ (git) |
 | v5.4.x | ✅ | ✅ | ⚠️ 일부 | — | — | ⚠️ | — | — | — | — |

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -24,18 +24,18 @@ graph TB
         Skills[skills/<br/>24 재사용 절차]
         Agents[agents/<br/>18 오케스트레이터]
         Hooks[hooks/<br/>27 이벤트 훅]
-        Scripts[scripts/<br/>22 유틸리티]
+        Scripts[scripts/<br/>23 유틸리티]
         Memory[memories/<br/>17 타입 × 2-hop]
         Workflow[workflow/GATES.md<br/>8 게이트]
-        Templates[templates/<br/>33 템플릿]
+        Templates[templates/<br/>34 템플릿]
         State[CURRENT.md<br/>STATE.md<br/>SESSION_HANDOFF.md<br/>VERIFICATION.md<br/>SPEC.md]
         Research[research/<br/>L3 근거]
     end
 
-    subgraph Outputs["빌드 타겟"]
-        Plugin[hxsk-plugin/]
-        Antigrav[antigravity-<br/>boilerplate/]
-        OpenCodeOut[opencode-<br/>boilerplate/]
+    subgraph Outputs["레거시/보조 산출물"]
+        Plugin[hxsk-plugin/<br/>superseded]
+        Antigrav[antigravity-<br/>boilerplate/<br/>superseded]
+        OpenCodeOut[opencode-<br/>boilerplate/<br/>superseded]
     end
 
     User --> Harness
@@ -48,7 +48,7 @@ graph TB
     Skills -->|Use| Templates
     Skills -->|Reference| Research
 
-    HXSK -.Build.-> Outputs
+    HXSK -.historical build path.-> Outputs
 
     style HXSK fill:#f0f8ff,stroke:#4a90e2
     style Harness fill:#fffacd,stroke:#daa520
@@ -233,11 +233,13 @@ graph TB
         Copilot[copilot-hooks.json]
         Windsurf[windsurf-hooks.json]
         OpenCode[opencode-plugin.ts]
+        Hermes[hermes/README.md]
         Cursor --> Tick
         Gemini --> Tick
         Copilot --> Tick
         Windsurf --> Tick
         OpenCode --> Tick
+        Hermes --> Tick
     end
 
     subgraph Tier3["Tier 3: Git Hook Fallback (lifecycle 훅 미지원 하네스)"]
@@ -296,7 +298,9 @@ graph LR
 - lockfile 수정 태스크는 `parallel: false` 필수
 - 파일 소유권 선언 없이 병렬 작업 금지 (AGENTS.md Iron Law)
 
-## 8. Build Pipeline (멀티 플랫폼)
+## 8. Legacy Build Pipeline (superseded)
+
+현재 배포 기본값은 **Self-Configure**이다. 사용자는 리포를 clone/pull 하고 `.hxsk/prompts/setup.md` 또는 `install.sh --harness <name>`으로 로컬 상태를 수렴시킨다. 아래 빌드 파이프라인은 과거 플러그인/보일러플레이트 배포 경로를 설명하는 historical reference이며, 현재 운영 경로가 아니다.
 
 ```mermaid
 graph LR

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -70,7 +70,7 @@ qlty fmt                # 자동 포맷
 
 ## 3. Layer 2 — Doc & Consistency
 
-### 3.1 doc-lint.sh (619 lines)
+### 3.1 doc-lint.sh
 
 검증 규칙 (각 규칙은 독립 실행 가능):
 
@@ -112,7 +112,7 @@ git config core.hooksPath .hxsk/githooks
 # 이후 commit 시 doc-lint.sh 자동 실행
 ```
 
-### 3.4 pre-pr-check.sh (344 lines)
+### 3.4 pre-pr-check.sh
 PR 생성 직전 종합 검증:
 ```bash
 bash .hxsk/hooks/pre-pr-check.sh
@@ -201,7 +201,7 @@ REFACTOR → 중복 제거, 설명 압축
 
 ## 6. Self-Configure Verification
 
-### 6.1 verify-self-configure.sh (341 lines)
+### 6.1 verify-self-configure.sh
 
 설치·업그레이드 후 환경 검증:
 ```bash
@@ -223,6 +223,15 @@ bash .hxsk/scripts/verify-self-configure.sh
 bash .hxsk/scripts/setup-verify.sh
 ```
 
+### 6.3 local-verify.sh — 로컬 종합 검증
+
+변경 완료 전 권장 기본값:
+```bash
+bash .hxsk/scripts/local-verify.sh
+```
+
+이 번들은 `doc-lint.sh`, `check-consistency.sh`, 스킬 테스트 dry-run(시나리오가 있을 때), `pre-pr-check.sh`를 순서대로 실행한다. 네트워크 의존 검사는 기본 비활성화하고 로컬에서 먼저 실패하도록 설계되어 있다.
+
 | 조건 | 확인 내용 |
 |------|---------|
 | 스킬 수 | `.claude/skills/` 내 스킬 디렉토리 ≥1 |
@@ -231,7 +240,7 @@ bash .hxsk/scripts/setup-verify.sh
 | 메모리 디렉토리 | `.hxsk/memories/` 하위 타입 디렉토리 존재 |
 | bootstrap 버전 | `.hxsk/.bootstrap-version` 파싱 성공 |
 
-### 6.3 Smoke Test
+### 6.4 Smoke Test
 
 설치 직후 수동 확인:
 ```bash
@@ -292,7 +301,7 @@ hxsk-ci:
 ```
 git commit 시도
     ↓
-1. pre-commit-doc-lint.sh (31 lines)
+1. pre-commit-doc-lint.sh
     └─ doc-lint.sh 실행 → 실패 시 commit 거부
     ↓
 2. pre-commit-version-check.sh (21 lines)

--- a/learn/260506-0000-docs-update/learn-results.tsv
+++ b/learn/260506-0000-docs-update/learn-results.tsv
@@ -1,0 +1,2 @@
+iteration	mode	docs_generated	docs_updated	validation_score	fix_iterations	learn_score	duration_s
+1	update	3	9	100	1	100	0

--- a/learn/260506-0000-docs-update/scout-context.md
+++ b/learn/260506-0000-docs-update/scout-context.md
@@ -1,0 +1,30 @@
+# Scout Context — docs update
+
+## Parsed Request
+
+`/autoresearch_learn --mode update` was invoked with no scope or depth. Interactive setup selected:
+
+- Mode: Update
+- Scope: Everything
+- Depth: Standard
+- Launch: Yes
+
+## Repository Scan
+
+- Project type: bash + markdown methodology repository, no package manager manifest detected.
+- Existing public docs: 9 root files under `docs/` plus `docs/plans/` research/plan documents.
+- Canonical version metadata: `.hxsk/.bootstrap-version` and `llms.txt` both report HXSK v5.7.0, last updated 2026-05-04.
+- Component counts from local scan: 24 skills, 18 agents, 27 hooks, 23 scripts, 34 templates, 43 research markdown files.
+- Primary verification entrypoint: `.hxsk/scripts/local-verify.sh`, with direct validators `doc-lint.sh` and `check-consistency.sh`.
+
+## Main Staleness Findings
+
+- Public docs mostly described v5.6.1 / 2026-04-30 while canonical metadata is v5.7.0 / 2026-05-04.
+- Script/template/research counts had drifted: scripts 22 → 23, templates 33 → 34, research markdown 42 → 43.
+- Several docs still emphasized legacy build outputs; Self-Configure is the current deployment path.
+- `local-verify.sh`, `active-state.sh`, Hermes, and HITL surfaces were underrepresented in public docs.
+- Internal docs had small drift: `.hxsk/docs/HOOKS.md` hook count, `.hxsk/docs/AGENTS.md` agent count/spec-reviewer omission, `.hxsk/docs/LINTING.md` top-level `scripts/` commands, `.hxsk/docs/BUILD.md` table formatting, and `.hxsk/docs/WORKFLOWS.md` legacy build overview.
+
+## External Pattern Notes
+
+External documentation patterns reinforced keeping README as the front door, separating configuration/testing/architecture references, documenting verification as a contract, and avoiding raw generated changelog noise in user-facing docs.

--- a/learn/260506-0000-docs-update/summary.md
+++ b/learn/260506-0000-docs-update/summary.md
@@ -1,0 +1,32 @@
+# Learn Summary — docs update
+
+## Summary
+
+Updated public and internal documentation to match the current v5.7.0 repository state and repaired validation-tool edge cases caused by generated runtime/autoresearch outputs.
+
+## Docs Updated
+
+- `README.md` — current badge/version language and template count.
+- `docs/codebase-summary.md` — version/date, file counts, script inventory, research count, and local verification script coverage.
+- `docs/configuration-guide.md` — `llms.txt` and `.bootstrap-version` examples updated to v5.7.0.
+- `docs/deployment-guide.md` — target version, v5.6→v5.7 migration row, and `local-verify.sh` guidance.
+- `docs/project-overview-pdr.md` — v5.7.0, 10+ harness language, scripts/templates counts.
+- `docs/project-roadmap.md` — v5.7.0 current line, timeline row, support matrix row.
+- `docs/testing-guide.md` — removed brittle line-count claims and added `local-verify.sh` as the standard local bundle.
+- `docs/system-architecture.md` — scripts/templates counts, Hermes adapter surface, and legacy-build clarification.
+- `.hxsk/docs/HOOKS.md` — hook count aligned to 27.
+- `.hxsk/docs/AGENTS.md` — agent count aligned to 18 and `spec-reviewer` listed.
+- `.hxsk/docs/LINTING.md` — shell lint commands pointed at `.hxsk/scripts`.
+- `.hxsk/docs/BUILD.md` — fixed setup prompt table formatting.
+- `.hxsk/docs/WORKFLOWS.md` — overview clarified as Self-Configure, with old build generation marked superseded.
+- `.hxsk/scripts/doc-lint.sh` — excluded `.hxsk/runtime/**` and allowed standard learn output filenames in DUP-01.
+
+## Validation
+
+- `bash .hxsk/scripts/doc-lint.sh` → PASS 7, FAIL 0.
+- `bash .hxsk/hooks/check-consistency.sh` → PASS 34, FAIL 0.
+- `bash .hxsk/scripts/local-verify.sh` → doc/consistency/skill dry-runs passed; pre-pr failed only because current branch is `master` with uncommitted changes.
+
+## Remaining Notes
+
+No documentation validation warnings remain. PR readiness requires a feature branch and commit before `pre-pr-check.sh` can pass.

--- a/learn/260506-0000-docs-update/validation-report.md
+++ b/learn/260506-0000-docs-update/validation-report.md
@@ -1,0 +1,24 @@
+# Validation Report — docs update
+
+Mode: update  
+Scope: entire repository  
+Depth: standard  
+Date: 2026-05-06
+
+## Commands
+
+| Command | Result | Evidence |
+|---------|--------|----------|
+| `bash .hxsk/scripts/doc-lint.sh` | PASS | PASS 7, FAIL 0; 287 markdown files checked |
+| `bash .hxsk/hooks/check-consistency.sh` | PASS | PASS 34, FAIL 0, WARN 0 |
+| `bash .hxsk/scripts/local-verify.sh` | CONDITIONAL | doc-lint, consistency, and skill dry-runs passed; pre-pr failed because worktree is on `master` with uncommitted changes |
+
+## Fix Loop
+
+One validation-tool fix was applied with approval: `.hxsk/scripts/doc-lint.sh` now excludes generated `.hxsk/runtime/**` markdown snapshots from the document corpus. This prevents DUP-01 from treating session snapshot copies of `CURRENT.md` and `SESSION_HANDOFF.md` as hand-authored documentation collisions.
+
+The existing autoresearch duplicate-name allowlist was also extended for standard learn output files: `scout-context.md` and `validation-report.md`.
+
+## Verdict
+
+Documentation validation is clean. PR-readiness validation is intentionally not clean until the changes are moved to a feature branch and committed.


### PR DESCRIPTION
## Summary
- Refresh public and internal HXSK docs to the current v5.7.0 repository state.
- Align script/template/research counts, Self-Configure wording, local verification guidance, Hermes/HITL surfaces, and learn audit output.
- Update doc-lint exclusions for generated runtime and learn artifacts so validation reflects hand-authored docs.

## Validation
- bash .hxsk/scripts/local-verify.sh

## Notes
- pre-pr-check reports non-blocking warnings for CHANGELOG date, skipped GitHub release check, and patch version recommendation.